### PR TITLE
feat(export): add export entry for individual replies and copy-as-image action

### DIFF
--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -4672,7 +4672,7 @@ body[data-color-scheme='dark'] .gv-export-fontsize-preview {
   position: fixed;
   left: 50%;
   transform: translateX(-50%);
-  top: calc(env(safe-area-inset-top, 0px) + 76px);
+  top: 12px;
   z-index: 2147483645;
   pointer-events: none;
 }
@@ -4806,7 +4806,7 @@ body[data-color-scheme='dark'] .gv-export-progress-desc {
   }
 
   .gv-export-progress-overlay {
-    top: calc(env(safe-area-inset-top, 0px) + 68px);
+    top: 10px;
   }
 
   .gv-export-progress-card {

--- a/src/features/export/services/ImageRenderService.ts
+++ b/src/features/export/services/ImageRenderService.ts
@@ -1,0 +1,144 @@
+import { toBlob } from 'html-to-image';
+
+const TRANSPARENT_IMAGE_PLACEHOLDER =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+const DEFAULT_OFFSCREEN_LEFT = '-100000px';
+const DEFAULT_SANITIZE_SELECTOR = 'img, video, iframe, canvas, svg image';
+const DEFAULT_RENDER_WIDTH = 720;
+
+export type RenderElementToImageBlobOptions = {
+  maxAttempts?: number;
+  retryDelayMs?: number;
+  shouldRetry?: (error: unknown) => boolean;
+  enableSanitizedFallback?: boolean;
+  sanitizeSelector?: string;
+  shouldFallback?: (error: unknown) => boolean;
+};
+
+export function isImageResourceRenderError(error: unknown): boolean {
+  if (error instanceof Event) return true;
+  if (!(error instanceof Error)) return false;
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('image') ||
+    message.includes('fetch') ||
+    message.includes('decode') ||
+    message.includes('resource') ||
+    message.includes('taint') ||
+    message.includes('canvas')
+  );
+}
+
+async function renderTargetToBlob(target: HTMLElement): Promise<Blob> {
+  const blob = await toBlob(target, {
+    cacheBust: true,
+    pixelRatio: 1.2,
+    backgroundColor: '#ffffff',
+    skipFonts: true,
+    imagePlaceholder: TRANSPARENT_IMAGE_PLACEHOLDER,
+    onImageErrorHandler: () => undefined,
+  });
+
+  if (!blob) {
+    const rect = target.getBoundingClientRect();
+    const width = Math.round(rect.width);
+    const height = Math.round(rect.height);
+    throw new Error(`Image render failed (${width}x${height})`);
+  }
+
+  return blob;
+}
+
+function sanitizeClone(target: HTMLElement, selector: string): HTMLElement {
+  const clone = target.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll(selector).forEach((element) => element.remove());
+  return clone;
+}
+
+function resolveRenderableWidth(target: HTMLElement): number {
+  let current: HTMLElement | null = target;
+  let depth = 0;
+  while (current && depth < 12) {
+    const width = Math.round(current.getBoundingClientRect().width);
+    if (Number.isFinite(width) && width > 24) {
+      return width;
+    }
+    current = current.parentElement;
+    depth += 1;
+  }
+
+  const viewportWidth = Math.round(globalThis.innerWidth || 0);
+  if (viewportWidth > 24) {
+    const preferred = Math.round(viewportWidth * 0.8);
+    return Math.max(360, Math.min(preferred, 1200));
+  }
+
+  return DEFAULT_RENDER_WIDTH;
+}
+
+async function renderUsingSanitizedClone(target: HTMLElement, selector: string): Promise<Blob> {
+  const container = document.createElement('div');
+  container.style.position = 'fixed';
+  container.style.left = DEFAULT_OFFSCREEN_LEFT;
+  container.style.top = '0';
+  container.style.opacity = '0';
+  container.style.pointerEvents = 'none';
+
+  const renderRoot = document.createElement('div');
+  renderRoot.style.display = 'block';
+  renderRoot.style.width = `${resolveRenderableWidth(target)}px`;
+  renderRoot.style.background = '#ffffff';
+
+  const clone = sanitizeClone(target, selector);
+  renderRoot.appendChild(clone);
+  container.appendChild(renderRoot);
+  document.body.appendChild(container);
+
+  try {
+    return await renderTargetToBlob(renderRoot);
+  } finally {
+    container.remove();
+  }
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function renderElementToImageBlob(
+  target: HTMLElement,
+  options: RenderElementToImageBlobOptions = {},
+): Promise<Blob> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 1);
+  const retryDelayMs = Math.max(0, options.retryDelayMs ?? 0);
+  const shouldRetry = options.shouldRetry ?? (() => false);
+
+  let primaryError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await renderTargetToBlob(target);
+    } catch (error) {
+      primaryError = error;
+      const canRetry = attempt < maxAttempts && shouldRetry(error);
+      if (!canRetry) break;
+      if (retryDelayMs > 0) {
+        await delay(retryDelayMs * attempt);
+      }
+    }
+  }
+
+  if (!options.enableSanitizedFallback) {
+    throw primaryError;
+  }
+
+  const shouldFallback = options.shouldFallback ?? isImageResourceRenderError;
+  if (!shouldFallback(primaryError)) {
+    throw primaryError;
+  }
+
+  return await renderUsingSanitizedClone(
+    target,
+    options.sanitizeSelector ?? DEFAULT_SANITIZE_SELECTOR,
+  );
+}

