### PR TITLE
feat: add input minimal collapse mode with double-enter expand

### DIFF
--- a/src/core/types/common.ts
+++ b/src/core/types/common.ts
@@ -61,6 +61,7 @@ export const StorageKeys = {
 
   // Input behavior
   CTRL_ENTER_SEND: 'gvCtrlEnterSend',
+  GV_INPUT_MIN_COLLAPSE: 'gvInputMinCollapseEnabled',
 
   // Default Model
   DEFAULT_MODEL: 'gvDefaultModel',

--- a/src/locales/ar/messages.json
+++ b/src/locales/ar/messages.json
@@ -980,6 +980,14 @@
     "message": "طي منطقة الإدخال عندما تكون فارغة للحصول على مساحة قراءة أكبر",
     "description": "Input collapse feature hint"
   },
+  "enableInputMinCollapse": {
+    "message": "تفعيل التصغير الكامل لمنطقة الإدخال",
+    "description": "Enable aggressive input collapse toggle label"
+  },
+  "enableInputMinCollapseHint": {
+    "message": "عند الطي، أخفِ منطقة الإدخال بالكامل واضغط Enter مرتين لفتحها",
+    "description": "Aggressive input collapse feature hint"
+  },
   "inputCollapsePlaceholder": {
     "message": "راسل Gemini",
     "description": "Placeholder text shown in collapsed input"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -980,6 +980,14 @@
     "message": "Collapse the input area when empty to gain more reading space",
     "description": "Input collapse feature hint"
   },
+  "enableInputMinCollapse": {
+    "message": "Enable input minimal collapse",
+    "description": "Enable aggressive input collapse toggle label"
+  },
+  "enableInputMinCollapseHint": {
+    "message": "When collapsed, fully hide the input area and press Enter twice to expand it",
+    "description": "Aggressive input collapse feature hint"
+  },
   "inputCollapsePlaceholder": {
     "message": "Message Gemini",
     "description": "Placeholder text shown in collapsed input"

--- a/src/locales/es/messages.json
+++ b/src/locales/es/messages.json
@@ -980,6 +980,14 @@
     "message": "Contrae el área de entrada cuando está vacía para ganar más espacio de lectura",
     "description": "Input collapse feature hint"
   },
+  "enableInputMinCollapse": {
+    "message": "Habilitar minimización completa del cuadro de entrada",
+    "description": "Enable aggressive input collapse toggle label"
+  },
+  "enableInputMinCollapseHint": {
+    "message": "Cuando esté contraído, oculta por completo el cuadro de entrada y pulsa Enter dos veces para expandirlo",
+    "description": "Aggressive input collapse feature hint"
+  },
   "inputCollapsePlaceholder": {
     "message": "Mensaje a Gemini",
     "description": "Placeholder text shown in collapsed input"

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -980,6 +980,14 @@
     "message": "Réduit la zone de saisie quand elle est vide pour gagner de l'espace",
     "description": "Input collapse feature hint"
   },
+  "enableInputMinCollapse": {
+    "message": "Activer la réduction minimale de l'entrée",
+    "description": "Enable aggressive input collapse toggle label"
+  },
+  "enableInputMinCollapseHint": {
+    "message": "Lorsqu'elle est réduite, masquer complètement la zone de saisie et appuyer deux fois sur Entrée pour l'ouvrir",
+    "description": "Aggressive input collapse feature hint"
+  },
   "inputCollapsePlaceholder": {
     "message": "Message à Gemini",
     "description": "Placeholder text shown in collapsed input"

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -980,6 +980,14 @@
     "message": "空の時に入力欄を折りたたみ、広い読書スペースを確保します",
     "description": "Input collapse feature hint"
   },
+  "enableInputMinCollapse": {
+    "message": "入力欄の最小化折りたたみを有効化",
+    "description": "Enable aggressive input collapse toggle label"
+  },
+  "enableInputMinCollapseHint": {
+    "message": "折りたたみ時に入力欄を完全に隠し、Enter を2回押すと展開します",
+    "description": "Aggressive input collapse feature hint"
+  },
   "inputCollapsePlaceholder": {
     "message": "Gemini にメッセージを送信",
     "description": "Placeholder text shown in collapsed input"

--- a/src/locales/ko/messages.json
+++ b/src/locales/ko/messages.json
@@ -980,6 +980,14 @@
     "message": "입력창이 비어 있을 때 접어서 더 많은 읽기 공간을 확보합니다",
     "description": "Input collapse feature hint"
   },
