### PR TITLE
feat(formulaCopy): add Notion-compatible formula copy format

### DIFF
--- a/src/features/formulaCopy/FormulaCopyService.test.ts
+++ b/src/features/formulaCopy/FormulaCopyService.test.ts
@@ -415,4 +415,37 @@ describe('FormulaCopyService', () => {
 
     document.body.removeChild(msKatex);
   });
+
+  it('should wrap both inline and display formulas with double dollar signs in notion format', async () => {
+    const clipboard = navigator.clipboard as unknown as { write?: unknown };
+    clipboard.write = undefined;
+
+    resetSingleton();
+    service = FormulaCopyService.getInstance({ format: 'notion' });
+
+    const inlineMath = document.createElement('span');
+    inlineMath.setAttribute('data-math', 'x^2');
+    inlineMath.classList.add('math-inline');
+
+    const displayMath = document.createElement('span');
+    displayMath.setAttribute('data-math', 'E = mc^2');
+    displayMath.classList.add('math-block');
+
+    document.body.appendChild(inlineMath);
+    document.body.appendChild(displayMath);
+
+    service.initialize();
+
+    inlineMath.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+
+    displayMath.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+
+    expect(writeTextMock).toHaveBeenNthCalledWith(1, '$$x^2$$');
+    expect(writeTextMock).toHaveBeenNthCalledWith(2, '$$E = mc^2$$');
+
+    document.body.removeChild(inlineMath);
+    document.body.removeChild(displayMath);
+  });
 });

--- a/src/features/formulaCopy/FormulaCopyService.ts
+++ b/src/features/formulaCopy/FormulaCopyService.ts
@@ -13,7 +13,7 @@ import type { ILogger } from '@/core/types/common';
 /**
  * Formula copy format options
  */
