### PR TITLE
fix: handle permissions request for Firefox browser

### DIFF
--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -12,9 +12,9 @@ import { googleDriveSyncService } from '@/core/services/GoogleDriveSyncService';
 import { StorageKeys } from '@/core/types/common';
 import type { FolderData } from '@/core/types/folder';
 import type { PromptItem, SyncAccountScope, SyncMode } from '@/core/types/sync';
+import { isFirefox } from '@/core/utils/browser';
 import type { ForkNode, ForkNodesData } from '@/pages/content/fork/forkTypes';
 import type { StarredMessage, StarredMessagesData } from '@/pages/content/timeline/starredTypes';
-import { isFirefox } from '@/core/utils/browser';
 
 const CUSTOM_CONTENT_SCRIPT_ID = 'gv-custom-content-script';
 const CUSTOM_WEBSITE_KEY = 'gvPromptCustomWebsites';
@@ -291,7 +291,7 @@ async function syncCustomContentScripts(domains?: string[]): Promise<void> {
 
   const jsResources = isFirefox()
     ? (manifestContentScript.js || []).map(toRelativeExtensionPath)
-    : (manifestContentScript.js || []);
+    : manifestContentScript.js || [];
   const cssResources = isFirefox()
     ? manifestContentScript.css?.map(toRelativeExtensionPath)
     : manifestContentScript.css;

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -9,7 +9,12 @@ import {
 } from '@/core/services/AccountIsolationService';
 import { StorageKeys } from '@/core/types/common';
 import type { ConversationReference, Folder } from '@/core/types/folder';
-import { getModifierKey, isSafari, isFirefox, shouldShowSafariUpdateReminder } from '@/core/utils/browser';
+import {
+  getModifierKey,
+  isFirefox,
+  isSafari,
+  shouldShowSafariUpdateReminder,
+} from '@/core/utils/browser';
 import { shouldShowUpdateReminderForCurrentVersion } from '@/core/utils/updateReminder';
 import { compareVersions } from '@/core/utils/version';
 import {


### PR DESCRIPTION
### 🚫 AI Policy / AI 政策

- **We explicitly reject AI-generated PRs that have not been manually verified.**
- **本项目拒绝接受任何未经人工复核的 AI 生成的 PR。**
- Low-quality AI PRs will be closed immediately. / 低质量的 AI PR 会被直接关闭。
- You must understand and take responsibility for every line of code you submit. / 你必须理解并对你提交的每一行代码负责。
- **Workflow Proficiency / 协作能力**: Ensure you are familiar with GitHub/Git workflows and maintain a clean Git history. Please learn the basics first if needed to avoid messy PR history. / 请确保你熟悉 GitHub/Git 工作流并保持 Git 历史整洁。如有必要请先学习相关知识，避免 PR 历史过于混乱。

---

### Description / 描述

<!-- Explain the goal of this PR and what changes were made. -->
<!-- 请解释此 PR 的目标以及做了哪些更改。 -->

目标：修复在**Firefox**浏览器中，「提示词管理器」的「自定义网站」功能不生效，当点击尝试添加自定义网站时，提示：`请求权限失败，请重试或在扩展设置中手动授权。`

修复方式：
- 定位到控制台输出了 `[Gemini Voyager] Failed to request permissions for custom website: Error: permissions.request may only be called from a user input handler`。究其原因，这是 Firefox 要求 `permissions.request` 必须在“用户手势链路”里触发，而当前代码在调用它之前有异步 await，会丢失用户手势。
- 我在 `src/pages/popup/Popup.tsx` 添加了 Firefox 特定的逻辑，避免 `await setSyncStorage` 和 `await browser.permissions.contains` 可能打断用户手势的问题。
- 在修复完此问题后，脚本仍然不能正确注入到自定义网站，控制台报错 `[Background] Failed to register custom content scripts: Error: Type error for parameter scripts (Error processing 0.css.0: SyntaxError: String "moz-extension://1f97eb43-f38f-4047-a5cd-543249bfbb25/contentStyle.css" must be a relative URL) for scripting.registerContentScripts.`，这是因为Firefox 在 registerContentScripts 里拒绝了绝对路径 moz-extension://... CSS URL，要求的是相对路径，我在 `src/pages/background/index.ts` 中添加了 Firefox 特定的逻辑，将其转换为相对路径。

### Related Issue / 相关 Issue

<!-- Link the issue this PR resolves (e.g., Closes #123). FOR NEW FEATURES: You MUST open an Issue for discussion first. PRs submitted without prior discussion will be closed. -->
<!-- 链接此 PR 解决的 issue（例如：Closes #123）。对于新功能：请务必先开启一个 Issue 进行讨论，未经讨论直接提交的 PR 会被关闭。 -->

Closes #566 

### Visual Proof / 可视化证据

<!-- REQUIRED for UI changes: Please provide screenshots or screen recordings. -->
<!-- UI 修改必填：请提供截图或屏幕录制。 -->

<img width="567" height="633" alt="图片" src="https://github.com/user-attachments/assets/3cb263f5-9f97-4054-82a6-848030203e6f" />
<img width="865" height="859" alt="图片" src="https://github.com/user-attachments/assets/036f879e-b8f9-46cc-abb0-ea1cac31c438" />
<img width="865" height="310" alt="图片" src="https://github.com/user-attachments/assets/84d3f0d2-6c61-48bf-a0ea-2a9a375be25f" />


### Browser Testing / 浏览器测试

- [ ] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [ ] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