--- a/src/features/export/services/__tests__/ImageExportService.test.ts
+++ b/src/features/export/services/__tests__/ImageExportService.test.ts
@@ -80,6 +80,17 @@ describe('ImageExportService', () => {
     expect((anchors[0] as HTMLAnchorElement).download).toBe('chat.png');
   });
 
+  it('renders conversation to blob without downloading', async () => {
+    const blob = new Blob(['blob'], { type: 'image/png' });
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(blob);
+
+    const result = await ImageExportService.renderConversationBlob(mockTurns, mockMetadata, {});
+
+    expect(result).toBe(blob);
+    expect(toBlob).toHaveBeenCalled();
+    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
   it('retries transient image render failures on Chrome and succeeds', async () => {
     (toBlob as unknown as ReturnType<typeof vi.fn>).mockReset();
     (toBlob as unknown as ReturnType<typeof vi.fn>)

--- a/src/features/export/services/__tests__/ImageRenderService.test.ts
+++ b/src/features/export/services/__tests__/ImageRenderService.test.ts
@@ -1,0 +1,104 @@
+import { toBlob } from 'html-to-image';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderElementToImageBlob } from '../ImageRenderService';
+
+vi.mock('html-to-image', () => ({
+  toBlob: vi.fn(),
+}));
+
+describe('ImageRenderService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders element to blob directly when primary render succeeds', async () => {
+    const target = document.createElement('div');
+    const blob = new Blob(['ok'], { type: 'image/png' });
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(blob);
+
+    const result = await renderElementToImageBlob(target);
+
+    expect(result).toBe(blob);
+    expect(toBlob).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when shouldRetry returns true and later succeeds', async () => {
+    const target = document.createElement('div');
+    const blob = new Blob(['ok'], { type: 'image/png' });
+    (toBlob as unknown as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Event('error'))
+      .mockResolvedValueOnce(blob);
+
+    const result = await renderElementToImageBlob(target, {
+      maxAttempts: 2,
+      retryDelayMs: 0,
+      shouldRetry: (error) => error instanceof Event,
+    });
+
+    expect(result).toBe(blob);
+    expect(toBlob).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to sanitized clone when resource rendering fails', async () => {
+    const target = document.createElement('div');
+    const image = document.createElement('img');
+    image.src = 'https://example.com/fail.png';
+    target.appendChild(image);
+    document.body.appendChild(target);
+
+    const blob = new Blob(['ok'], { type: 'image/png' });
+    (toBlob as unknown as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('Failed to fetch resource'))
+      .mockResolvedValueOnce(blob);
+
+    const result = await renderElementToImageBlob(target, {
+      enableSanitizedFallback: true,
+    });
+
+    expect(result).toBe(blob);
+    expect(toBlob).toHaveBeenCalledTimes(2);
+
+    const secondTarget = (toBlob as unknown as ReturnType<typeof vi.fn>).mock.calls[1][0];
+    expect(secondTarget).not.toBe(target);
+    expect((secondTarget as HTMLElement).querySelector('img')).toBeNull();
+  });
+
+  it('uses fallback render root with non-zero width for zero-size targets', async () => {
+    const target = document.createElement('div');
+    target.textContent = 'fallback';
+    document.body.appendChild(target);
+
+    let callCount = 0;
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (node: HTMLElement) => {
+        callCount += 1;
+        if (callCount === 1) {
+          return null;
+        }
+        const width = Number.parseInt(node.style.width || '0', 10);
+        if (width > 0) {
+          return new Blob(['ok'], { type: 'image/png' });
+        }
+        return null;
+      },
+    );
+
+    const result = await renderElementToImageBlob(target, {
+      enableSanitizedFallback: true,
+      shouldFallback: () => true,
+    });
+
+    expect(result).toBeInstanceOf(Blob);
+    expect(toBlob).toHaveBeenCalledTimes(2);
+    const secondTarget = (toBlob as unknown as ReturnType<typeof vi.fn>).mock.calls[1][0];
+    expect(Number.parseInt((secondTarget as HTMLElement).style.width || '0', 10)).toBeGreaterThan(
+      0,
+    );
+  });
+});

