### PR TITLE
fix(sidebarAutoHide): add missing storage default for full-hide toggle

### DIFF
--- a/src/pages/content/sidebarAutoHide/index.ts
+++ b/src/pages/content/sidebarAutoHide/index.ts
@@ -425,8 +425,12 @@ function checkAndReattach(): void {
   }
 
   // Full-hide: sync edge trigger visibility with sidebar state
+  // Check height > 0 to exclude responsive layouts where Gemini hides the sidebar entirely
+  // (our full-hide CSS only zeroes width, not height)
   if (fullHideEnabled && edgeTriggerElement) {
-    if (isSidebarCollapsed()) {
+    const sidenav = getSidenavElement();
+    const sidenavExists = sidenav && sidenav.getBoundingClientRect().height > 0;
+    if (sidenavExists && isSidebarCollapsed()) {
       showEdgeTrigger();
     } else {
       hideEdgeTrigger();

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -741,6 +741,7 @@ export default function Popup() {
           gvQuoteReplyEnabled: true,
           gvCtrlEnterSend: false,
           gvSidebarAutoHide: false,
+          gvSidebarFullHide: false,
           gvSnowEffect: false,
           gvPreventAutoScrollEnabled: false,
           [StorageKeys.FORK_ENABLED]: false,


### PR DESCRIPTION
## Summary
Follow-up fix for #485 — the last fix commit was pushed after squash-merge.

- Add `gvSidebarFullHide: false` to popup's `chrome.storage.sync.get` defaults so the toggle correctly reflects stored state
- Gate edge trigger on sidebar `height > 0` to exclude responsive layouts where Gemini hides the sidebar entirely

## Test plan
- [x] TypeScript typecheck passes
- [x] Tests pass
- [ ] Manual: enable full-hide → close popup → reopen → toggle should show ON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
