### PR TITLE
feat(folder): add folder color indicator to native conversation list

### DIFF
--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -6666,3 +6666,18 @@ body.gv-rtl .timeline-preview-index {
   text-align: right;
   justify-content: flex-end;
 }
+
+/* Folder color indicator for native conversation list */
+.gv-folder-indicator {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-right: 8px;
+}
+
+.gv-folder-indicator.gv-folder-indicator-multi {
+  background: linear-gradient(135deg, #3b82f6 0%, #8b5cf6 50%, #ec4899 100%);
+}
+

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -1267,6 +1267,9 @@ export class FolderManager {
       } else {
         (conv as HTMLElement).classList.remove('gv-conversation-archived');
       }
+
+      // Apply folder color indicator
+      this.applyFolderIndicatorToConversation(conv as HTMLElement);
     });
   }
 
@@ -1781,6 +1784,7 @@ export class FolderManager {
             if (node.matches('[data-test-id="conversation"]')) {
               this.makeConversationDraggable(node);
               this.applyHideArchivedToConversation(node);
+              this.applyFolderIndicatorToConversation(node);
               // Cancel pending removal for this conversation (it's back!)
               this.cancelPendingRemovalForElement(node);
             }
@@ -1791,6 +1795,8 @@ export class FolderManager {
               this.makeConversationDraggable(convElement);
               // Apply hide archived setting to newly added conversations
               this.applyHideArchivedToConversation(convElement);
+              // Apply folder indicator to newly added conversations
+              this.applyFolderIndicatorToConversation(convElement);
               // Cancel pending removal for this conversation (it's back!)
               this.cancelPendingRemovalForElement(convElement);
             });
@@ -5083,6 +5089,9 @@ export class FolderManager {
     // Update active highlight after re-render
     this.highlightActiveConversationInFolders();
 
+    // Update folder color indicators in native conversation list
+    this.updateAllFolderIndicators();
+
     // Flush any pending title updates collected during rendering
     if (this.pendingTitleUpdates.size > 0) {
       this.debug(`Flushing ${this.pendingTitleUpdates.size} pending title updates`);
@@ -5860,6 +5869,99 @@ export class FolderManager {
       }
     }
     return false;
+  }
+
+  /**
+   * Get all folders that contain a specific conversation
+   * @returns Array of folder objects with id, name, and color
+   */
+  private getFoldersForConversation(conversationId: string): Array<{ id: string; name: string; color: string }> {
+    const result: Array<{ id: string; name: string; color: string }> = [];
+    const dark = isDarkMode();
+
+    for (const folderId in this.data.folderContents) {
+      if (folderId === ROOT_CONVERSATIONS_ID) continue;
+
+      const conversations = this.data.folderContents[folderId];
+      const hasConversation = conversations.some((c) => {
+        if (c.conversationId === conversationId) return true;
+        const cleanId = conversationId.replace(/^c_/, '');
+        const cleanStoredId = c.conversationId.replace(/^c_/, '');
+        if (cleanId && cleanId === cleanStoredId) return true;
+        if (cleanId && cleanId.length > 8 && c.url.includes(cleanId)) return true;
+        return false;
+      });
+
+      if (hasConversation) {
+        const folder = this.data.folders.find((f) => f.id === folderId);
+        if (folder) {
+          result.push({
+            id: folder.id,
+            name: folder.name,
+            color: getFolderColor(folder.color, dark),
+          });
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Apply folder color indicator to a native conversation element
+   */
+  private applyFolderIndicatorToConversation(conv: HTMLElement): void {
+    const convId = this.extractConversationId(conv);
+    const folders = this.getFoldersForConversation(convId);
+
+    // Find or create indicator element
+    let indicator = conv.querySelector('.gv-folder-indicator') as HTMLElement | null;
+
+    if (folders.length === 0) {
+      // No folders - remove indicator if exists
+      if (indicator) {
+        indicator.remove();
+      }
+      return;
+    }
+
+    // Create indicator if doesn't exist
+    if (!indicator) {
+      indicator = document.createElement('span');
+      indicator.className = 'gv-folder-indicator';
+
+      // Insert before the title/link
+      const titleElement = conv.querySelector('.conversation-title, a') as HTMLElement | null;
+      if (titleElement && titleElement.parentElement) {
+        titleElement.parentElement.insertBefore(indicator, titleElement);
+      } else {
+        conv.insertBefore(indicator, conv.firstChild);
+      }
+    }
+
+    // Update indicator based on number of folders
+    if (folders.length === 1) {
+      indicator.classList.remove('gv-folder-indicator-multi');
+      indicator.style.backgroundColor = folders[0].color;
+      indicator.title = folders[0].name;
+    } else {
+      // Multiple folders - use gradient
+      indicator.classList.add('gv-folder-indicator-multi');
+      indicator.style.backgroundColor = '';
+      indicator.title = folders.map((f) => f.name).join(', ');
+    }
+  }
+
+  /**
+   * Update all folder indicators in the native conversation list
+   */
+  private updateAllFolderIndicators(): void {
+    if (!this.recentSection) return;
+
+    const conversations = this.recentSection.querySelectorAll('[data-test-id="conversation"]');
+    conversations.forEach((conv) => {
+      this.applyFolderIndicatorToConversation(conv as HTMLElement);
+    });
   }
 
   private generateId(): string {


### PR DESCRIPTION
Add a small colored dot before conversation titles to indicate which folder they belong to. Supports single folder (solid color) and multiple folders (gradient).

### 🚫 AI Policy / AI 政策

- **We explicitly reject AI-generated PRs that have not been manually verified.**
- **本项目拒绝接受任何未经人工复核的 AI 生成的 PR。**
- Low-quality AI PRs will be closed immediately. / 低质量的 AI PR 会被直接关闭。
- You must understand and take responsibility for every line of code you submit. / 你必须理解并对你提交的每一行代码负责。
- **Workflow Proficiency / 协作能力**: Ensure you are familiar with GitHub/Git workflows and maintain a clean Git history. Please learn the basics first if needed to avoid messy PR history. / 请确保你熟悉 GitHub/Git 工作流并保持 Git 历史整洁。如有必要请先学习相关知识，避免 PR 历史过于混乱。

---

### Description / 描述

<!-- Explain the goal of this PR and what changes were made. -->
<!-- 请解释此 PR 的目标以及做了哪些更改。 -->

### Related Issue / 相关 Issue

<!-- Link the issue this PR resolves (e.g., Closes #123). FOR NEW FEATURES: You MUST open an Issue for discussion first. PRs submitted without prior discussion will be closed. -->
<!-- 链接此 PR 解决的 issue（例如：Closes #123）。对于新功能：请务必先开启一个 Issue 进行讨论，未经讨论直接提交的 PR 会被关闭。 -->

### Visual Proof / 可视化证据

<!-- REQUIRED for UI changes: Please provide screenshots or screen recordings. -->
<!-- UI 修改必填：请提供截图或屏幕录制。 -->

### Browser Testing / 浏览器测试

- [ ] **Chrome / Edge (Chromium)**: Tested / 已测试
- [ ] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [ ] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [ ] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [ ] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [ ] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