--- a/src/pages/content/export/__tests__/responseActionImageButton.test.ts
+++ b/src/pages/content/export/__tests__/responseActionImageButton.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { injectResponseActionCopyImageButtons } from '../responseActionImageButton';
+
+function createNativeActionButton({
+  testId,
+  iconName,
+  ariaLabel,
+}: {
+  testId: string;
+  iconName: string;
+  ariaLabel: string;
+}): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.className = 'mdc-icon-button mat-mdc-icon-button gds-icon-button';
+  button.setAttribute('type', 'button');
+  button.setAttribute('data-test-id', testId);
+  button.setAttribute('aria-label', ariaLabel);
+  button.title = ariaLabel;
+
+  const icon = document.createElement('mat-icon');
+  icon.className =
+    'mat-icon notranslate gds-icon-m google-symbols mat-ligature-font mat-icon-no-color';
+  icon.setAttribute('fonticon', iconName);
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = iconName;
+
+  button.appendChild(icon);
+  return button;
+}
+
+function createAssistantActionBar(): HTMLElement {
+  const host = document.createElement('div');
+  host.setAttribute('data-message-author-role', 'assistant');
+
+  const bar = document.createElement('div');
+  bar.className = 'message-actions';
+
+  const like = createNativeActionButton({
+    testId: 'rate-up-button',
+    iconName: 'thumb_up',
+    ariaLabel: 'Good response',
+  });
+  const copy = createNativeActionButton({
+    testId: 'copy-button',
+    iconName: 'content_copy',
+    ariaLabel: 'Copy response',
+  });
+  const more = createNativeActionButton({
+    testId: 'more-menu-button',
+    iconName: 'more_vert',
+    ariaLabel: 'More options',
+  });
+
+  bar.appendChild(like);
+  bar.appendChild(copy);
+  bar.appendChild(more);
+  host.appendChild(bar);
+  document.body.appendChild(host);
+  return bar;
+}
+
+function createNestedAssistantActionBar(): HTMLElement {
+  const modelResponse = document.createElement('model-response');
+  const responseContainer = document.createElement('div');
+  responseContainer.className = 'response-container';
+  const messageActions = document.createElement('message-actions');
+  const actionsContainer = document.createElement('div');
+  actionsContainer.className = 'actions-container-v2';
+  const buttons = document.createElement('div');
+  buttons.className = 'buttons-container-v2';
+
+  const copy = createNativeActionButton({
+    testId: 'copy-button',
+    iconName: 'content_copy',
+    ariaLabel: 'Copy response',
+  });
+  const moreWrapper = document.createElement('div');
+  moreWrapper.className = 'more-menu-button-container';
+  const more = createNativeActionButton({
+    testId: 'more-menu-button',
+    iconName: 'more_vert',
+    ariaLabel: 'Show more options',
+  });
+  moreWrapper.appendChild(more);
+
+  buttons.appendChild(copy);
+  buttons.appendChild(moreWrapper);
+  actionsContainer.appendChild(buttons);
+  messageActions.appendChild(actionsContainer);
+  responseContainer.appendChild(messageActions);
+  modelResponse.appendChild(responseContainer);
+  document.body.appendChild(modelResponse);
+
+  return buttons;
+}
+
+describe('responseActionImageButton', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('injects copy-image button between native copy and more buttons', () => {
+    const bar = createAssistantActionBar();
+    const onClick = vi.fn();
+
+    const injected = injectResponseActionCopyImageButtons(document, {
+      label: 'Copy response as image',
+      tooltip: 'Copy response as image',
+      onClick,
+    });
+
+    expect(injected).toHaveLength(1);
+
+    const children = Array.from(bar.children);
+    const copyIndex = children.findIndex((el) => el.getAttribute('data-test-id') === 'copy-button');
+    const insertedIndex = children.findIndex(
+      (el) => el.getAttribute('data-test-id') === 'gv-copy-image-button',
+    );
+    const moreIndex = children.findIndex(
+      (el) => el.getAttribute('data-test-id') === 'more-menu-button',
+    );
+
+    expect(copyIndex).toBeGreaterThanOrEqual(0);
+    expect(insertedIndex).toBe(copyIndex + 1);
+    expect(moreIndex).toBe(insertedIndex + 1);
+
+    const inserted = children[insertedIndex] as HTMLButtonElement;
+    const copyIcon = bar.querySelector('[data-test-id="copy-button"] mat-icon') as HTMLElement;
+    const insertedIcon = inserted.querySelector('mat-icon') as HTMLElement;
+
+    expect(inserted.className).toBe(
+      (bar.querySelector('[data-test-id="copy-button"]') as HTMLElement).className,
+    );
+    expect(insertedIcon.className).toBe(copyIcon.className);
+    expect(insertedIcon.getAttribute('fonticon')).toBe('image');
+    expect((insertedIcon.textContent || '').trim()).toBe('image');
+
+    inserted.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('avoids duplicate injection and updates tooltip/label on reinjection', () => {
+    createAssistantActionBar();
+    const onClick = vi.fn();
+
+    const first = injectResponseActionCopyImageButtons(document, {
+      label: 'Copy response as image',
+      tooltip: 'Copy response as image',
+      onClick,
+    });
+    const second = injectResponseActionCopyImageButtons(document, {
+      label: '复制回复为图片',
+      tooltip: '复制回复为图片',
+      onClick,
+    });
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(second[0]).toBe(first[0]);
+    expect(second[0].getAttribute('aria-label')).toBe('复制回复为图片');
+    expect(second[0].title).toBe('复制回复为图片');
+  });
+
+  it('does not duplicate click handlers after repeated reinjection', () => {
+    createAssistantActionBar();
+    const onClick = vi.fn();
+
+    injectResponseActionCopyImageButtons(document, {
+      label: 'Copy response as image',
+      tooltip: 'Copy response as image',
+      onClick,
+    });
+    const second = injectResponseActionCopyImageButtons(document, {
+      label: 'Copy response as image',
+      tooltip: 'Copy response as image',
+      onClick,
+    });
+    const third = injectResponseActionCopyImageButtons(document, {
+      label: 'Copy response as image',
+      tooltip: 'Copy response as image',
+      onClick,
+    });
+
+    expect(second).toHaveLength(1);
+    expect(third).toHaveLength(1);
+    const button = document.querySelector('[data-test-id="gv-copy-image-button"]');
+    expect(button).toBeTruthy();
+
+    (button as HTMLButtonElement).click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not inject when action row has no more-options button', () => {
+    const host = document.createElement('div');
+    host.setAttribute('data-message-author-role', 'assistant');
+    const bar = document.createElement('div');
+    const copy = createNativeActionButton({
+      testId: 'copy-button',
+      iconName: 'content_copy',
+      ariaLabel: 'Copy response',
+    });
+    bar.appendChild(copy);
+    host.appendChild(bar);
+    document.body.appendChild(host);
+
+    const injected = injectResponseActionCopyImageButtons(document, {
+      label: 'Copy response as image',
+      tooltip: 'Copy response as image',
+      onClick: vi.fn(),
+    });
+    expect(injected).toHaveLength(0);
+  });
+
+  it('injects when copy/more buttons are nested under buttons-container-v2', () => {
+    const buttons = createNestedAssistantActionBar();
+    const injected = injectResponseActionCopyImageButtons(document, {
+      label: 'Copy response as image',
+      tooltip: 'Copy response as image',
+      onClick: vi.fn(),
+    });
+
+    expect(injected).toHaveLength(1);
+    expect(buttons.querySelector('[data-test-id="gv-copy-image-button"]')).toBeTruthy();
+  });
+});

--- a/src/pages/content/export/__tests__/responseImageCopy.test.ts
+++ b/src/pages/content/export/__tests__/responseImageCopy.test.ts
@@ -1,0 +1,167 @@
+import { toBlob } from 'html-to-image';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  copyElementAsImageToClipboard,
+  copyImageBlobToClipboard,
+  downloadImageBlob,
+} from '../responseImageCopy';
+
+vi.mock('html-to-image', () => ({
+  toBlob: vi.fn(),
+}));
+
+class MockClipboardItem {
+  data: Record<string, Blob>;
+
+  constructor(data: Record<string, Blob>) {
+    this.data = data;
+  }
+}
+
+describe('responseImageCopy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes rendered png blob to clipboard', async () => {
+    const target = document.createElement('div');
+    const blob = new Blob(['img'], { type: 'image/png' });
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(blob);
+
+    const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+
+    await copyElementAsImageToClipboard(target, {
+      clipboard: { write: clipboardWrite },
+      ClipboardItemCtor: MockClipboardItem as unknown as typeof ClipboardItem,
+    });
+
+    expect(toBlob).toHaveBeenCalledOnce();
+    expect(clipboardWrite).toHaveBeenCalledOnce();
+
+    const [items] = clipboardWrite.mock.calls[0] as [MockClipboardItem[]];
+    expect(items).toHaveLength(1);
+    expect(items[0].data['image/png']).toBe(blob);
+  });
+
+  it('writes provided image blob to clipboard directly', async () => {
+    const blob = new Blob(['img'], { type: 'image/png' });
+    const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+
+    await copyImageBlobToClipboard(blob, {
+      clipboard: { write: clipboardWrite },
+      ClipboardItemCtor: MockClipboardItem as unknown as typeof ClipboardItem,
+    });
+
+    expect(clipboardWrite).toHaveBeenCalledOnce();
+    const [items] = clipboardWrite.mock.calls[0] as [MockClipboardItem[]];
+    expect(items[0].data['image/png']).toBe(blob);
+  });
+
+  it('throws when render returns null blob', async () => {
+    const target = document.createElement('div');
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    await expect(
+      copyElementAsImageToClipboard(target, {
+        clipboard: { write: vi.fn() },
+        ClipboardItemCtor: MockClipboardItem as unknown as typeof ClipboardItem,
+      }),
+    ).rejects.toThrow('Image render failed');
+  });
+
+  it('throws when clipboard image API is unavailable', async () => {
+    const target = document.createElement('div');
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Blob(['img'], { type: 'image/png' }),
+    );
+
+    await expect(
+      copyElementAsImageToClipboard(target, {
+        clipboard: null,
+        ClipboardItemCtor: MockClipboardItem as unknown as typeof ClipboardItem,
+      }),
+    ).rejects.toThrow('Clipboard image copy is not supported');
+  });
+
+  it('falls back to a sanitized clone when first render fails on external resources', async () => {
+    const target = document.createElement('div');
+    const img = document.createElement('img');
+    img.src = 'https://example.com/blocked.png';
+    target.appendChild(img);
+    document.body.appendChild(target);
+
+    const blob = new Blob(['img'], { type: 'image/png' });
+    (toBlob as unknown as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('Failed to fetch resource'))
+      .mockResolvedValueOnce(blob);
+
+    const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+
+    await copyElementAsImageToClipboard(target, {
+      clipboard: { write: clipboardWrite },
+      ClipboardItemCtor: MockClipboardItem as unknown as typeof ClipboardItem,
+    });
+
+    expect(toBlob).toHaveBeenCalledTimes(2);
+
+    const secondCallTarget = (toBlob as unknown as ReturnType<typeof vi.fn>).mock.calls[1]?.[0];
+    expect(secondCallTarget).not.toBe(target);
+    expect((secondCallTarget as HTMLElement).querySelector('img')).toBeNull();
+    expect(clipboardWrite).toHaveBeenCalledOnce();
+  });
+
+  it('falls back when primary render returns null blob', async () => {
+    const target = document.createElement('div');
+    target.textContent = 'content';
+    document.body.appendChild(target);
+
+    const blob = new Blob(['img'], { type: 'image/png' });
+    (toBlob as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(blob);
+
+    const clipboardWrite = vi.fn().mockResolvedValue(undefined);
+
+    await copyElementAsImageToClipboard(target, {
+      clipboard: { write: clipboardWrite },
+      ClipboardItemCtor: MockClipboardItem as unknown as typeof ClipboardItem,
+    });
+
+    expect(toBlob).toHaveBeenCalledTimes(2);
+    expect(clipboardWrite).toHaveBeenCalledOnce();
+  });
+
+  it('downloads image blob via object URL and revokes it', () => {
+    vi.useFakeTimers();
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test');
+    const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    const appendSpy = vi.spyOn(document.body, 'appendChild');
+    const removeSpy = vi.spyOn(document.body, 'removeChild');
+    const clickSpy = vi.fn();
+    const nativeCreateElement = document.createElement.bind(document);
+    const anchor = nativeCreateElement('a');
+    anchor.click = clickSpy;
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
+      if (tagName.toLowerCase() === 'a') return anchor;
+      return nativeCreateElement(tagName);
+    });
+
+    const blob = new Blob(['img'], { type: 'image/png' });
+    downloadImageBlob(blob, 'reply-image.png');
+
+    expect(createObjectURLSpy).toHaveBeenCalledOnce();
+    expect(anchor.href).toContain('blob:test');
+    expect(anchor.download).toBe('reply-image.png');
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(appendSpy).toHaveBeenCalled();
+
+    vi.runAllTimers();
+    expect(removeSpy).toHaveBeenCalled();
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:test');
+
+    createElementSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/src/pages/content/export/__tests__/selectionModeInteraction.test.ts
+++ b/src/pages/content/export/__tests__/selectionModeInteraction.test.ts
@@ -22,7 +22,7 @@ describe('selection mode interaction', () => {
     expect(overlayBlock).toContain('position: fixed;');
     expect(overlayBlock).toContain('left: 50%;');
     expect(overlayBlock).toContain('transform: translateX(-50%);');
-    expect(overlayBlock).toContain('top: calc(env(safe-area-inset-top, 0px) + 76px);');
+    expect(overlayBlock).toContain('top: 12px;');
     expect(overlayBlock).toContain('pointer-events: none;');
     expect(cardBlock).toContain('border-radius: 999px;');
     expect(cardBlock).toContain('backdrop-filter: blur(10px);');
@@ -44,5 +44,34 @@ describe('selection mode interaction', () => {
     expect(code).toContain('isSafari()');
     expect(code).toContain('showExportToast(');
     expect(code).toContain("t('export_toast_safari_pdf_ready')");
+  });
+
+  it('aligns selection bar and export progress toast with shared alignment hook', () => {
+    const code = readFileSync(resolve(process.cwd(), 'src/pages/content/export/index.ts'), 'utf8');
+
+    expect(code).toContain('function alignElementToConversationTitleCenter(');
+    expect(code).toContain('cleanupTasks.push(alignElementToConversationTitleCenter(bar));');
+    expect(code).toContain(
+      'const unbindAlignment = alignElementToConversationTitleCenter(overlay);',
+    );
+  });
+
+  it('falls back to direct download on Safari when clipboard copy fails', () => {
+    const code = readFileSync(resolve(process.cwd(), 'src/pages/content/export/index.ts'), 'utf8');
+
+    expect(code).toContain('let blobForFallback: Blob | null = null;');
+    expect(code).toContain('if (isSafari() && blobForFallback)');
+    expect(code).toContain('downloadImageBlob(blobForFallback, buildResponseImageFilename());');
+  });
+
+  it('uses conversation canvas based alignment and avoids sidebar title selectors', () => {
+    const code = readFileSync(resolve(process.cwd(), 'src/pages/content/export/index.ts'), 'utf8');
+
+    expect(code).toContain('function resolveConversationCanvasCenterX(');
+    expect(code).toContain('#chat-history');
+    expect(code).toContain('infinite-scroller.chat-history');
+    expect(code).toContain('function isLikelySidebarElement(');
+    expect(code).not.toContain('function resolveConversationTitleElement(');
+    expect(code).not.toContain('candidate.closest(\'[data-test-id="conversation"]\')');
   });
 });

--- a/src/pages/content/export/__tests__/selectionUtils.test.ts
+++ b/src/pages/content/export/__tests__/selectionUtils.test.ts
@@ -4,6 +4,7 @@ import {
   filterItemsBySelectedIds,
   findSelectionStartIdAtLine,
   groupSelectedMessagesByTurn,
+  resolveInitialSelectedMessageIds,
   selectBelowIds,
 } from '../selectionUtils';
 
@@ -112,6 +113,29 @@ describe('selectionUtils', () => {
       const turns = groupSelectedMessagesByTurn(selected);
 
       expect(turns.map((turn) => turn.turnId)).toEqual(['t2', 't1']);
+    });
+  });
+
+  describe('resolveInitialSelectedMessageIds', () => {
+    it('returns only the preferred id when it exists in all ids', () => {
+      const allIds = ['t1:u', 't1:a', 't2:u'];
+      const selected = resolveInitialSelectedMessageIds(allIds, 't1:a');
+
+      expect(Array.from(selected)).toEqual(['t1:a']);
+    });
+
+    it('returns empty set when preferred id is missing', () => {
+      const allIds = ['t1:u', 't1:a'];
+      const selected = resolveInitialSelectedMessageIds(allIds, 't9:a');
+
+      expect(selected.size).toBe(0);
+    });
+
+    it('returns empty set when preferred id is not provided', () => {
+      const allIds = ['t1:u', 't1:a'];
+      const selected = resolveInitialSelectedMessageIds(allIds, null);
+
+      expect(selected.size).toBe(0);
     });
   });
 });

