### PR TITLE
feat: make Gemini folder tree indent configurable

### DIFF
--- a/src/core/types/common.ts
+++ b/src/core/types/common.ts
@@ -74,6 +74,7 @@ export const StorageKeys = {
   // Folder spacing
   GV_FOLDER_SPACING: 'gvFolderSpacing',
   GV_AISTUDIO_FOLDER_SPACING: 'gvAIStudioFolderSpacing',
+  GV_FOLDER_TREE_INDENT: 'gvFolderTreeIndent',
 } as const;
 
 export type StorageKey = (typeof StorageKeys)[keyof typeof StorageKeys];

--- a/src/locales/ar/messages.json
+++ b/src/locales/ar/messages.json
@@ -1160,6 +1160,18 @@
     "message": "واسع",
     "description": "Spacious folder spacing label"
   },
+  "folderTreeIndent": {
+    "message": "إزاحة المجلدات الفرعية",
+    "description": "Subfolder tree indentation adjustment label"
+  },
+  "folderTreeIndentCompact": {
+    "message": "أضيق",
+    "description": "Narrow subfolder indentation label"
+  },
+  "folderTreeIndentSpacious": {
+    "message": "أوسع",
+    "description": "Wide subfolder indentation label"
+  },
   "export_select_mode_select_all": {
     "message": "Select all",
     "description": "Selection mode select all toggle"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1160,6 +1160,18 @@
     "message": "Spacious",
     "description": "Spacious folder spacing label"
   },
+  "folderTreeIndent": {
+    "message": "Subfolder indent",
+    "description": "Subfolder tree indentation adjustment label"
+  },
+  "folderTreeIndentCompact": {
+    "message": "Narrow",
+    "description": "Narrow subfolder indentation label"
+  },
+  "folderTreeIndentSpacious": {
+    "message": "Wide",
+    "description": "Wide subfolder indentation label"
+  },
   "export_select_mode_select_all": {
     "message": "Select all",
     "description": "Selection mode select all toggle"

--- a/src/locales/es/messages.json
+++ b/src/locales/es/messages.json
@@ -1160,6 +1160,18 @@
     "message": "Espacioso",
     "description": "Spacious folder spacing label"
   },
+  "folderTreeIndent": {
+    "message": "Sangría de subcarpetas",
+    "description": "Subfolder tree indentation adjustment label"
+  },
+  "folderTreeIndentCompact": {
+    "message": "Estrecha",
+    "description": "Narrow subfolder indentation label"
+  },
+  "folderTreeIndentSpacious": {
+    "message": "Ancha",
+    "description": "Wide subfolder indentation label"
+  },
   "export_select_mode_select_all": {
     "message": "Select all",
     "description": "Selection mode select all toggle"

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -1160,6 +1160,18 @@
     "message": "Spacieux",
     "description": "Spacious folder spacing label"
   },
+  "folderTreeIndent": {
+    "message": "Retrait des sous-dossiers",
+    "description": "Subfolder tree indentation adjustment label"
+  },
+  "folderTreeIndentCompact": {
+    "message": "Étroit",
+    "description": "Narrow subfolder indentation label"
+  },
+  "folderTreeIndentSpacious": {
+    "message": "Large",
+    "description": "Wide subfolder indentation label"
+  },
   "export_select_mode_select_all": {
     "message": "Select all",
     "description": "Selection mode select all toggle"

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -1160,6 +1160,18 @@
     "message": "ゆったり",
     "description": "ゆったりフォルダ間隔ラベル"
   },
+  "folderTreeIndent": {
+    "message": "サブフォルダのインデント",
+    "description": "サブフォルダ階層のインデント調整ラベル"
+  },
+  "folderTreeIndentCompact": {
+    "message": "狭い",
+    "description": "狭いサブフォルダインデントラベル"
+  },
+  "folderTreeIndentSpacious": {
+    "message": "広い",
+    "description": "広いサブフォルダインデントラベル"
+  },
   "export_select_mode_select_all": {
     "message": "すべて選択",
     "description": "Selection mode select all toggle"

--- a/src/locales/ko/messages.json
+++ b/src/locales/ko/messages.json
@@ -1160,6 +1160,18 @@
     "message": "넓게",
     "description": "Spacious folder spacing label"
   },
