### PR TITLE
feat(defaultModel): refocus chat input after auto model switch

### DIFF
--- a/src/pages/content/defaultModel/__tests__/modelLocker.test.ts
+++ b/src/pages/content/defaultModel/__tests__/modelLocker.test.ts
@@ -343,6 +343,119 @@ describe('DefaultModelManager (default model locker)', () => {
     expect(proItem.click).toHaveBeenCalledTimes(0);
   });
 
+  it('focuses chat input after auto-switching model', async () => {
+    (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (_keys: unknown, callback: (items: Record<string, unknown>) => void) => {
+        callback({ gvDefaultModel: 'Pro' });
+      },
+    );
+
+    history.replaceState({}, '', '/u/0/app?hl=en');
+
+    const selectorBtn = document.createElement('button');
+    selectorBtn.className = 'input-area-switch-label';
+    selectorBtn.textContent = 'Flash';
+    selectorBtn.click = vi.fn();
+    document.body.appendChild(selectorBtn);
+
+    const menuPanel = document.createElement('div');
+    menuPanel.className = 'mat-mdc-menu-panel';
+    menuPanel.setAttribute('role', 'menu');
+
+    const flashItem = document.createElement('button');
+    flashItem.setAttribute('role', 'menuitemradio');
+    flashItem.innerHTML = `
+      <div class="title-and-description">
+        <div class="mode-title">Flash</div>
+      </div>
+    `;
+    flashItem.click = vi.fn();
+
+    const proItem = document.createElement('button');
+    proItem.setAttribute('role', 'menuitemradio');
+    proItem.innerHTML = `
+      <div class="title-and-description">
+        <div class="mode-title">Pro</div>
+      </div>
+    `;
+    proItem.click = vi.fn();
+
+    menuPanel.appendChild(flashItem);
+    menuPanel.appendChild(proItem);
+    document.body.appendChild(menuPanel);
+
+    const main = document.createElement('main');
+    const richTextarea = document.createElement('rich-textarea');
+    const input = document.createElement('div');
+    input.setAttribute('contenteditable', 'true');
+    input.setAttribute('role', 'textbox');
+    const focusSpy = vi.spyOn(input, 'focus').mockImplementation(() => {});
+    richTextarea.appendChild(input);
+    main.appendChild(richTextarea);
+    document.body.appendChild(main);
+
+    const { default: DefaultModelManager } = await import('../modelLocker');
+    await DefaultModelManager.getInstance().init();
+    destroyManager = () => DefaultModelManager.getInstance().destroy();
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(proItem.click).toHaveBeenCalledTimes(1);
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it('does not focus chat input when target model is already selected', async () => {
+    (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (_keys: unknown, callback: (items: Record<string, unknown>) => void) => {
+        callback({ gvDefaultModel: 'Pro' });
+      },
+    );
+
+    history.replaceState({}, '', '/u/0/app?hl=en');
+
+    const selectorBtn = document.createElement('button');
+    selectorBtn.className = 'input-area-switch-label';
+    selectorBtn.textContent = 'Flash';
+    selectorBtn.click = vi.fn();
+    document.body.appendChild(selectorBtn);
+
+    const menuPanel = document.createElement('div');
+    menuPanel.className = 'mat-mdc-menu-panel';
+    menuPanel.setAttribute('role', 'menu');
+
+    const proItem = document.createElement('button');
+    proItem.setAttribute('role', 'menuitemradio');
+    proItem.setAttribute('aria-checked', 'true');
+    proItem.innerHTML = `
+      <div class="title-and-description">
+        <div class="mode-title">Pro</div>
+      </div>
+    `;
+    proItem.click = vi.fn();
+
+    menuPanel.appendChild(proItem);
+    document.body.appendChild(menuPanel);
+
+    const main = document.createElement('main');
+    const richTextarea = document.createElement('rich-textarea');
+    const input = document.createElement('div');
+    input.setAttribute('contenteditable', 'true');
+    input.setAttribute('role', 'textbox');
+    const focusSpy = vi.spyOn(input, 'focus').mockImplementation(() => {});
+    richTextarea.appendChild(input);
+    main.appendChild(richTextarea);
+    document.body.appendChild(main);
+
+    const { default: DefaultModelManager } = await import('../modelLocker');
+    await DefaultModelManager.getInstance().init();
+    destroyManager = () => DefaultModelManager.getInstance().destroy();
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(proItem.click).toHaveBeenCalledTimes(0);
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+
   it('skips auto-selection when default model is Flash (Gemini default)', async () => {
     // Set default model to Flash (by ID)
     (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(

--- a/src/pages/content/defaultModel/modelLocker.ts
+++ b/src/pages/content/defaultModel/modelLocker.ts
@@ -16,6 +16,17 @@ const FAST_MODEL_IDS = new Set([
 // Known Flash/Fast model name patterns (case-insensitive)
 const FAST_MODEL_NAMES = ['flash', '2.0 flash', 'gemini 2.0 flash', 'fast', '高速', '高速モード'];
 
+const CHAT_INPUT_SELECTORS = [
+  'main rich-textarea [contenteditable="true"]',
+  'rich-textarea [contenteditable="true"]',
+  'main div[contenteditable="true"][role="textbox"]',
+  'div[contenteditable="true"][role="textbox"]',
+  'main .input-area textarea',
+  '.input-area textarea',
+  'main [contenteditable="true"]',
+  'main textarea',
+] as const;
+
 class DefaultModelManager {
   private static instance: DefaultModelManager;
   private observer: MutationObserver | null = null;
@@ -584,6 +595,7 @@ class DefaultModelManager {
 
       const items = menuPanel.querySelectorAll('[role="menuitemradio"]');
       let found = false;
+      let switchedModel = false;
 
       if (targetModel.kind === 'id') {
         const targetItem = Array.from(items).find((item) => {
@@ -598,6 +610,7 @@ class DefaultModelManager {
 
           if (!alreadySelected) {
             targetItem.click();
+            switchedModel = true;
           } else {
             // Already selected, close menu to avoid stuck UI
             document.body.click();
@@ -615,6 +628,7 @@ class DefaultModelManager {
 
             if (!alreadySelected) {
               (item as HTMLElement).click();
+              switchedModel = true;
             } else {
               // Already selected, close menu to avoid stuck UI
               document.body.click();
@@ -636,6 +650,7 @@ class DefaultModelManager {
 
             if (!alreadySelected) {
               (item as HTMLElement).click();
+              switchedModel = true;
             } else {
               // Already selected, close menu to avoid stuck UI
               document.body.click();
@@ -649,6 +664,9 @@ class DefaultModelManager {
       if (found && this.checkTimer) {
         clearInterval(this.checkTimer);
         this.consecutiveFailures = 0;
+      }
+      if (switchedModel) {
+        this.focusChatInputAfterAutoSwitch();
       }
 
       if (!found) {
@@ -669,6 +687,32 @@ class DefaultModelManager {
     } finally {
       this.isLocked = false;
     }
+  }
+
+  private focusChatInputAfterAutoSwitch(): void {
+    const focusDelayMs = 120;
+    window.setTimeout(() => {
+      const input = this.findChatInputElement();
+      if (!input) return;
+
+      try {
+        input.focus({ preventScroll: true });
+      } catch {
+        input.focus();
+      }
+    }, focusDelayMs);
+  }
+
+  private findChatInputElement(): HTMLElement | null {
+    for (const selector of CHAT_INPUT_SELECTORS) {
+      const candidates = document.querySelectorAll<HTMLElement>(selector);
+      for (const candidate of Array.from(candidates)) {
+        if (!candidate.isConnected) continue;
+        if (candidate instanceof HTMLTextAreaElement && candidate.disabled) continue;
+        return candidate;
+      }
+    }
+    return null;
   }
 
   private parseStoredDefaultModel(value: unknown): DefaultModelSetting | null {


### PR DESCRIPTION
### 🚫 AI Policy / AI 政策

- **We explicitly reject AI-generated PRs that have not been manually verified.**
- **本项目拒绝接受任何未经人工复核的 AI 生成的 PR。**
- Low-quality AI PRs will be closed immediately. / 低质量的 AI PR 会被直接关闭。
- You must understand and take responsibility for every line of code you submit. / 你必须理解并对你提交的每一行代码负责。
- **Workflow Proficiency / 协作能力**: Ensure you are familiar with GitHub/Git workflows and maintain a clean Git history. Please learn the basics first if needed to avoid messy PR history. / 请确保你熟悉 GitHub/Git 工作流并保持 Git 历史整洁。如有必要请先学习相关知识，避免 PR 历史过于混乱。

---

### Description / 描述

After the model is automatically selected, wait for a 120ms delay (to avoid conflicts with the selection process) and then refocus on the chat box.
在模型自动选择模型后，延迟 120ms （避免和模型选择起冲突），随后重新聚焦在对话框。

### Related Issue / 相关 Issue

https://github.com/Nagi-ovo/gemini-voyager/issues/370

### Visual Proof / 可视化证据

Refocus Feature Test Video
测试重新聚焦功能的视频
https://github.com/user-attachments/assets/f3410d8f-e681-4db6-8784-4998d59c4327


### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
