### PR TITLE
fix(timeline): stabilize init and improve long chat perf

### DIFF
--- a/src/pages/content/timeline/__tests__/TimelineBootstrap.test.ts
+++ b/src/pages/content/timeline/__tests__/TimelineBootstrap.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const timelineManagerSpies = {
+  constructed: vi.fn(),
+  init: vi.fn().mockResolvedValue(undefined),
+  destroy: vi.fn(),
+};
+
+vi.mock('../manager', () => {
+  class TimelineManager {
+    init = timelineManagerSpies.init;
+    destroy = timelineManagerSpies.destroy;
+    constructor() {
+      timelineManagerSpies.constructed();
+    }
+  }
+
+  return { TimelineManager };
+});
+
+describe('Timeline bootstrap', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    timelineManagerSpies.constructed.mockClear();
+    timelineManagerSpies.init.mockClear();
+    timelineManagerSpies.destroy.mockClear();
+
+    document.body.innerHTML = '<main></main>';
+    history.replaceState({}, '', '/app');
+  });
+
+  afterEach(() => {
+    window.dispatchEvent(new Event('beforeunload'));
+  });
+
+  it('startTimeline initializes only once when body already exists', async () => {
+    const { startTimeline } = await import('../index');
+
+    startTimeline();
+    expect(timelineManagerSpies.constructed).toHaveBeenCalledTimes(1);
+    expect(timelineManagerSpies.init).toHaveBeenCalledTimes(1);
+
+    // Trigger DOM mutations; should not re-initialize
+    document.body.appendChild(document.createElement('div'));
+    await Promise.resolve();
+
+    expect(timelineManagerSpies.constructed).toHaveBeenCalledTimes(1);
+    expect(timelineManagerSpies.init).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/src/pages/content/timeline/__tests__/TimelineManagerActiveIndex.test.ts
+++ b/src/pages/content/timeline/__tests__/TimelineManagerActiveIndex.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { TimelineManager } from '../manager';
+
+describe('TimelineManager active marker', () => {
+  it('uses cached marker tops when available', () => {
+    const manager = new TimelineManager();
+
+    const scrollContainer = document.createElement('div');
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 400, configurable: true });
+    scrollContainer.scrollTop = 0;
+
+    const elements = [document.createElement('div'), document.createElement('div'), document.createElement('div')];
+    const rectSpies = elements.map((el) => vi.spyOn(el, 'getBoundingClientRect'));
+
+    const markers = elements.map((element, index) => ({
+      id: `m${index}`,
+      element,
+      summary: '',
+      n: 0,
+      baseN: 0,
+      dotElement: null,
+      starred: false,
+    }));
+
+    const internal = manager as unknown as {
+      scrollContainer: HTMLElement | null;
+      markers: typeof markers;
+      markerTops: number[];
+      activeTurnId: string | null;
+      computeActiveByScroll: () => void;
+    };
+
+    internal.scrollContainer = scrollContainer;
+    internal.markers = markers;
+    internal.markerTops = [0, 100, 200];
+    internal.activeTurnId = null;
+
+    internal.computeActiveByScroll();
+
+    expect(internal.activeTurnId).toBe('m1');
+    rectSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+});
+

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -20,6 +20,7 @@ globalThis.chrome = {
   },
   runtime: {
     lastError: null,
+    id: 'test-extension-id',
   },
 } as any;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@locales': path.resolve(__dirname, './src/locales'),
       '@/core': path.resolve(__dirname, './src/core'),
       '@/features': path.resolve(__dirname, './src/features'),
     },


### PR DESCRIPTION
Prevents double initialization, makes initial render deterministic, and reduces scroll-time work on long conversations (cached tops + binary search).

Closes #168
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/177">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