+  "enableInputMinCollapse": {
+    "message": "입력창 완전 최소화 접기 활성화",
+    "description": "Enable aggressive input collapse toggle label"
+  },
+  "enableInputMinCollapseHint": {
+    "message": "접힌 상태에서 입력창을 완전히 숨기고 Enter를 두 번 누르면 다시 펼칩니다",
+    "description": "Aggressive input collapse feature hint"
+  },
   "inputCollapsePlaceholder": {
     "message": "Gemini에게 메시지 보내기",
     "description": "Placeholder text shown in collapsed input"

--- a/src/locales/pt/messages.json
+++ b/src/locales/pt/messages.json
@@ -980,6 +980,14 @@
     "message": "Contrai a área de entrada quando vazia para ganhar mais espaço de leitura",
     "description": "Input collapse feature hint"
   },
+  "enableInputMinCollapse": {
+    "message": "Ativar minimização total da entrada",
+    "description": "Enable aggressive input collapse toggle label"
+  },
+  "enableInputMinCollapseHint": {
+    "message": "Quando contraída, oculta totalmente a área de entrada e pressione Enter duas vezes para expandir",
+    "description": "Aggressive input collapse feature hint"
+  },
   "inputCollapsePlaceholder": {
     "message": "Mensagem para o Gemini",
     "description": "Placeholder text shown in collapsed input"

--- a/src/locales/ru/messages.json
+++ b/src/locales/ru/messages.json
@@ -980,6 +980,14 @@
     "message": "Сворачивать поле ввода, когда оно пустое, для увеличения пространства для чтения",
     "description": "Input collapse feature hint"
   },
+  "enableInputMinCollapse": {
+    "message": "Включить минимальное сворачивание поля ввода",
+    "description": "Enable aggressive input collapse toggle label"
+  },
+  "enableInputMinCollapseHint": {
+    "message": "При сворачивании полностью скрывать поле ввода; дважды нажмите Enter, чтобы развернуть",
+    "description": "Aggressive input collapse feature hint"
+  },
   "inputCollapsePlaceholder": {
     "message": "Сообщение Gemini",
     "description": "Placeholder text shown in collapsed input"

--- a/src/locales/zh/messages.json
+++ b/src/locales/zh/messages.json
@@ -980,6 +980,14 @@
     "message": "输入框为空时自动折叠，获得更多阅读空间",
     "description": "输入框折叠功能提示"
   },
+  "enableInputMinCollapse": {
+    "message": "启用输入框最小化折叠",
+    "description": "启用输入框最小化折叠开关标签"
+  },
+  "enableInputMinCollapseHint": {
+    "message": "折叠时完全隐藏输入框并释放空间，双击 Enter 可自动弹开",
+    "description": "输入框最小化折叠功能提示"
+  },
   "inputCollapsePlaceholder": {
     "message": "给 Gemini 发消息",
     "description": "折叠输入框时显示的占位符文本"

--- a/src/locales/zh_TW/messages.json
+++ b/src/locales/zh_TW/messages.json
@@ -940,6 +940,14 @@
     "message": "輸入框為空時自動摺疊，獲得更多閱讀空間",
     "description": "輸入框摺疊功能提示"
   },
