### PR TITLE
feat: double-click to expand/collapse folder

### DIFF
--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -499,6 +499,9 @@ export class FolderManager {
     const folderIcon = document.createElement('span');
     folderIcon.className = 'gv-folder-icon google-symbols';
     folderIcon.textContent = 'folder';
+    folderIcon.style.cursor = 'pointer';
+    folderIcon.style.userSelect = 'none';
+    folderIcon.addEventListener('dblclick', () => this.toggleFolder(folder.id));
 
     // Folder name
     const folderName = document.createElement('span');


### PR DESCRIPTION
- Supports double-clicking folder icons to expand/collapse.
- Added `user-select: none` to prevent unwanted text selection during rapid clicking.
Closes #154