+  "folderTreeIndent": {
+    "message": "하위 폴더 들여쓰기",
+    "description": "Subfolder tree indentation adjustment label"
+  },
+  "folderTreeIndentCompact": {
+    "message": "좁게",
+    "description": "Narrow subfolder indentation label"
+  },
+  "folderTreeIndentSpacious": {
+    "message": "넓게",
+    "description": "Wide subfolder indentation label"
+  },
   "export_select_mode_select_all": {
     "message": "전체 선택",
     "description": "Selection mode select all toggle"

--- a/src/locales/pt/messages.json
+++ b/src/locales/pt/messages.json
@@ -1160,6 +1160,18 @@
     "message": "Espaçoso",
     "description": "Spacious folder spacing label"
   },
+  "folderTreeIndent": {
+    "message": "Recuo de subpastas",
+    "description": "Subfolder tree indentation adjustment label"
+  },
+  "folderTreeIndentCompact": {
+    "message": "Estreito",
+    "description": "Narrow subfolder indentation label"
+  },
+  "folderTreeIndentSpacious": {
+    "message": "Largo",
+    "description": "Wide subfolder indentation label"
+  },
   "export_select_mode_select_all": {
     "message": "Select all",
     "description": "Selection mode select all toggle"

--- a/src/locales/ru/messages.json
+++ b/src/locales/ru/messages.json
@@ -1160,6 +1160,18 @@
     "message": "Просторно",
     "description": "Spacious folder spacing label"
   },
+  "folderTreeIndent": {
+    "message": "Отступ подпапок",
+    "description": "Subfolder tree indentation adjustment label"
+  },
+  "folderTreeIndentCompact": {
+    "message": "Узкий",
+    "description": "Narrow subfolder indentation label"
+  },
+  "folderTreeIndentSpacious": {
+    "message": "Широкий",
+    "description": "Wide subfolder indentation label"
+  },
   "export_select_mode_select_all": {
     "message": "Select all",
     "description": "Selection mode select all toggle"

--- a/src/locales/zh/messages.json
+++ b/src/locales/zh/messages.json
@@ -1160,6 +1160,18 @@
     "message": "宽松",
     "description": "宽松文件夹间距标签"
   },
+  "folderTreeIndent": {
+    "message": "子文件夹缩进",
+    "description": "子文件夹树形缩进调节标签"
+  },
+  "folderTreeIndentCompact": {
+    "message": "更窄",
+    "description": "较窄的子文件夹缩进标签"
+  },
+  "folderTreeIndentSpacious": {
+    "message": "更宽",
+    "description": "较宽的子文件夹缩进标签"
+  },
   "export_select_mode_select_all": {
     "message": "全选",
     "description": "Selection mode select all toggle"

--- a/src/locales/zh_TW/messages.json
+++ b/src/locales/zh_TW/messages.json
@@ -1160,6 +1160,18 @@
     "message": "寬鬆",
     "description": "寬鬆資料夾間距標籤"
   },