+  "enableInputMinCollapse": {
+    "message": "啟用輸入框最小化摺疊",
+    "description": "啟用輸入框最小化摺疊開關標籤"
+  },
+  "enableInputMinCollapseHint": {
+    "message": "摺疊時完全隱藏輸入框並釋放空間，連按兩次 Enter 可自動展開",
+    "description": "輸入框最小化摺疊功能提示"
+  },
   "inputCollapsePlaceholder": {
     "message": "傳送訊息給 Gemini",
     "description": "摺疊輸入框時顯示的佔位符文字"

--- a/src/pages/content/inputCollapse/__tests__/inputCollapse.minimize.test.ts
+++ b/src/pages/content/inputCollapse/__tests__/inputCollapse.minimize.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    storage: {
+      onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('../../../../utils/i18n', () => ({
+  getTranslationSync: (key: string) => (key === 'inputCollapsePlaceholder' ? 'Message Gemini' : key),
+}));
+
+type StorageChangeListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  area: string,
+) => void;
+
+function createInputContainer(): HTMLElement {
+  const container = document.createElement('div');
+  container.style.backgroundColor = 'rgb(240, 244, 249)';
+
+  const richTextarea = document.createElement('rich-textarea');
+  const editor = document.createElement('div');
+  editor.className = 'ql-editor';
+  editor.setAttribute('contenteditable', 'true');
+  richTextarea.appendChild(editor);
+  container.appendChild(richTextarea);
+  document.body.appendChild(container);
+
+  return container;
+}
+
+describe('inputCollapse minimize mode', () => {
+  let storageChangeListener: StorageChangeListener | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+    storageChangeListener = null;
+
+    (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (
+        _defaults: Record<string, unknown>,
+        callback: (result: Record<string, unknown>) => void,
+      ) => {
+        callback({
+          gvInputCollapseEnabled: true,
+          gvInputMinCollapseEnabled: true,
+        });
+      },
+    );
+
+    (
+      chrome.storage.onChanged.addListener as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation((listener: StorageChangeListener) => {
+      storageChangeListener = listener;
+    });
+  });
+
+  afterEach(() => {
+    storageChangeListener?.(
+      {
+        gvInputCollapseEnabled: { oldValue: true, newValue: false } as chrome.storage.StorageChange,
+      },
+      'sync',
+    );
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  async function initAndCollapse({
+    minCollapseEnabled = true,
+  }: { minCollapseEnabled?: boolean } = {}): Promise<HTMLElement> {
+    (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (
+        _defaults: Record<string, unknown>,
+        callback: (result: Record<string, unknown>) => void,
+      ) => {
+        callback({
+          gvInputCollapseEnabled: true,
+          gvInputMinCollapseEnabled: minCollapseEnabled,
+        });
+      },
+    );
+
+    const container = createInputContainer();
+    const { startInputCollapse } = await import('../index');
+    startInputCollapse();
+
+    // Trigger observer once and flush collapse timeout.
+    document.body.appendChild(document.createElement('div'));
+    await Promise.resolve();
+    vi.advanceTimersByTime(200);
+
+    return container;
+  }
+
+  it('applies minimized collapse class when enabled', async () => {
+    const container = await initAndCollapse({ minCollapseEnabled: true });
+    expect(container.classList.contains('gv-input-collapsed')).toBe(true);
+    expect(container.classList.contains('gv-input-min-collapsed')).toBe(true);
+  });
+
+  it('double Enter expands the minimized input', async () => {
+    const container = await initAndCollapse({ minCollapseEnabled: true });
+    expect(container.classList.contains('gv-input-min-collapsed')).toBe(true);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(container.classList.contains('gv-input-collapsed')).toBe(false);
+    expect(container.classList.contains('gv-input-min-collapsed')).toBe(false);
+  });
+
+  it('does not expand on double Enter when minimized mode is disabled', async () => {
+    const container = await initAndCollapse({ minCollapseEnabled: true });
+    expect(container.classList.contains('gv-input-collapsed')).toBe(true);
+    expect(container.classList.contains('gv-input-min-collapsed')).toBe(true);
+
+    storageChangeListener?.(
+      {
+        gvInputMinCollapseEnabled: {
+          oldValue: true,
+          newValue: false,
+        } as chrome.storage.StorageChange,
+      },
+      'sync',
+    );
+    expect(container.classList.contains('gv-input-min-collapsed')).toBe(false);
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(container.classList.contains('gv-input-collapsed')).toBe(true);
+  });
+
+  it('cleans up collapse classes when main toggle is disabled', async () => {
+    const container = await initAndCollapse({ minCollapseEnabled: true });
+    expect(container.classList.contains('gv-input-min-collapsed')).toBe(true);
+    expect(storageChangeListener).not.toBeNull();
+
+    storageChangeListener?.(
+      {
+        gvInputCollapseEnabled: { oldValue: true, newValue: false } as chrome.storage.StorageChange,
+      },
+      'sync',
+    );
+
+    expect(container.classList.contains('gv-input-collapsed')).toBe(false);
+    expect(container.classList.contains('gv-input-min-collapsed')).toBe(false);
+  });
+});

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -119,6 +119,7 @@ interface SettingsUpdate {
   watermarkRemoverEnabled?: boolean;
   hidePromptManager?: boolean;
   inputCollapseEnabled?: boolean;
+  inputMinCollapseEnabled?: boolean;
   tabTitleUpdateEnabled?: boolean;
   mermaidEnabled?: boolean;
   quoteReplyEnabled?: boolean;
@@ -146,6 +147,7 @@ export default function Popup() {
   const [watermarkRemoverEnabled, setWatermarkRemoverEnabled] = useState<boolean>(true);
   const [hidePromptManager, setHidePromptManager] = useState<boolean>(false);
   const [inputCollapseEnabled, setInputCollapseEnabled] = useState<boolean>(false);
+  const [inputMinCollapseEnabled, setInputMinCollapseEnabled] = useState<boolean>(false);
   const [tabTitleUpdateEnabled, setTabTitleUpdateEnabled] = useState<boolean>(true);
   const [mermaidEnabled, setMermaidEnabled] = useState<boolean>(true);
   const [quoteReplyEnabled, setQuoteReplyEnabled] = useState<boolean>(true);
@@ -215,6 +217,8 @@ export default function Popup() {
         payload.gvHidePromptManager = settings.hidePromptManager;
       if (typeof settings.inputCollapseEnabled === 'boolean')
         payload.gvInputCollapseEnabled = settings.inputCollapseEnabled;
+      if (typeof settings.inputMinCollapseEnabled === 'boolean')
+        payload.gvInputMinCollapseEnabled = settings.inputMinCollapseEnabled;
       if (typeof settings.tabTitleUpdateEnabled === 'boolean')
         payload.gvTabTitleUpdateEnabled = settings.tabTitleUpdateEnabled;
       if (typeof settings.mermaidEnabled === 'boolean')
@@ -431,6 +435,7 @@ export default function Popup() {
           geminiWatermarkRemoverEnabled: true,
           gvHidePromptManager: false,
           gvInputCollapseEnabled: false,
+          gvInputMinCollapseEnabled: false,
           gvTabTitleUpdateEnabled: true,
           gvMermaidEnabled: true,
           gvQuoteReplyEnabled: true,
@@ -454,7 +459,9 @@ export default function Popup() {
           setCustomWebsites(loadedCustomWebsites);
           setWatermarkRemoverEnabled(res?.geminiWatermarkRemoverEnabled !== false);
           setHidePromptManager(!!res?.gvHidePromptManager);
-          setInputCollapseEnabled(res?.gvInputCollapseEnabled !== false);
+          const collapseEnabled = res?.gvInputCollapseEnabled !== false;
+          setInputCollapseEnabled(collapseEnabled);
+          setInputMinCollapseEnabled(collapseEnabled && res?.gvInputMinCollapseEnabled === true);
           setTabTitleUpdateEnabled(res?.gvTabTitleUpdateEnabled !== false);
           setMermaidEnabled(res?.gvMermaidEnabled !== false);
           setQuoteReplyEnabled(res?.gvQuoteReplyEnabled !== false);
@@ -1068,8 +1075,37 @@ export default function Popup() {
                 id="input-collapse-enabled"
                 checked={inputCollapseEnabled}
                 onChange={(e) => {
-                  setInputCollapseEnabled(e.target.checked);
-                  apply({ inputCollapseEnabled: e.target.checked });
+                  const enabled = e.target.checked;
+                  setInputCollapseEnabled(enabled);
+                  if (!enabled) {
+                    setInputMinCollapseEnabled(false);
+                    apply({ inputCollapseEnabled: false, inputMinCollapseEnabled: false });
+                  } else {
+                    apply({ inputCollapseEnabled: true });
+                  }
+                }}
+              />
+            </div>
+            <div className="group flex items-center justify-between">
+              <div className="flex-1">
+                <Label
+                  htmlFor="input-min-collapse-enabled"
+                  className="group-hover:text-primary cursor-pointer text-sm font-medium transition-colors"
+                >
+                  {t('enableInputMinCollapse')}
+                </Label>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  {t('enableInputMinCollapseHint')}
+                </p>
+              </div>
+              <Switch
+                id="input-min-collapse-enabled"
+                checked={inputMinCollapseEnabled}
+                disabled={!inputCollapseEnabled}
+                onChange={(e) => {
+                  const enabled = e.target.checked;
+                  setInputMinCollapseEnabled(enabled);
+                  apply({ inputMinCollapseEnabled: enabled });
                 }}
               />
             </div>


### PR DESCRIPTION
## Summary
- Add a new nested setting `Enable Input Minimal Collapse` under existing input collapse.
- When enabled, collapsed input can fully disappear from layout and be restored by double pressing `Enter` (350ms window).
- Keep child option visually dimmed/disabled when parent input-collapse toggle is off.

## Why
- Some users want a cleaner UI than compact collapse.
- Keyboard-first restore keeps the flow fast without extra UI controls.

## Logic Changes
- Add storage key `gvInputMinCollapseEnabled` (default `false`).
- Add minimized collapse class behavior and cleanup logic when parent toggle is disabled.
- Restrict double-`Enter` shortcut handling to minimized state only.
- Update popup dependency and visual weakening behavior for child option.

## User Impact
- New optional minimal mode for input collapse.
- No behavior change unless user enables the new toggle.

## Test Plan
- [x] `npm run test -- src/pages/content/inputCollapse/__tests__/inputCollapse.minimize.test.ts`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run build:firefox`
- [x] Manual validation on Chrome
- [x] Manual validation on Firefox

## Visual Proof
- Video/screenshots will be attached in PR comment right after upload.