### PR TITLE
fix(ui): add explicit font-family to extension UI elements to prevent…

### DIFF
--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -560,15 +560,18 @@ html.dark .timeline-left-slider::before {
   z-index: 2147483646;
   opacity: 0;
 }
+
 .gemini-timeline-bar:hover ~ .timeline-preview-toggle,
 .timeline-preview-toggle:hover,
 .timeline-preview-toggle.active {
   opacity: 1;
 }
+
 .timeline-preview-toggle:hover {
   color: var(--timeline-dot-active-color);
   background-color: var(--timeline-tooltip-bg);
 }
+
 .timeline-preview-toggle.active {
   color: var(--timeline-dot-active-color);
   background-color: var(--timeline-tooltip-bg);
@@ -592,6 +595,7 @@ html.dark .timeline-left-slider::before {
   pointer-events: none;
   overflow: hidden;
 }
+
 .timeline-preview-panel.visible {
   opacity: 1;
   transform: scale(1) translateX(0);
@@ -603,6 +607,7 @@ html.dark .timeline-left-slider::before {
   border-bottom: 1px solid var(--timeline-tooltip-border);
   flex-shrink: 0;
 }
+
 .timeline-preview-search input {
   width: 100%;
   box-sizing: border-box;
@@ -616,10 +621,12 @@ html.dark .timeline-left-slider::before {
   outline: none;
   transition: border-color 0.15s ease;
 }
+
 .timeline-preview-search input::placeholder {
   color: var(--timeline-dot-color);
   opacity: 0.7;
 }
+
 .timeline-preview-search input:focus {
   border-color: var(--timeline-dot-active-color);
 }
@@ -644,13 +651,16 @@ html.dark .timeline-left-slider::before {
   gap: 0px;
   transition: background-color 0.1s ease;
 }
+
 .timeline-preview-item:hover {
   background-color: rgba(59, 130, 246, 0.08);
 }
+
 .timeline-preview-item.active {
   border-left-color: var(--timeline-dot-active-color);
   background-color: rgba(59, 130, 246, 0.1);
 }
+
 .timeline-preview-item.starred .timeline-preview-index::after {
   content: ' \2605';
   color: var(--timeline-star-color);
@@ -702,15 +712,19 @@ mark.timeline-search-highlight {
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
 }
+
 .theme-host.dark-theme .timeline-preview-item:hover {
   background-color: rgba(96, 165, 250, 0.08);
 }
+
 .theme-host.dark-theme .timeline-preview-item.active {
   background-color: rgba(96, 165, 250, 0.12);
 }
+
 .theme-host.dark-theme .timeline-preview-highlight {
   background-color: rgba(96, 165, 250, 0.25);
 }
+
 .theme-host.dark-theme mark.timeline-search-highlight {
   background-color: oklch(0.7729 0.1535 163.2231 / 0.3);
 }
@@ -2564,6 +2578,7 @@ body.light-theme {
   padding: 8px 8px 8px 12px;
   /* Ensure alignment with Recent section */
   margin-left: 0;
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
 }
 
 /* Folder Header */
@@ -3362,6 +3377,7 @@ body.light-theme {
   z-index: 2147483647;
   min-width: 240px;
   max-width: 320px;
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
 }
 
 .gv-folder-confirm-message {
@@ -3430,6 +3446,7 @@ body.light-theme {
   max-height: 80vh;
   display: flex;
   flex-direction: column;
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
 }
 
 .gv-folder-dialog-title {
@@ -3520,6 +3537,7 @@ body.light-theme {
   opacity: 0;
   transition: opacity 0.15s ease-in-out;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
 }
 
 .gv-tooltip.show {
@@ -3573,6 +3591,7 @@ html[data-color-scheme='light'] [data-math]:hover {
   transform: translateY(-10px) scale(0.9);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   white-space: nowrap;
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
 }
 
 /* Success state */
@@ -4072,6 +4091,7 @@ body.dark-theme .gv-folder-action-btn.gv-filter-active mat-icon,
   min-width: 400px;
   max-width: 500px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
 }
 
 html.dark .gv-folder-import-dialog,
@@ -4270,6 +4290,7 @@ html.dark .gv-folder-dialog-btn-secondary:hover,
   transform: translateY(20px);
   transition: all 0.3s ease;
   max-width: 400px;
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
 }
 
 .gv-notification.show {
@@ -4327,6 +4348,7 @@ html.dark .gv-folder-dialog-btn-secondary:hover,
   min-width: 420px;
   max-width: 500px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
   animation: gv-slide-up 0.3s ease-out;
 }
 
@@ -5118,6 +5140,7 @@ body[data-color-scheme='dark'] .gv-export-progress-desc {
   display: flex;
   flex-direction: column;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
   animation: gv-slide-up 0.3s ease-out;
 }
 
@@ -5521,6 +5544,7 @@ html.dark .gv-changelog-chrome-rating-link:hover,
     opacity: 0;
     transform: scale(0.96);
   }
+
   to {
     opacity: 1;
     transform: scale(1);


### PR DESCRIPTION
### Description
This PR fixes a UI rendering issue where Gemini Voyager extension elements fallback to a serif font (like Times New Roman) when Gemini's strict Content Security Policy blocks KaTeX font files. 
The main change is the addition of the explicit `font-family: 'Google Sans', Roboto, Arial, sans-serif;` declaration to 10 root-level `gv-`-prefixed UI containers injected by the content script. This ensures they always render correctly without relying on inherited page fonts.
Affected components fixed:
- Folder Dialog & Container (`.gv-folder-container`, `.gv-folder-dialog`)
- Confirmation Dialogs (`.gv-folder-confirm-dialog`, `.gv-folder-import-dialog`)
- Notifications & Toasts (`.gv-notification`, `.gv-copy-toast`)
- Prompt Manager Panel (`.gv-pm-panel`)
- Export Dialog (`.gv-export-dialog`)
- Changelog Dialog (`.gv-changelog-dialog`)
- Tooltips (`.gv-tooltip`)
*(Note: While the primary focus is the `font-family` fix, some minor code formatting/prettification was also applied to [contentStyle.css](cci:7://file:///e:/gemini-voyager/public/contentStyle.css:0:0-0:0) to improve readability).*

### Visual Proof
<img width="362" height="119" alt="Screenshot 2026-02-26 185902" src="https://github.com/user-attachments/assets/fc3959d6-5086-43c1-bbef-7a4fb757aed2" />
<img width="315" height="66" alt="Screenshot 2026-02-26 185837" src="https://github.com/user-attachments/assets/6c078c5f-c6b7-48a1-b011-e2eaf967730f" />
<img width="278" height="71" alt="Screenshot 2026-02-26 185801" src="https://github.com/user-attachments/assets/382759db-90ef-4ca7-9eab-757644e06305" />
<img width="253" height="68" alt="Screenshot 2026-02-26 185726" src="https://github.com/user-attachments/assets/c8791762-478f-4bc0-b990-e2b2631151b5" />
<img width="623" height="481" alt="Screenshot 2026-02-26 185633" src="https://github.com/user-attachments/assets/417cc13e-dc92-44fa-93a7-7455bd8b1aff" />
<img width="285" height="99" alt="Screenshot 2026-02-26 184649" src="https://github.com/user-attachments/assets/5bcb9298-5ddb-45f3-94bc-14bcfddd046d" />
<img width="271" height="99" alt="Screenshot 2026-02-26 180959" src="https://github.com/user-attachments/assets/9423ffcd-d178-4484-9949-f807269811bb" />

*(See attached screenshots showing the UI elements rendering correctly in sans-serif)*
### Browser Testing
- [x] **Chrome / Edge (Chromium)**: Tested
- [x] **Firefox**: Tested (Mandatory)
- [ ] **Safari**: Tested (Optional) or labeled as unsupported
### Checklist
- [x] I have manually verified that the feature works as intended.
- [x] I have confirmed that this PR does not break existing functionality.
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`.
- [x] I have added/updated necessary tests and they pass (`bun run test`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