-export type FormulaCopyFormat = 'latex' | 'unicodemath' | 'no-dollar';
+export type FormulaCopyFormat = 'latex' | 'unicodemath' | 'no-dollar' | 'notion';
 
 /**
  * Configuration for the formula copy service
@@ -42,7 +42,12 @@ export class FormulaCopyService {
   >[0] = (changes, areaName) => {
     if (areaName === 'sync' && changes[StorageKeys.FORMULA_COPY_FORMAT]) {
       const newFormat = changes[StorageKeys.FORMULA_COPY_FORMAT].newValue as FormulaCopyFormat;
-      if (newFormat === 'latex' || newFormat === 'unicodemath' || newFormat === 'no-dollar') {
+      if (
+        newFormat === 'latex' ||
+        newFormat === 'unicodemath' ||
+        newFormat === 'no-dollar' ||
+        newFormat === 'notion'
+      ) {
         this.currentFormat = newFormat;
         this.logger.debug('Formula format changed', { format: newFormat });
       }
@@ -100,7 +105,12 @@ export class FormulaCopyService {
     try {
       const result = await browser.storage.sync.get(StorageKeys.FORMULA_COPY_FORMAT);
       const format = result[StorageKeys.FORMULA_COPY_FORMAT] as FormulaCopyFormat | undefined;
-      if (format === 'latex' || format === 'unicodemath' || format === 'no-dollar') {
+      if (
+        format === 'latex' ||
+        format === 'unicodemath' ||
+        format === 'no-dollar' ||
+        format === 'notion'
+      ) {
         this.currentFormat = format;
         this.logger.debug('Loaded formula format preference', { format });
       }
@@ -434,6 +444,12 @@ export class FormulaCopyService {
 
     if (this.currentFormat === 'no-dollar') {
       return { text: formula };
+    }
+
+    if (this.currentFormat === 'notion') {
+      // Notion format: always use $$ for both inline and display formulas
+      const wrapped = `$$${formula}$$`;
+      return { text: wrapped };
     }
 
     // Default: LaTeX format with delimiters

--- a/src/locales/ar/messages.json
+++ b/src/locales/ar/messages.json
@@ -399,6 +399,10 @@
     "message": "LaTeX (بدون علامة الدولار)",
     "description": "LaTeX format option without dollar signs"
   },
+  "formulaCopyFormatNotion": {
+    "message": "Notion ($$ تنسيق)",
+    "description": "Notion-compatible format with $$ delimiters"
+  },
   "folder_filter_current_user": {
     "message": "عزل الحساب",
     "description": "Show only conversations from the current Google account"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -399,6 +399,10 @@
     "message": "LaTeX (No Dollar Sign)",
     "description": "LaTeX format option without dollar signs"
   },
+  "formulaCopyFormatNotion": {
+    "message": "Notion ($$ format)",
+    "description": "Notion-compatible format with $$ delimiters"
+  },
   "folder_filter_current_user": {
     "message": "Account Isolation",
     "description": "Show only conversations from the current Google account"

--- a/src/locales/es/messages.json
+++ b/src/locales/es/messages.json
@@ -399,6 +399,10 @@
     "message": "LaTeX (Sin signo de dólar)",
     "description": "LaTeX format option without dollar signs"
   },
+  "formulaCopyFormatNotion": {
+    "message": "Notion ($$ Formato)",
+    "description": "Notion-compatible format with $$ delimiters"
+  },
   "folder_filter_current_user": {
     "message": "Aislamiento de cuenta",
     "description": "Show only conversations from the current Google account"

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -399,6 +399,10 @@
     "message": "LaTeX (Sans dollars)",
     "description": "LaTeX format option without dollar signs"
   },
+  "formulaCopyFormatNotion": {
+    "message": "Notion ($$ Format)",
+    "description": "Notion-compatible format with $$ delimiters"
+  },
   "folder_filter_current_user": {
     "message": "Isolation de compte",
     "description": "Show only conversations from the current Google account"

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -399,6 +399,10 @@
     "message": "LaTeX (ドル記号なし)",
     "description": "LaTeX format option without dollar signs"
   },
+  "formulaCopyFormatNotion": {
+    "message": "Notion ($$ 形式)",
+    "description": "Notion-compatible format with $$ delimiters"
+  },
   "folder_filter_current_user": {
     "message": "アカウント隔離",
     "description": "Show only conversations from the current Google account"

--- a/src/locales/ko/messages.json
+++ b/src/locales/ko/messages.json
@@ -399,6 +399,10 @@
     "message": "LaTeX (달러 기호 없음)",
     "description": "LaTeX format option without dollar signs"
   },
+  "formulaCopyFormatNotion": {
+    "message": "Notion ($$ 포맷)",
+    "description": "Notion-compatible format with $$ delimiters"
+  },
   "folder_filter_current_user": {
     "message": "계정 분리",
     "description": "Show only conversations from the current Google account"

--- a/src/locales/pt/messages.json
+++ b/src/locales/pt/messages.json
@@ -399,6 +399,10 @@
     "message": "LaTeX (Sem cifrão)",
     "description": "LaTeX format option without dollar signs"
   },
+  "formulaCopyFormatNotion": {
+    "message": "Notion ($$ Formato)",
+    "description": "Notion-compatible format with $$ delimiters"
+  },
   "folder_filter_current_user": {
     "message": "Isolamento de conta",
     "description": "Show only conversations from the current Google account"

--- a/src/locales/ru/messages.json
+++ b/src/locales/ru/messages.json
@@ -399,6 +399,10 @@
     "message": "LaTeX (без знака доллара)",
     "description": "LaTeX format option without dollar signs"
   },
+  "formulaCopyFormatNotion": {
+    "message": "Notion ($$ Формат)",
+    "description": "Notion-compatible format with $$ delimiters"
+  },
   "folder_filter_current_user": {
     "message": "Изоляция аккаунтов",
     "description": "Show only conversations from the current Google account"

--- a/src/locales/zh/messages.json
+++ b/src/locales/zh/messages.json
@@ -399,6 +399,10 @@
     "message": "LaTeX (纯文本，无 $ 符号)",
     "description": "LaTeX 格式选项，无美元符号"
   },
+  "formulaCopyFormatNotion": {
+    "message": "Notion (双$格式)",
+    "description": "Notion 兼容格式，使用 $$ 分隔符"
+  },
   "folder_filter_current_user": {
     "message": "账号隔离模式",
     "description": "Show only conversations from the current Google account"

--- a/src/locales/zh_TW/messages.json
+++ b/src/locales/zh_TW/messages.json
@@ -359,6 +359,10 @@
     "message": "LaTeX (純文字，無 $ 符號)",
     "description": "LaTeX 格式選項，無美元符號"
   },
+  "formulaCopyFormatNotion": {
+    "message": "Notion (雙$格式)",
+    "description": "Notion 相容格式，使用 $$ 分隔符"
+  },
   "folder_filter_current_user": {
     "message": "帳號隔離模式",
     "description": "Show only conversations from the current Google account"

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -413,9 +413,9 @@ export default function Popup() {
   const [newWebsiteInput, setNewWebsiteInput] = useState<string>('');
   const [websiteError, setWebsiteError] = useState<string>('');
   const [showStarredHistory, setShowStarredHistory] = useState<boolean>(false);
-  const [formulaCopyFormat, setFormulaCopyFormat] = useState<'latex' | 'unicodemath' | 'no-dollar'>(
-    'latex',
-  );
+  const [formulaCopyFormat, setFormulaCopyFormat] = useState<
+    'latex' | 'unicodemath' | 'no-dollar' | 'notion'
+  >('latex');
   const [extVersion, setExtVersion] = useState<string | null>(null);
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [safariDmgUrl, setSafariDmgUrl] = useState<string | null>(null);
@@ -461,7 +461,7 @@ export default function Popup() {
   }, []);
 
   const handleFormulaCopyFormatChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const format = e.target.value as 'latex' | 'unicodemath' | 'no-dollar';
+    const format = e.target.value as 'latex' | 'unicodemath' | 'no-dollar' | 'notion';
     setFormulaCopyFormat(format);
     try {
       chrome.storage?.sync?.set({ gvFormulaCopyFormat: format });
@@ -858,8 +858,17 @@ export default function Popup() {
         (res) => {
           const m = res?.geminiTimelineScrollMode as ScrollMode;
           if (m === 'jump' || m === 'flow') setMode(m);
-          const format = res?.gvFormulaCopyFormat as 'latex' | 'unicodemath' | 'no-dollar';
-          if (format === 'latex' || format === 'unicodemath' || format === 'no-dollar')
+          const format = res?.gvFormulaCopyFormat as
+            | 'latex'
+            | 'unicodemath'
+            | 'no-dollar'
+            | 'notion';
+          if (
+            format === 'latex' ||
+            format === 'unicodemath' ||
+            format === 'no-dollar' ||
+            format === 'notion'
+          )
             setFormulaCopyFormat(format);
           setHideContainer(!!res?.geminiTimelineHideContainer);
           setDraggableTimeline(!!res?.geminiTimelineDraggable);
@@ -1973,6 +1982,17 @@ export default function Popup() {
                     className="h-4 w-4"
                   />
                   <span className="text-sm">{t('formulaCopyFormatNoDollar')}</span>
+                </label>
+                <label className="flex cursor-pointer items-center space-x-3">
+                  <input
+                    type="radio"
+                    name="formulaCopyFormat"
+                    value="notion"
+                    checked={formulaCopyFormat === 'notion'}
+                    onChange={handleFormulaCopyFormatChange}
+                    className="h-4 w-4"
+                  />
+                  <span className="text-sm">{t('formulaCopyFormatNotion')}</span>
                 </label>
               </div>
             </CardContent>


### PR DESCRIPTION
### 🚫 AI Policy / AI 政策

- **We explicitly reject AI-generated PRs that have not been manually verified.**
- **本项目拒绝接受任何未经人工复核的 AI 生成的 PR。**
- Low-quality AI PRs will be closed immediately. / 低质量的 AI PR 会被直接关闭。
- You must understand and take responsibility for every line of code you submit. / 你必须理解并对你提交的每一行代码负责。
- **Workflow Proficiency / 协作能力**: Ensure you are familiar with GitHub/Git workflows and maintain a clean Git history. Please learn the basics first if needed to avoid messy PR history. / 请确保你熟悉 GitHub/Git 工作流并保持 Git 历史整洁。如有必要请先学习相关知识，避免 PR 历史过于混乱。

---

### Description / 描述

<!-- Explain the goal of this PR and what changes were made. -->
<!-- 请解释此 PR 的目标以及做了哪些更改。 -->

This PR adds a Notion-compatible formula copy format to Voyager.

Changes included:
- add a new `Notion` option in popup settings for formula copy format
- support copying formulas in a Notion-friendly wrapped format
- keep existing `LaTeX`, `UnicodeMath`, and `no-dollar` options intact
- update related i18n labels
- add regression coverage for formula copy behavior

User impact:
- users can choose a dedicated copy format when pasting formulas into Notion
- existing formula copy behavior remains available for other workflows

---

本次PR为Voyager新增了兼容Notion的公式复制格式。

包含的变更：
- 在弹窗设置中新增“Notion”选项作为公式复制格式
- 支持以Notion的格式复制公式
- 保留原有的“LaTeX”、“UnicodeMath”及“无美元符号”选项不变
- 更新相关 i18n 标签
- 为公式复制行为添加测试

用户影响：
- 用户向Notion粘贴公式时，可选择专用复制格式
- 现有公式复制功能仍适用于其他工作流程


### Related Issue / 相关 Issue

<!-- Link the issue this PR resolves (e.g., Closes #123). FOR NEW FEATURES: You MUST open an Issue for discussion first. PRs submitted without prior discussion will be closed. -->
<!-- 链接此 PR 解决的 issue（例如：Closes #123）。对于新功能：请务必先开启一个 Issue 进行讨论，未经讨论直接提交的 PR 会被关闭。 -->

https://github.com/Nagi-ovo/gemini-voyager/issues/515

### Visual Proof / 可视化证据

<!-- REQUIRED for UI changes: Please provide screenshots or screen recordings. -->
<!-- UI 修改必填：请提供截图或屏幕录制。 -->

<img width="270" height="461" alt="_1" src="https://github.com/user-attachments/assets/836adead-dcaa-4018-98fb-13a083006de4" />

---

<img width="970" height="366" alt="_2" src="https://github.com/user-attachments/assets/da13b12f-0db3-4e4b-8f40-43fae8a2c0f2" />


### Browser Testing / 浏览器测试

- [✅] **Chrome / Edge (Chromium)**: Tested / 已测试
- [✅] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [✅] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [✅] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [✅] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [✅] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
