### PR TITLE
feat(export): add DOM content extraction support for JSON export (issue #213)

### DIFF
--- a/src/features/export/services/ConversationExportService.ts
+++ b/src/features/export/services/ConversationExportService.ts
@@ -90,9 +90,6 @@ export class ConversationExportService {
         user: userContent,
         assistant: assistantContent,
         starred: turn.starred,
-        // Exclude DOM elements from JSON output (not serializable)
-        userElement: {},
-        assistantElement: {},
       };
     });
 

--- a/src/features/export/services/__tests__/ConversationExportService.test.ts
+++ b/src/features/export/services/__tests__/ConversationExportService.test.ts
@@ -169,12 +169,22 @@ describe('ConversationExportService', () => {
         },
       ];
 
+      const downloadSpy = vi.spyOn(ConversationExportService as any, 'downloadJSON');
       const result = await ConversationExportService.export(turnsWithoutDom, mockMetadata, {
         format: 'json' as any,
       });
 
       expect(result.success).toBe(true);
       expect(result.format).toBe('json');
+
+      expect(downloadSpy).toHaveBeenCalledOnce();
+      const payload = downloadSpy.mock.calls[0][0] as any;
+
+      expect(payload.items).toHaveLength(1);
+      expect(payload.items[0].user).toBe('Plain text user');
+      expect(payload.items[0].assistant).toBe('Plain text assistant');
+
+      expect(payload.items[0].userElement).toBeUndefined();
     });
 
     // Note: Testing DOMContentExtractor integration is skipped per ROI testing strategy.


### PR DESCRIPTION
### 🚫 AI Policy / AI 政策

- **We explicitly reject AI-generated PRs that have not been manually verified.**
- **本项目拒绝接受任何未经人工复核的 AI 生成的 PR。**
- Low-quality AI PRs will be closed immediately. / 低质量的 AI PR 会被直接关闭。
- You must understand and take responsibility for every line of code you submit. / 你必须理解并对你提交的每一行代码负责。

---

### Description / 描述
- 目标：保持导出的json文件的 `assistant` 字段的值的 markdown 格式
- 更改：
  - 在导出json之前先使用 `DOMContentExtractor` 处理一遍。无 DOM 元素时回退到使用原始文本
  - 添加了一个测试用例确保回退逻辑


### Related Issue / 相关 Issue
#213 


### Visual Proof / 可视化证据
以下是处理后的导出结果。
[export.json](https://github.com/user-attachments/files/24915254/export.json) 导出后的json文件
[export.md](https://github.com/user-attachments/files/24915257/export.md) 导出后的markdown文件
[processed.md](https://github.com/user-attachments/files/24915258/processed.md) 导出后json文件的 `assistant` 字段的值对应的markdown文件


### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/215">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
