### PR TITLE
fix(hide-input): resolve focus interference and optimize selector performance

### DIFF
--- a/src/pages/content/inputCollapse/__tests__/inputCollapse.test.ts
+++ b/src/pages/content/inputCollapse/__tests__/inputCollapse.test.ts
@@ -249,7 +249,7 @@ describe('inputCollapse', () => {
       const focusOutEvent = new Event('focusout', { bubbles: true });
       Object.defineProperty(focusOutEvent, 'relatedTarget', { value: null, writable: false });
       container.dispatchEvent(focusOutEvent);
-      vi.advanceTimersByTime(200);
+      vi.advanceTimersByTime(250);
       expect(container.classList.contains('gv-input-collapsed')).toBe(true);
 
       // Simulate setting change to disabled
@@ -260,7 +260,7 @@ describe('inputCollapse', () => {
 
         container.classList.remove('gv-input-collapsed');
         container.dispatchEvent(focusOutEvent);
-        vi.advanceTimersByTime(200);
+        vi.advanceTimersByTime(250);
         // Should not collapse when disabled
         expect(container.classList.contains('gv-input-collapsed')).toBe(false);
       }

--- a/src/pages/content/inputCollapse/index.ts
+++ b/src/pages/content/inputCollapse/index.ts
@@ -507,20 +507,23 @@ function initInputCollapse(allowCollapseNotEmpty: boolean = false) {
           // This allows focusin events to cancel the collapse if focus returns
           collapseTimer = window.setTimeout(() => {
             // Double-check: focus should truly be away from input-related elements
-            const active = document.activeElement;
+            const active = document.activeElement as HTMLElement;
             if (active && currentContainer.contains(active)) {
               return; // Focus came back, don't collapse
             }
 
             // Also check if the new focus is in an input-related overlay/menu
-            if (newFocus && isInputRelatedElement(newFocus, currentContainer)) {
+            if (
+              (newFocus && isInputRelatedElement(newFocus, currentContainer)) ||
+              (active && isInputRelatedElement(active, currentContainer))
+            ) {
               return; // Focus moved to input-related UI, don't collapse
             }
 
             // Now safe to collapse
             tryCollapse(currentContainer);
             collapseTimer = null;
-          }, 50); // 50ms delay - enough for focusin to cancel if needed
+          }, 100); // 100ms delay - enough for focusin to cancel if needed
         },
         { signal },
       );
@@ -614,11 +617,10 @@ function isInputRelatedElement(element: HTMLElement, container: HTMLElement): bo
     '[data-test-id*="file"]',
   ];
 
-  // Check if element matches any of the selectors
-  for (const selector of INPUT_RELATED_SELECTORS) {
-    if (element.matches(selector) || element.closest(selector)) {
-      return true;
-    }
+  // Combine selectors into a single string for better performance
+  const combinedSelector = INPUT_RELATED_SELECTORS.join(', ');
+  if (element.matches(combinedSelector) || element.closest(combinedSelector)) {
+    return true;
   }
 
   // Additional heuristic: check if element is within a reasonable proximity


### PR DESCRIPTION
- Added active element check to prevent unexpected collapse when focus moves to `attachment uploader menu`.
- Increased collapse delay from 50ms to 100ms for better focus transition handling in Safari.
- Combined query selectors in `isInputRelatedElement` for improved matching performance.
- Updated related unit tests to reflect the new timing and logic.

---

### Description / 描述

This PR addresses an issue where the input box would unexpectedly collapse, when the user interacts with `attachment uploader` (Chrome/Firefox) and all input-related UI elements(Safari).

**Changes:**
1. Added `active` element with `newFocus` to  ensure the input not collapse if the focus has moved to a valid input-related UI element (uploader).
2. Increased the `collapseTimer` delay from 50ms to 100ms. In Safari, 50ms is too short for the `focusin` event to clear the collapse timer effectively.
3. Optimized the `isInputRelatedElement` function by combining DOM selectors, which improves matching performance.
4. Updated `inputCollapse.test.ts` to account for the new timing and logic.

### Related Issue / 相关 Issue

https://github.com/Nagi-ovo/gemini-voyager/issues/525

### Visual Proof / 可视化证据
The first clip reproduces the bug, while the second clip shows the version after the fix. Video recorded in Safari, all three buttons are fixed. For Chrome/Firefox, the same behaviour.

https://github.com/user-attachments/assets/c34995d7-fa98-4861-beb8-173c99b3d1f2

### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested 
- [x] **Firefox**: Tested (Mandatory)
- [x] **Safari**: Tested and fixed the same bug on other two buttons

### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
