### PR TITLE
fix #110，解决了对话响应前几秒 loading 图标会偏移

### DIFF
--- a/src/pages/content/chatWidth/index.ts
+++ b/src/pages/content/chatWidth/index.ts
@@ -131,13 +131,13 @@ function applyWidth(widthPercent: number) {
       margin-left: auto !important;
       margin-right: auto !important;
     }
-      
     model-response:has(> .deferred-response-indicator),
     .response-container:has(img[src*="sparkle"]), 
     main > div:has(img[src*="sparkle"]) {
-        margin-left: auto !important;
-        margin-right: auto !important;
-        width: min(100%, ${widthValue}) !important;
+      max-width: ${widthValue} !important;
+      width: min(100%, ${widthValue}) !important;
+      margin-left: auto !important;
+      margin-right: auto !important;
     }
 
     /* Additional deep targeting for nested elements */


### PR DESCRIPTION
fix #110 ，解决了当插件启用，配置较低的宽度时，对话响应前几秒 loading 图标会偏移