### PR TITLE
fix(prompt): suppress click after dragging trigger

### DIFF
--- a/src/pages/content/prompt/index.ts
+++ b/src/pages/content/prompt/index.ts
@@ -1072,6 +1072,12 @@ export async function startPromptManager(): Promise<{ destroy: () => void }> {
 
     // Events
     trigger.addEventListener('click', async () => {
+      // Suppress click after a drag gesture
+      if (triggerWasDragged) {
+        triggerWasDragged = false;
+        return;
+      }
+
       // When changelog badge is active, open changelog modal instead of prompt manager
       if (changelogBadgeActive) {
         changelogBadgeActive = false;
@@ -1153,9 +1159,11 @@ export async function startPromptManager(): Promise<{ destroy: () => void }> {
 
     // Trigger drag (always draggable)
     let triggerDragStartPos: { x: number; y: number } | null = null;
+    let triggerWasDragged = false;
     trigger.addEventListener('pointerdown', (ev: PointerEvent) => {
       if (typeof ev.button === 'number' && ev.button !== 0) return;
       draggingTrigger = true;
+      triggerWasDragged = false;
       triggerDragStartPos = { x: ev.clientX, y: ev.clientY };
       try {
         trigger.setPointerCapture?.(ev.pointerId);
@@ -1170,6 +1178,7 @@ export async function startPromptManager(): Promise<{ destroy: () => void }> {
           const dx = Math.abs(ev.clientX - triggerDragStartPos.x);
           const dy = Math.abs(ev.clientY - triggerDragStartPos.y);
           if (dx > 5 || dy > 5) {
+            triggerWasDragged = true;
             const r = parseFloat((trigger.style.right || '').replace('px', '')) || 18;
             const b = parseFloat((trigger.style.bottom || '').replace('px', '')) || 18;
             await writeStorage(STORAGE_KEYS.triggerPos, { right: r, bottom: b });


### PR DESCRIPTION
## Summary
- 修复拖动提示词管理器悬浮球松手后误触发点击打开面板的问题
- 新增 `triggerWasDragged` 标志位，拖拽超过 5px 阈值时置为 true，在 click handler 中检测并跳过 toggle

## Test plan
- [ ] 拖动悬浮球到新位置，松手后面板不应弹出
- [ ] 单击悬浮球仍能正常打开/关闭面板
- [ ] changelog badge 激活时点击仍能正常打开 changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