--- a/src/pages/content/export/__tests__/topNodePreload.test.ts
+++ b/src/pages/content/export/__tests__/topNodePreload.test.ts
@@ -105,7 +105,7 @@ describe('topNodePreload', () => {
     expect(result.fingerprint.signature).toBe(before.signature);
   });
 
-  it('does not resolve unchanged fingerprint before the default minimum wait window', async () => {
+  it('resolves unchanged fingerprint within about one second by default', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
     document.body.innerHTML = '';
@@ -133,9 +133,7 @@ describe('topNodePreload', () => {
     });
 
     await vi.advanceTimersByTimeAsync(1000);
-    expect(resolved).toBe(false);
-
-    await vi.advanceTimersByTimeAsync(800);
+    expect(resolved).toBe(true);
 
     const result = await promise;
     expect(result.changed).toBe(false);

--- a/src/pages/content/export/responseActionImageButton.ts
+++ b/src/pages/content/export/responseActionImageButton.ts
@@ -1,0 +1,184 @@
+export type ResponseActionCopyImageOptions = {
+  label: string;
+  tooltip: string;
+  onClick: (button: HTMLElement) => void;
+};
+
+const COPY_BUTTON_TEST_ID = 'copy-button';
+const MORE_BUTTON_TEST_ID = 'more-menu-button';
+const COPY_IMAGE_BUTTON_TEST_ID = 'gv-copy-image-button';
+const COPY_IMAGE_ICON_NAME = 'image';
+const ASSISTANT_SCOPE_SELECTOR = [
+  '[data-message-author-role="assistant"]',
+  '[data-message-author-role="model"]',
+  'article[data-author="assistant"]',
+  'article[data-turn="assistant"]',
+  'article[data-turn="model"]',
+  '.model-response',
+  'model-response',
+  '.response-container',
+  '.presented-response-container',
+].join(', ');
+
+type BoundCopyImageButton = HTMLElement & {
+  __gvCopyImageHandler?: (event: Event) => void;
+};
+
+function updateButtonLabelAndTooltip(
+  button: HTMLElement,
+  label: string,
+  tooltip: string,
+): HTMLElement {
+  const interactive = button.matches('button')
+    ? button
+    : ((button.querySelector('button, [role="button"]') as HTMLElement | null) ?? button);
+
+  interactive.setAttribute('aria-label', tooltip);
+  interactive.title = tooltip;
+  interactive.removeAttribute('aria-describedby');
+  button.setAttribute('aria-label', tooltip);
+  button.title = tooltip;
+  button.setAttribute('data-gv-copy-image-label', label);
+
+  return interactive;
+}
+
+function updateButtonIcon(button: HTMLElement): void {
+  const icon = button.querySelector('mat-icon');
+  if (!(icon instanceof HTMLElement)) return;
+
+  if (icon.hasAttribute('fonticon')) {
+    icon.setAttribute('fonticon', COPY_IMAGE_ICON_NAME);
+  }
+  icon.textContent = COPY_IMAGE_ICON_NAME;
+}
+
+function findButtonByTestId(container: HTMLElement, testId: string): HTMLElement | null {
+  const escaped =
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(testId) : testId;
+  return (container.querySelector(`[data-test-id="${escaped}"]`) as HTMLElement | null) ?? null;
+}
+
+function findActionContainerFromMoreButton(moreButton: HTMLElement): HTMLElement | null {
+  let current: HTMLElement | null = moreButton;
+  let depth = 0;
+  while (current && depth < 12) {
+    const hasCopy = !!findButtonByTestId(current, COPY_BUTTON_TEST_ID);
+    const hasMore = !!findButtonByTestId(current, MORE_BUTTON_TEST_ID);
+    if (hasCopy && hasMore) {
+      return current;
+    }
+    current = current.parentElement;
+    depth += 1;
+  }
+
+  return null;
+}
+
+function bindButtonClick(
+  button: HTMLElement,
+  interactive: HTMLElement,
+  onClick: (button: HTMLElement) => void,
+): void {
+  const typed = button as BoundCopyImageButton;
+  if (typed.__gvCopyImageHandler) {
+    interactive.removeEventListener('click', typed.__gvCopyImageHandler);
+  }
+
+  const handler = (event: Event) => {
+    try {
+      event.preventDefault();
+    } catch {}
+    try {
+      event.stopPropagation();
+    } catch {}
+    onClick(button);
+  };
+
+  typed.__gvCopyImageHandler = handler;
+  interactive.addEventListener('click', handler);
+}
+
+function isAssistantActionContainer(container: HTMLElement): boolean {
+  return !!container.closest(ASSISTANT_SCOPE_SELECTOR);
+}
+
+function ensureButtonPosition(
+  container: HTMLElement,
+  copyImageButton: HTMLElement,
+  moreButton: HTMLElement,
+): void {
+  if (!moreButton.parentElement) {
+    if (!container.contains(copyImageButton)) container.appendChild(copyImageButton);
+    return;
+  }
+
+  if (copyImageButton !== moreButton.previousElementSibling) {
+    moreButton.parentElement.insertBefore(copyImageButton, moreButton);
+  }
+}
+
+function injectIntoActionContainer(
+  container: HTMLElement,
+  options: ResponseActionCopyImageOptions,
+): HTMLElement | null {
+  if (!isAssistantActionContainer(container)) return null;
+
+  const copyButton = findButtonByTestId(container, COPY_BUTTON_TEST_ID);
+  const moreButton = findButtonByTestId(container, MORE_BUTTON_TEST_ID);
+  if (!(copyButton instanceof HTMLElement) || !(moreButton instanceof HTMLElement)) return null;
+
+  const existing = findButtonByTestId(container, COPY_IMAGE_BUTTON_TEST_ID);
+  if (existing) {
+    const interactive = updateButtonLabelAndTooltip(existing, options.label, options.tooltip);
+    updateButtonIcon(existing);
+    bindButtonClick(existing, interactive, options.onClick);
+    ensureButtonPosition(container, existing, moreButton);
+    return existing;
+  }
+
+  const cloned = copyButton.cloneNode(true) as HTMLElement;
+  cloned.setAttribute('data-test-id', COPY_IMAGE_BUTTON_TEST_ID);
+  cloned.removeAttribute('id');
+
+  const interactive = updateButtonLabelAndTooltip(cloned, options.label, options.tooltip);
+  updateButtonIcon(cloned);
+  bindButtonClick(cloned, interactive, options.onClick);
+
+  ensureButtonPosition(container, cloned, moreButton);
+  return cloned;
+}
+
+export function injectResponseActionCopyImageButtons(
+  root: ParentNode,
+  options: ResponseActionCopyImageOptions,
+): HTMLElement[] {
+  const moreButtons: HTMLElement[] = [];
+  if (root instanceof HTMLElement && root.getAttribute('data-test-id') === MORE_BUTTON_TEST_ID) {
+    moreButtons.push(root);
+  }
+  moreButtons.push(
+    ...Array.from(root.querySelectorAll<HTMLElement>(`[data-test-id="${MORE_BUTTON_TEST_ID}"]`)),
+  );
+
+  if (moreButtons.length === 0 && root instanceof HTMLElement) {
+    const directContainer = findActionContainerFromMoreButton(root);
+    if (directContainer) {
+      const maybeInjected = injectIntoActionContainer(directContainer, options);
+      return maybeInjected ? [maybeInjected] : [];
+    }
+  }
+
+  const visitedContainers = new Set<HTMLElement>();
+  const injected: HTMLElement[] = [];
+
+  for (const moreButton of moreButtons) {
+    const container = findActionContainerFromMoreButton(moreButton);
+    if (!container || visitedContainers.has(container)) continue;
+    visitedContainers.add(container);
+    const maybeInjected = injectIntoActionContainer(container, options);
+    if (maybeInjected) injected.push(maybeInjected);
+  }
+
+  return injected;
+}

--- a/src/pages/content/export/responseImageCopy.ts
+++ b/src/pages/content/export/responseImageCopy.ts
@@ -1,0 +1,61 @@
+import { renderElementToImageBlob } from '@/features/export/services/ImageRenderService';
+
+type ClipboardWriteLike = Pick<Clipboard, 'write'>;
+type ClipboardItemLike = new (items: Record<string, Blob>) => ClipboardItem;
+
+export type CopyElementAsImageOptions = {
+  clipboard?: ClipboardWriteLike | null;
+  ClipboardItemCtor?: ClipboardItemLike | null;
+};
+
+function resolveClipboardDependencies(options?: CopyElementAsImageOptions): {
+  clipboard: ClipboardWriteLike | null;
+  ClipboardItemCtor: ClipboardItemLike | null;
+} {
+  const clipboard = options?.clipboard ?? navigator.clipboard ?? null;
+  const globalClipboardItem = (globalThis as unknown as { ClipboardItem?: ClipboardItemLike })
+    .ClipboardItem;
+  const ClipboardItemCtor = options?.ClipboardItemCtor ?? globalClipboardItem ?? null;
+
+  return { clipboard, ClipboardItemCtor };
+}
+
+export async function copyImageBlobToClipboard(
+  blob: Blob,
+  options?: CopyElementAsImageOptions,
+): Promise<void> {
+  const { clipboard, ClipboardItemCtor } = resolveClipboardDependencies(options);
+  if (!clipboard?.write || !ClipboardItemCtor) {
+    throw new Error('Clipboard image copy is not supported in this browser');
+  }
+
+  const item = new ClipboardItemCtor({ [blob.type || 'image/png']: blob });
+  await clipboard.write([item]);
+}
+
+export function downloadImageBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename.toLowerCase().endsWith('.png') ? filename : `${filename}.png`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  setTimeout(() => {
+    try {
+      document.body.removeChild(anchor);
+    } catch {
+      /* ignore */
+    }
+    URL.revokeObjectURL(url);
+  }, 0);
+}
+
+export async function copyElementAsImageToClipboard(
+  target: HTMLElement,
+  options?: CopyElementAsImageOptions,
+): Promise<void> {
+  const blob = await renderElementToImageBlob(target, {
+    enableSanitizedFallback: true,
+  });
+  await copyImageBlobToClipboard(blob, options);
+}

--- a/src/pages/content/export/selectionUtils.ts
+++ b/src/pages/content/export/selectionUtils.ts
@@ -98,3 +98,12 @@ export function findSelectionStartIdAtLine(
 
   return null;
 }
+
+export function resolveInitialSelectedMessageIds(
+  allMessageIds: readonly string[],
+  preferredMessageId: string | null | undefined,
+): Set<string> {
+  if (!preferredMessageId) return new Set<string>();
+  if (!allMessageIds.includes(preferredMessageId)) return new Set<string>();
+  return new Set<string>([preferredMessageId]);
+}

--- a/src/pages/content/export/topNodePreload.ts
+++ b/src/pages/content/export/topNodePreload.ts
@@ -65,8 +65,8 @@ export type WaitForConversationChangeResult = {
 
 const DEFAULT_OPTIONS: WaitForConversationChangeOptions = {
   timeoutMs: 20000,
-  idleMs: 550,
-  minWaitMs: 1200,
+  idleMs: 320,
+  minWaitMs: 600,
   pollIntervalMs: 80,
   maxSamples: 10,
 };


### PR DESCRIPTION
## 变更说明
- 在单条 AI 回复的 `more options` 菜单中注入“导出对话”入口；用户选择导出格式后，默认预选当前这条回复
- 在回复动作区新增“复制为图片”按钮（位于 more options 与 copy response 之间），并复用现有图片导出链路
- 优化选择模式下导出条与加载 Toast 的定位鲁棒性；Safari 下剪贴板写图失败时自动回退为直接下载该条回复图片，保证功能可用

## 测试验证
- [x] `bun run test src/pages/content/export/__tests__/conversationMenuInjection.test.ts`
- [x] `bun run test src/pages/content/export/__tests__/selectionUtils.test.ts`
- [x] `bun run test src/pages/content/export/__tests__/responseActionImageButton.test.ts`
- [x] `bun run test src/pages/content/export/__tests__/responseImageCopy.test.ts`
- [x] `bun run test src/pages/content/export/__tests__/selectionModeInteraction.test.ts`
- [x] `bun run test src/pages/content/export/__tests__/topNodePreload.test.ts`
- [x] `bun run test src/features/export/services/__tests__/ImageExportService.test.ts`
- [x] `bun run test src/features/export/services/__tests__/ImageRenderService.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build:all`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
