### PR TITLE
fix: URL detection afer switching user

### DIFF
--- a/src/pages/content/timeline/index.ts
+++ b/src/pages/content/timeline/index.ts
@@ -1,7 +1,9 @@
 import { TimelineManager } from './manager';
 
 function isGeminiConversationRoute(pathname = location.pathname): boolean {
-  return pathname.startsWith('/app') || pathname.startsWith('/gem/');
+  // Support account-scoped routes like /u/1/app or /u/0/gem/
+  // Matches: "/app", "/gem/", "/u/<num>/app", "/u/<num>/gem/"
+  return /^\/(?:u\/\d+\/)?(app|gem)(\/|$)/.test(pathname);
 }
 
 let timelineManagerInstance: TimelineManager | null = null;


### PR DESCRIPTION
our route check only matched “/app” or “/gem/”, but Google profile switching changes the path to “/u/{n}/…”.
So updated the matcher and verified no linter issues.