### PR TITLE
fix: preserve AI Studio history titles when dragging into folders

### DIFF
--- a/src/pages/content/folder/__tests__/aistudio.test.ts
+++ b/src/pages/content/folder/__tests__/aistudio.test.ts
@@ -134,6 +134,43 @@ describe('AIStudio prompt binding performance guards', () => {
       ]),
     );
   });
+
+  it('uses aria-label/title fallback for drag payload titles when text is missing', () => {
+    const { root, row, anchor } = createPromptRow('abc124', '');
+    anchor.setAttribute('aria-label', 'Native prompt title');
+    anchor.setAttribute('title', 'Backup title');
+
+    const manager = new AIStudioFolderManager();
+    const bindDraggablesInPromptList = (
+      manager as unknown as {
+        bindDraggablesInPromptList: (scope?: ParentNode | null) => void;
+      }
+    ).bindDraggablesInPromptList.bind(manager);
+
+    bindDraggablesInPromptList(root);
+
+    const transfer: DragDataTransferMock = {
+      effectAllowed: '',
+      setData: vi.fn(),
+      setDragImage: vi.fn(),
+    };
+    const dragstart = new Event('dragstart') as DragEvent;
+    Object.defineProperty(dragstart, 'dataTransfer', {
+      value: transfer,
+      configurable: true,
+    });
+
+    row.dispatchEvent(dragstart);
+
+    const jsonPayload = (transfer.setData.mock.calls as Array<[string, string]>).find(
+      ([type]) => type === 'application/json',
+    )?.[1];
+    expect(jsonPayload).toBeTruthy();
+    expect(JSON.parse(jsonPayload || '{}')).toMatchObject({
+      conversationId: 'abc124',
+      title: 'Native prompt title',
+    });
+  });
 });
 
 describe('AIStudio theme compatibility', () => {

--- a/src/pages/content/folder/aistudio.ts
+++ b/src/pages/content/folder/aistudio.ts
@@ -1565,7 +1565,7 @@ export class AIStudioFolderManager {
           if (!promptAnchor) return;
 
           const id = this.extractPromptId(promptAnchor);
-          const title = normalizeText(promptAnchor.textContent || '');
+          const title = this.extractPromptTitle(promptAnchor) || '';
           const rawHref = promptAnchor.getAttribute('href') || promptAnchor.href || '';
           const url = rawHref.startsWith('http')
             ? rawHref
@@ -1647,7 +1647,7 @@ export class AIStudioFolderManager {
         e.stopPropagation();
 
         const id = this.extractPromptId(anchor);
-        const title = normalizeText(anchor.textContent || '');
+        const title = this.extractPromptTitle(anchor) || '';
         // Ensure accurate URL construction
         const rawHref = anchor.getAttribute('href') || anchor.href || '';
         const url = rawHref.startsWith('http')


### PR DESCRIPTION
## Summary
- use AI Studio's native title extraction helper when building drag payloads from history/library rows
- preserve aria-label/title-based prompt names instead of falling back to an empty string and "Untitled"
- add a regression test covering prompt rows whose visible text is missing during drag

## Validation
- `git diff --check`

Closes #317.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
