### PR TITLE
feat(popup): move quote reply toggle above snow effect

### DIFF
--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -1068,6 +1068,33 @@ export default function Popup() {
           </Card>
         )}
 
+        {/* Quote Reply - Gemini only */}
+        {!isAIStudio && (
+          <Card className="p-4 transition-shadow hover:shadow-lg">
+            <CardContent className="p-0">
+              <div className="group flex items-center justify-between">
+                <div className="flex-1">
+                  <Label
+                    htmlFor="quote-reply-enabled"
+                    className="group-hover:text-primary cursor-pointer text-sm font-medium transition-colors"
+                  >
+                    {t('enableQuoteReply')}
+                  </Label>
+                  <p className="text-muted-foreground mt-1 text-xs">{t('enableQuoteReplyHint')}</p>
+                </div>
+                <Switch
+                  id="quote-reply-enabled"
+                  checked={quoteReplyEnabled}
+                  onChange={(e) => {
+                    setQuoteReplyEnabled(e.target.checked);
+                    apply({ quoteReplyEnabled: e.target.checked });
+                  }}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
         {/* Snow Effect - Gemini only */}
         {!isAIStudio && (
           <Card className="p-4 transition-shadow hover:shadow-lg">
@@ -1374,25 +1401,6 @@ export default function Popup() {
                 onChange={(e) => {
                   setMermaidEnabled(e.target.checked);
                   apply({ mermaidEnabled: e.target.checked });
-                }}
-              />
-            </div>
-            <div className="group flex items-center justify-between">
-              <div className="flex-1">
-                <Label
-                  htmlFor="quote-reply-enabled"
-                  className="group-hover:text-primary cursor-pointer text-sm font-medium transition-colors"
-                >
-                  {t('enableQuoteReply')}
-                </Label>
-                <p className="text-muted-foreground mt-1 text-xs">{t('enableQuoteReplyHint')}</p>
-              </div>
-              <Switch
-                id="quote-reply-enabled"
-                checked={quoteReplyEnabled}
-                onChange={(e) => {
-                  setQuoteReplyEnabled(e.target.checked);
-                  apply({ quoteReplyEnabled: e.target.checked });
                 }}
               />
             </div>


### PR DESCRIPTION
## Description

Moves the "Quote Reply" toggle from the General Options section to its own card above the "Snow Effect" toggle. This improves visibility and accessibility for users who want to quickly toggle this feature, similar to the Snow Effect toggle.

## Changes

- Moved `quoteReplyEnabled` switch UI in `src/pages/popup/Popup.tsx`.
- Wrapped it in a conditional render `{!isAIStudio && ...}` consistent with its behavior in `content/index.tsx`.

## Motivation

Some users find the quote reply button intrusive when selecting text for reading purposes. Moving this toggle to a more prominent location (alongside other feature toggles like Snow Effect) makes it easier for users to find and configure.