### PR TITLE
fix: show prompt-logo correctly in Firefox

### DIFF
--- a/src/pages/content/prompt/index.ts
+++ b/src/pages/content/prompt/index.ts
@@ -47,7 +47,7 @@ const LATEST_VERSION_CACHE_KEY = 'gvLatestVersionCache';
 const LATEST_VERSION_MAX_AGE = 1000 * 60 * 60 * 6; // 6 hours
 
 function getRuntimeUrl(path: string): string {
-  // 优先尝试标准 Web Extensions API (主要针对 Firefox)
+  // Try the standard Web Extensions API first (mainly for Firefox)
   try {
     return browser.runtime.getURL(path);
   } catch {


### PR DESCRIPTION
Before: 
<img width="147" height="84" alt="1c3d07fa4469767636fd18234d2f44c0" src="https://github.com/user-attachments/assets/ce2cf804-6def-40fb-8fd7-a2be76c6a2dd" />
Now:
<img width="159" height="84" alt="d21f3c59afcdc02453d80316dfb08ad7" src="https://github.com/user-attachments/assets/39929933-c839-472c-bb48-9367b718bde3" />