### PR TITLE
fix: 修复文件夹内对话项行间距异常

### DIFF
--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -1348,8 +1348,6 @@ html.dark-theme .gv-pm-trigger { background: rgba(17,24,39,0.75); color: #fff; b
   cursor: pointer;
   transition: background-color 0.15s ease, opacity 0.2s;
   position: relative;
-  /* min-height: 40px; */
-  /* line-height: 20px;  */
 }
 
 .gv-folder-conversation:hover {


### PR DESCRIPTION

# 描述
将 .gv-folder-conversation 的强制最小高度移除

# 变更要点
修改 public/contentStyle.css 中 .gv-folder-conversation 规则，删除 min-height: 40px; 

# 影响范围
仅影响扩展创建的“文件夹内对话”项的垂直间距展示，不改变其它交互或视觉风格。

# 示意图
<img width="500" height="490" alt="image" src="https://github.com/user-attachments/assets/f30da7eb-27d8-4dee-87c9-f96255aec6f4" />