+  "folderTreeIndent": {
+    "message": "子資料夾縮排",
+    "description": "子資料夾樹狀縮排調整標籤"
+  },
+  "folderTreeIndentCompact": {
+    "message": "更窄",
+    "description": "較窄的子資料夾縮排標籤"
+  },
+  "folderTreeIndentSpacious": {
+    "message": "更寬",
+    "description": "較寬的子資料夾縮排標籤"
+  },
   "export_select_mode_select_all": {
     "message": "全選",
     "description": "Selection mode select all toggle"

--- a/src/pages/content/folder/__tests__/treeIndent.test.ts
+++ b/src/pages/content/folder/__tests__/treeIndent.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  FolderManager,
+  calculateFolderConversationPaddingLeft,
+  calculateFolderDialogPaddingLeft,
+  calculateFolderHeaderPaddingLeft,
+  clampFolderTreeIndent,
+} from '../manager';
+
+vi.mock('@/utils/i18n', () => ({
+  getTranslationSync: (key: string) => key,
+  getTranslationSyncUnsafe: (key: string) => key,
+  initI18n: () => Promise.resolve(),
+}));
+
+describe('folder tree indentation', () => {
+  let manager: FolderManager | null = null;
+
+  afterEach(() => {
+    manager?.destroy();
+    manager = null;
+    document.body.innerHTML = '';
+  });
+
+  it('clamps configured indent into [8, 32]', () => {
+    expect(clampFolderTreeIndent(-10)).toBe(8);
+    expect(clampFolderTreeIndent(64)).toBe(32);
+    expect(clampFolderTreeIndent(16)).toBe(16);
+  });
+
+  it('calculates folder and conversation paddings from indent and level', () => {
+    expect(calculateFolderHeaderPaddingLeft(2, 16)).toBe(40); // 2 * 16 + 8
+    expect(calculateFolderConversationPaddingLeft(2, 16)).toBe(56); // 2 * 16 + 24
+    expect(calculateFolderDialogPaddingLeft(2, 16)).toBe(44); // 2 * 16 + 12
+  });
+
+  it('updates indent and refreshes render when setting changes', () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as {
+      folderEnabled: boolean;
+      containerElement: HTMLElement | null;
+      folderTreeIndent: number;
+      renderAllFolders: () => void;
+      applyFolderTreeIndentSetting: (value: unknown) => void;
+    };
+
+    typedManager.folderEnabled = true;
+    typedManager.containerElement = document.createElement('div');
+    typedManager.folderTreeIndent = 16;
+    const renderSpy = vi.spyOn(typedManager, 'renderAllFolders').mockImplementation(() => {});
+
+    typedManager.applyFolderTreeIndentSetting(28);
+    expect(typedManager.folderTreeIndent).toBe(28);
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -61,6 +61,7 @@ const normalizePercent = (
 };
 
 const FOLDER_SPACING = { min: 0, max: 16, defaultValue: 2 };
+const FOLDER_TREE_INDENT = { min: 8, max: 32, defaultValue: 16 };
 const CHAT_PERCENT = { min: 30, max: 100, defaultValue: 70, legacyBaselinePx: LEGACY_BASELINE_PX };
 const EDIT_PERCENT = { min: 30, max: 100, defaultValue: 60, legacyBaselinePx: LEGACY_BASELINE_PX };
 const SIDEBAR_PERCENT = {
@@ -330,6 +331,18 @@ export default function Popup() {
       },
       [folderSpacingKey],
     ),
+  });
+
+  const folderTreeIndentAdjuster = useWidthAdjuster({
+    storageKey: 'gvFolderTreeIndent',
+    defaultValue: FOLDER_TREE_INDENT.defaultValue,
+    normalize: (v) => clampNumber(v, FOLDER_TREE_INDENT.min, FOLDER_TREE_INDENT.max),
+    onApply: useCallback((indent: number) => {
+      const clamped = clampNumber(indent, FOLDER_TREE_INDENT.min, FOLDER_TREE_INDENT.max);
+      try {
+        chrome.storage?.sync?.set({ gvFolderTreeIndent: clamped });
+      } catch {}
+    }, []),
   });
 
   useEffect(() => {
@@ -938,6 +951,20 @@ export default function Popup() {
           onChange={folderSpacingAdjuster.handleChange}
           onChangeComplete={folderSpacingAdjuster.handleChangeComplete}
         />
+        {!isAIStudio && (
+          <WidthSlider
+            label={t('folderTreeIndent')}
+            value={folderTreeIndentAdjuster.width}
+            min={FOLDER_TREE_INDENT.min}
+            max={FOLDER_TREE_INDENT.max}
+            step={1}
+            narrowLabel={t('folderTreeIndentCompact')}
+            wideLabel={t('folderTreeIndentSpacious')}
+            valueFormatter={(v) => `${v}px`}
+            onChange={folderTreeIndentAdjuster.handleChange}
+            onChangeComplete={folderTreeIndentAdjuster.handleChangeComplete}
+          />
+        )}
         {/* Chat Width */}
         <WidthSlider
           label={t('chatWidth')}


### PR DESCRIPTION
## Summary
- add configurable Gemini-only folder tree indent setting (`8-32`, step `1`, default `16`)
- replace hardcoded indent calculations in folder manager with storage-backed clamped value
- update popup UI, locale strings, and add tests for clamp and padding formulas

## Test Plan
- `npm run test -- src/pages/content/folder/__tests__/treeIndent.test.ts`
- `npm run build`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
