### PR TITLE
fix(core): restrict gemini-only features to gemini.google.com

### DIFF
--- a/src/pages/content/export/index.ts
+++ b/src/pages/content/export/index.ts
@@ -2006,13 +2006,6 @@ export async function startExportButton(): Promise<void> {
   // Check for pending export immediately
   checkPendingExport();
 
-  if (
-    location.hostname !== 'gemini.google.com' &&
-    location.hostname !== 'aistudio.google.com' &&
-    location.hostname !== 'aistudio.google.cn'
-  )
-    return;
-
   // i18n setup for tooltip and label
   const dict = await loadDictionaries();
   let lang = await getLanguage();

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -227,6 +227,9 @@ async function initializeFeatures(): Promise<void> {
       // Default Model Manager
       DefaultModelManager.getInstance().init();
       await delay(LIGHT_FEATURE_INIT_DELAY);
+
+      startExportButton();
+      await delay(LIGHT_FEATURE_INIT_DELAY);
     }
 
     if (
@@ -236,7 +239,9 @@ async function initializeFeatures(): Promise<void> {
     ) {
       promptManagerInstance = await startPromptManager();
       await delay(HEAVY_FEATURE_INIT_DELAY);
+    }
 
+    if (location.hostname === 'gemini.google.com') {
       // Initialize Mermaid rendering (lightweight)
       startMermaid();
       await delay(LIGHT_FEATURE_INIT_DELAY);
@@ -253,8 +258,6 @@ async function initializeFeatures(): Promise<void> {
       startFormulaCopy();
       await delay(LIGHT_FEATURE_INIT_DELAY);
     }
-
-    startExportButton();
   } catch (e) {
     if (isExtensionContextInvalidatedError(e)) {
       return;

--- a/src/pages/content/timeline/__tests__/TimelineBootstrap.test.ts
+++ b/src/pages/content/timeline/__tests__/TimelineBootstrap.test.ts
@@ -26,6 +26,24 @@ describe('Timeline bootstrap', () => {
     timelineManagerSpies.destroy.mockClear();
 
     document.body.innerHTML = '<main></main>';
+
+    // Mock location.hostname to simulate Gemini environment
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'gemini.google.com',
+        pathname: '/app',
+        search: '',
+        hash: '',
+        href: 'https://gemini.google.com/app',
+        origin: 'https://gemini.google.com',
+        assign: vi.fn(),
+        replace: vi.fn(),
+        reload: vi.fn(),
+        toString: () => 'https://gemini.google.com/app',
+      },
+      writable: true,
+    });
+
     history.replaceState({}, '', '/app');
   });
 


### PR DESCRIPTION
### 🚫 AI Policy / AI 政策

- **We explicitly reject AI-generated PRs that have not been manually verified.**
- **本项目拒绝接受任何未经人工复核的 AI 生成的 PR。**
- Low-quality AI PRs will be closed immediately. / 低质量的 AI PR 会被直接关闭。
- You must understand and take responsibility for every line of code you submit. / 你必须理解并对你提交的每一行代码负责。
- **Workflow Proficiency / 协作能力**: Ensure you are familiar with GitHub/Git workflows and maintain a clean Git history. Please learn the basics first if needed to avoid messy PR history. / 请确保你熟悉 GitHub/Git 工作流并保持 Git 历史整洁。如有必要请先学习相关知识，避免 PR 历史过于混乱。

---

### Description / 描述

此 PR 限制了几个专为 Gemini (gemini.google.com) 设计的功能在 AI Studio (aistudio.google.com) 上运行。由于 AI Studio 的 DOM 结构完全不同，这些功能在上面不仅无法使用，还会导致严重的性能问题甚至冲突。

特别是“导出为图片 (Copy Response as Image)”功能，之前在 AI Studio 的 Library 页面会导致浏览器严重卡顿甚至冻结（因为会无条件扫描整个巨大的 DOM 树）。

还有一个是 Mermaid 渲染功能，虽然没有吃性能但是确实目前不兼容 AI Studio，因此我也排除 AI Studio 了。

### Related Issue / 相关 Issue

#307 
你之前修了，然而我在我电脑上测试并没有真的修复。现在是真修了。

### Visual Proof / 可视化证据

修复前的性能图：
<img width="2802" height="1872" alt="PixPin_2026-02-16_12-48-42" src="https://github.com/user-attachments/assets/6f280343-b7e3-421e-bd2e-7c1e48c1e851" />
可以看到查找 copy-button 消耗了非常多的性能。录屏我懒得弄了，反正就是卡着基本啥也干不了。

修复后：
<img width="2802" height="1872" alt="PixPin_2026-02-16_12-49-20" src="https://github.com/user-attachments/assets/28d5ca39-e30f-4cd9-a3c7-03b0994b249f" />
可以看到扩展基本不吃性能了。


### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
