### PR TITLE
fix: delay and reposition quote reply button to prevent misclicks / 延迟并调整引用按钮位置以防止误触

### DIFF
--- a/src/pages/content/quoteReply/index.ts
+++ b/src/pages/content/quoteReply/index.ts
@@ -23,7 +23,7 @@ const TIMING = {
   /** Delay before retrying focus for editors that need extra time */
   FOCUS_RETRY_DELAY_MS: 50,
   /** Debounce delay for selection change detection */
-  SELECTION_DEBOUNCE_MS: 10,
+  SELECTION_DEBOUNCE_MS: 250,
 } as const;
 
 /** UI positioning constants (in pixels) */
@@ -31,7 +31,7 @@ const POSITIONING = {
   /** Minimum distance from viewport edge */
   MIN_EDGE_OFFSET_PX: 10,
   /** Gap between button and selection */
-  BUTTON_SELECTION_GAP_PX: 10,
+  BUTTON_SELECTION_GAP_PX: 16,
 } as const;
 
 /** SVG icon for the quote button */


### PR DESCRIPTION
### Description / 描述

Adjusted the trigger delay and position of the quote reply button. This prevents accidental quote triggers when double-clicking or triple-clicking to select text, which previously caused unwanted quote text to be repeatedly inserted into the input box.

调整了引用回复按钮的触发延迟和位置，以防止在双击或三击选中段落时意外触发引用功能，导致输入框中被错误插入多余的引用文本。

### Changes / 更改

- `SELECTION_DEBOUNCE_MS`: Increased from `10ms` to `250ms` (从 `10ms` 增加到 `250ms`).
- `BUTTON_SELECTION_GAP_PX`: Increased from `10px` to `16px` (从 `10px` 增加到 `16px`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
