### PR TITLE
fix(folder): avoid stale account index in saved URLs

### DIFF
--- a/src/pages/content/folder/__tests__/folderNameInteraction.test.ts
+++ b/src/pages/content/folder/__tests__/folderNameInteraction.test.ts
@@ -13,6 +13,12 @@ type TestableManager = {
   createFolderElement: (folder: Folder, level?: number) => HTMLElement;
   toggleFolder: (folderId: string) => void;
   renameFolder: (folderId: string) => void;
+  // Expose private method via type casting for testing only
+  extractConversationData: (element: HTMLElement) => {
+    url: string;
+    isGem: boolean;
+    gemId?: string;
+  };
 };
 
 function createFolder(): Folder {
@@ -83,5 +89,26 @@ describe('folder name click/double-click interaction', () => {
     expect(toggleSpy).not.toHaveBeenCalled();
     expect(renameSpy).toHaveBeenCalledTimes(1);
     expect(renameSpy).toHaveBeenCalledWith('folder-1');
+  });
+
+  it('builds conversation URL without embedding /u/{num} segment', () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager & {
+      accountIsolationEnabled: boolean;
+    };
+
+    // Enable hard isolation so that URL normalization logic is active
+    typedManager.accountIsolationEnabled = true;
+
+    // Simulate current URL containing /u/1/app?foo=bar (same-origin relative path)
+    window.history.pushState({}, '', '/u/1/app?foo=bar');
+
+    const convEl = document.createElement('div');
+    convEl.setAttribute('jslog', '["c_2b6fe5971f124c03"]');
+
+    const data = typedManager.extractConversationData(convEl);
+
+    expect(data.url).toContain('/app/2b6fe5971f124c03');
+    expect(data.url).not.toContain('/u/1/');
   });
 });

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -1666,30 +1666,37 @@ export class FolderManager {
       return { url: window.location.href, isGem: false };
     }
 
-    const currentPath = window.location.pathname;
-
-    // Preserve user account number (e.g., /u/1/)
-    const userMatch = currentPath.match(/\/u\/(\d+)\//);
-
-    // Build URL with user context preserved
-    let url = window.location.origin;
-    if (userMatch) {
-      url += `/u/${userMatch[1]}`;
-    }
-
-    // Always use /app/{id} URL
-    // Gemini will auto-redirect to /gem/{gem-id}/{id} if it's a Gem conversation
-    // We'll detect and update the gemId after navigation completes
-    url += `/app/${hexId}`;
-
-    // Also preserve URL parameters
+    const origin = window.location.origin;
     const currentUrl = new URL(window.location.href);
     const searchParams = currentUrl.searchParams.toString();
+
+    let url: string;
+
+    if (this.accountIsolationEnabled) {
+      // In hard isolation mode, intentionally do not persist the /u/{num} account index;
+      // only store the path that is intrinsic to the conversation itself.
+      // At navigation time we rebuild the correct /u/{num} segment based on the
+      // current window/account context, so that URLs stay valid even if the
+      // account index changes (e.g. saved with /u/1, later browsing under /u/2).
+      url = `${origin}/app/${hexId}`;
+    } else {
+      // Backward-compatible behavior: preserve the current /u/{num} segment
+      // when hard isolation is disabled, matching legacy URL structure.
+      const currentPath = window.location.pathname;
+      const userMatch = currentPath.match(/\/u\/(\d+)\//);
+
+      if (userMatch) {
+        url = `${origin}/u/${userMatch[1]}/app/${hexId}`;
+      } else {
+        url = `${origin}/app/${hexId}`;
+      }
+    }
+
     if (searchParams) {
       url += `?${searchParams}`;
     }
 
-    this.debug('Built URL:', url);
+    this.debug('Built conversation URL:', url);
     return { url, isGem: false, gemId: undefined };
   }
 
@@ -5476,6 +5483,26 @@ export class FolderManager {
       const pathParts = targetUrl.pathname.split('/');
       const hexId = pathParts[pathParts.length - 1]; // Get the hex ID part
 
+      let effectivePath: string | null = null;
+      let effectiveUrl: string | null = null;
+
+      if (this.accountIsolationEnabled) {
+        // In hard isolation mode, build a navigation URL that matches the
+        // current account context:
+        // - If the current path contains /u/{num}/, reuse that {num}
+        // - Otherwise navigate to /app/{hexId} directly
+        // This prevents us from reusing stale /u/{num} segments from previously
+        // saved URLs when the active account index has changed.
+        const currentPath = window.location.pathname;
+        const currentUserMatch = currentPath.match(/\/u\/(\d+)\//);
+        if (currentUserMatch) {
+          effectivePath = `/u/${currentUserMatch[1]}/app/${hexId}`;
+        } else {
+          effectivePath = `/app/${hexId}`;
+        }
+        effectiveUrl = `${window.location.origin}${effectivePath}${targetUrl.search}`;
+      }
+
       const conversations = document.querySelectorAll('[data-test-id="conversation"]');
       for (const conv of Array.from(conversations)) {
         const jslog = conv.getAttribute('jslog');
@@ -5510,17 +5537,21 @@ export class FolderManager {
       }
 
       // If we can't find the sidebar element, try pushState + popstate
+      const navigationUrl = this.accountIsolationEnabled && effectiveUrl ? effectiveUrl : url;
+      const navigationPath =
+        this.accountIsolationEnabled && effectivePath ? effectivePath : targetUrl.pathname;
+
       this.debug('Sidebar element not found, trying pushState');
-      window.history.pushState({}, '', url);
+      window.history.pushState({}, '', navigationUrl);
       const popStateEvent = new PopStateEvent('popstate', { state: {} });
       window.dispatchEvent(popStateEvent);
       setTimeout(() => this.highlightActiveConversationInFolders(), 0);
 
       // If that doesn't work, fall back to page reload
       setTimeout(() => {
-        if (window.location.pathname !== targetUrl.pathname) {
+        if (window.location.pathname !== navigationPath) {
           this.debug('Falling back to page reload');
-          window.location.href = url;
+          window.location.href = navigationUrl;
         }
       }, 200);
     } catch (error) {


### PR DESCRIPTION
### Description / 描述

<!-- Explain the goal of this PR and what changes were made. -->
<!-- 请解释此 PR 的目标以及做了哪些更改。 -->

在 启用硬隔离（Hard Isolation） 的情况下，保存 URL 的时候去掉 u/{Num}/ 仅保留 Chat 的 HexID，这样可以不用关系多个账号的登录顺序。

### Related Issue / 相关 Issue

#411 

### Visual Proof / 可视化证据

非 UI 修改

### Browser Testing / 浏览器测试

- [ X ] **Chrome / Edge (Chromium)**: Tested / 已测试
- [ X ] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [ X ] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [ X ] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [ X ] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [ X ] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
