### PR TITLE
feat(export): add width selection for image export

### DIFF
--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -6371,6 +6371,88 @@ body[data-color-scheme='dark'] .gv-export-fontsize-preview {
   color: #e8eaed;
 }
 
+/* Image Width Section */
+.gv-export-imagewidth-section {
+  margin-top: 16px;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.02);
+  border-radius: 8px;
+}
+
+html.dark .gv-export-imagewidth-section,
+[data-theme='dark'] .gv-export-imagewidth-section,
+[data-color-scheme='dark'] .gv-export-imagewidth-section,
+html.dark-theme .gv-export-imagewidth-section,
+body.dark-theme .gv-export-imagewidth-section,
+body[data-theme='dark'] .gv-export-imagewidth-section,
+body[data-color-scheme='dark'] .gv-export-imagewidth-section {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.gv-export-width-group {
+  display: flex;
+  gap: 8px;
+}
+
+.gv-export-width-btn {
+  flex: 1;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  background: transparent;
+  color: #4b5563;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.gv-export-width-btn:hover {
+  background: rgba(0, 0, 0, 0.04);
+  border-color: #9ca3af;
+}
+
+.gv-export-width-btn.active {
+  background: oklch(0.55 0.17 155);
+  color: #ffffff;
+  border-color: oklch(0.55 0.17 155);
+  box-shadow: 0 2px 4px oklch(0.55 0.17 155 / 0.2);
+}
+
+html.dark .gv-export-width-btn,
+[data-theme='dark'] .gv-export-width-btn,
+[data-color-scheme='dark'] .gv-export-width-btn,
+html.dark-theme .gv-export-width-btn,
+body.dark-theme .gv-export-width-btn,
+body[data-theme='dark'] .gv-export-width-btn,
+body[data-color-scheme='dark'] .gv-export-width-btn {
+  color: #9ca3af;
+  border-color: #374151;
+}
+
+html.dark .gv-export-width-btn:hover,
+[data-theme='dark'] .gv-export-width-btn:hover,
+[data-color-scheme='dark'] .gv-export-width-btn:hover,
+html.dark-theme .gv-export-width-btn:hover,
+body.dark-theme .gv-export-width-btn:hover,
+body[data-theme='dark'] .gv-export-width-btn:hover,
+body[data-color-scheme='dark'] .gv-export-width-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: #4b5563;
+}
+
+html.dark .gv-export-width-btn.active,
+[data-theme='dark'] .gv-export-width-btn.active,
+[data-color-scheme='dark'] .gv-export-width-btn.active,
+html.dark-theme .gv-export-width-btn.active,
+body.dark-theme .gv-export-width-btn.active,
+body[data-theme='dark'] .gv-export-width-btn.active,
+body[data-color-scheme='dark'] .gv-export-width-btn.active {
+  background: oklch(0.7 0.16 155);
+  color: #111827;
+  border-color: oklch(0.7 0.16 155);
+}
+
 .gv-aistudio .gv-conversation-title {
   min-width: 0;
   font-size: 12px;

--- a/src/features/export/services/ConversationExportService.ts
+++ b/src/features/export/services/ConversationExportService.ts
@@ -220,7 +220,11 @@ export class ConversationExportService {
     options: ExportOptions,
   ): Promise<ExportResult> {
     const filename = options.filename || this.generateFilename('png', metadata.title);
-    await ImageExportService.export(turns, metadata, { filename, fontSize: options.fontSize });
+    await ImageExportService.export(turns, metadata, {
+      filename,
+      fontSize: options.fontSize,
+      imageWidth: options.imageWidth,
+    });
     return { success: true, format: 'image' as ExportFormat, filename };
   }
 
@@ -302,7 +306,7 @@ export class ConversationExportService {
         markdown: content.markdown,
         html: content.html,
       },
-      { filename },
+      { filename, imageWidth: options.imageWidth },
     );
 
     return {

--- a/src/features/export/services/ConversationExportService.ts
+++ b/src/features/export/services/ConversationExportService.ts
@@ -277,13 +277,16 @@ export class ConversationExportService {
     metadata: ConversationMetadata,
     options: ExportOptions,
   ): Promise<ExportResult> {
-    await DeepResearchPDFPrintService.export({
-      title: metadata.title || 'Deep Research Report',
-      url: metadata.url,
-      exportedAt: metadata.exportedAt,
-      markdown: content.markdown,
-      html: content.html,
-    });
+    await DeepResearchPDFPrintService.export(
+      {
+        title: metadata.title || 'Deep Research Report',
+        url: metadata.url,
+        exportedAt: metadata.exportedAt,
+        markdown: content.markdown,
+        html: content.html,
+      },
+      { fontSize: options.fontSize },
+    );
 
     return {
       success: true,
@@ -306,7 +309,11 @@ export class ConversationExportService {
         markdown: content.markdown,
         html: content.html,
       },
-      { filename, imageWidth: options.imageWidth },
+      {
+        filename,
+        fontSize: options.fontSize,
+        imageWidth: options.imageWidth,
+      },
     );
 
     return {

--- a/src/features/export/services/DeepResearchPDFPrintService.ts
+++ b/src/features/export/services/DeepResearchPDFPrintService.ts
@@ -17,12 +17,15 @@ export class DeepResearchPDFPrintService {
   private static cleanupFallbackTimer: ReturnType<typeof setTimeout> | null = null;
   private static originalDocumentTitle: string | null = null;
 
-  static async export(content: PrintableDocumentContent): Promise<void> {
+  static async export(
+    content: PrintableDocumentContent,
+    options?: { fontSize?: number },
+  ): Promise<void> {
     this.cleanup();
 
     const container = this.createPrintContainer(content);
     document.body.appendChild(container);
-    this.injectPrintStyles();
+    this.injectPrintStyles(options?.fontSize);
     document.body.classList.add(this.PRINT_BODY_CLASS);
 
     this.originalDocumentTitle = document.title;
@@ -251,8 +254,14 @@ export class DeepResearchPDFPrintService {
     }
   }
 
-  private static injectPrintStyles(): void {
+  private static injectPrintStyles(fontSize?: number): void {
     if (document.getElementById(this.PRINT_STYLES_ID)) return;
+
+    const basePt = fontSize ?? 11;
+    const coverTitlePt = Math.round(basePt * (36 / 11));
+    const metaPt = Math.max(basePt + 1, 10);
+    const codePt = Math.max(basePt - 2, 8);
+    const footerPt = Math.max(basePt - 2, 8);
 
     const style = document.createElement('style');
     style.id = this.PRINT_STYLES_ID;
@@ -386,7 +395,7 @@ export class DeepResearchPDFPrintService {
         }
 
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-cover-title {
-          font-size: 36pt;
+          font-size: ${coverTitlePt}pt;
           font-weight: 800;
           letter-spacing: -0.02em;
           margin: 0 0 1.5em 0;
@@ -396,7 +405,7 @@ export class DeepResearchPDFPrintService {
         }
 
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-meta {
-          font-size: 12pt;
+          font-size: ${metaPt}pt;
           color: #666;
           line-height: 2;
         }
@@ -417,7 +426,7 @@ export class DeepResearchPDFPrintService {
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-content {
           margin: 2em 0;
           line-height: 1.65;
-          font-size: 11pt;
+          font-size: ${basePt}pt;
         }
 
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-report p {
@@ -435,7 +444,7 @@ export class DeepResearchPDFPrintService {
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-report pre,
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-report code {
           font-family: 'Courier New', monospace;
-          font-size: 9pt;
+          font-size: ${codePt}pt;
           background: #f5f5f5;
           border-radius: 3px;
         }
@@ -458,7 +467,7 @@ export class DeepResearchPDFPrintService {
           margin-top: 2em;
           padding-top: 1em;
           border-top: 1px solid #ccc;
-          font-size: 9pt;
+          font-size: ${footerPt}pt;
           color: #666;
           text-align: center;
         }

--- a/src/features/export/services/ImageExportService.ts
+++ b/src/features/export/services/ImageExportService.ts
@@ -39,13 +39,13 @@ export class ImageExportService {
 
   static async exportDocument(
     content: RenderableDocumentContent,
-    options: { filename: string; imageWidth?: number },
+    options: { filename: string; fontSize?: number; imageWidth?: number },
   ): Promise<void> {
     const filename = options.filename.toLowerCase().endsWith('.png')
       ? options.filename
       : `${options.filename}.png`;
 
-    const blob = await this.renderDocumentBlob(content, options.imageWidth);
+    const blob = await this.renderDocumentBlob(content, options.imageWidth, options.fontSize);
     this.downloadBlob(blob, filename);
   }
 

--- a/src/features/export/services/ImageExportService.ts
+++ b/src/features/export/services/ImageExportService.ts
@@ -27,7 +27,7 @@ export class ImageExportService {
   static async export(
     turns: ChatTurn[],
     metadata: ConversationMetadata,
-    options: { filename: string; fontSize?: number },
+    options: { filename: string; fontSize?: number; imageWidth?: number },
   ): Promise<void> {
     const filename = options.filename.toLowerCase().endsWith('.png')
       ? options.filename
@@ -39,27 +39,36 @@ export class ImageExportService {
 
   static async exportDocument(
     content: RenderableDocumentContent,
-    options: { filename: string },
+    options: { filename: string; imageWidth?: number },
   ): Promise<void> {
     const filename = options.filename.toLowerCase().endsWith('.png')
       ? options.filename
       : `${options.filename}.png`;
 
-    const blob = await this.renderDocumentBlob(content);
+    const blob = await this.renderDocumentBlob(content, options.imageWidth);
     this.downloadBlob(blob, filename);
   }
 
   static async renderConversationBlob(
     turns: ChatTurn[],
     metadata: ConversationMetadata,
-    options: { fontSize?: number },
+    options: { fontSize?: number; imageWidth?: number },
   ): Promise<Blob> {
-    const container = this.createRenderContainer(turns, metadata, options.fontSize);
+    const container = this.createRenderContainer(
+      turns,
+      metadata,
+      options.fontSize,
+      options.imageWidth,
+    );
     return await this.renderContainerToBlob(container);
   }
 
-  static async renderDocumentBlob(content: RenderableDocumentContent): Promise<Blob> {
-    const container = this.createDocumentRenderContainer(content);
+  static async renderDocumentBlob(
+    content: RenderableDocumentContent,
+    imageWidth?: number,
+    fontSize?: number,
+  ): Promise<Blob> {
+    const container = this.createDocumentRenderContainer(content, imageWidth, fontSize);
     return await this.renderContainerToBlob(container);
   }
 
@@ -67,6 +76,7 @@ export class ImageExportService {
     turns: ChatTurn[],
     metadata: ConversationMetadata,
     fontSize?: number,
+    imageWidth?: number,
   ): HTMLElement {
     const outer = document.createElement('div');
     outer.className = 'gv-image-export-container';
@@ -74,7 +84,7 @@ export class ImageExportService {
       position: 'fixed',
       left: '-10000px',
       top: '0',
-      width: '620px',
+      width: `${imageWidth ?? 620}px`,
       background: '#ffffff',
       color: '#111827',
       zIndex: '-1',
@@ -265,18 +275,25 @@ export class ImageExportService {
     return outer;
   }
 
-  private static createDocumentRenderContainer(content: RenderableDocumentContent): HTMLElement {
+  private static createDocumentRenderContainer(
+    content: RenderableDocumentContent,
+    imageWidth?: number,
+    fontSize?: number,
+  ): HTMLElement {
     const outer = document.createElement('div');
+    const baseFontSize = fontSize ?? 20;
+
     outer.className = 'gv-image-export-container';
     Object.assign(outer.style, {
       position: 'fixed',
       left: '-10000px',
       top: '0',
-      width: '620px',
+      width: `${imageWidth ?? 620}px`,
       background: '#ffffff',
       color: '#111827',
       zIndex: '-1',
       pointerEvents: 'none',
+      fontSize: `${baseFontSize}px`,
     } as Partial<CSSStyleDeclaration>);
 
     const date = this.formatDate(content.exportedAt);
@@ -302,69 +319,69 @@ export class ImageExportService {
     style.textContent = `
       .gv-image-export-doc {
         font-family: Georgia, 'Times New Roman', serif;
-        font-size: 20px;
+        font-size: 1em;
         line-height: 1.9;
-        padding: 26px;
+        padding: 1.3em;
       }
 
       .gv-image-export-header {
-        margin-bottom: 18px;
-        padding-bottom: 14px;
+        margin-bottom: 0.9em;
+        padding-bottom: 0.7em;
         border-bottom: 1px solid rgba(0,0,0,0.12);
       }
 
       .gv-image-export-title {
         margin: 0;
-        font-size: 50px;
+        font-size: 2.5em;
         line-height: 1.2;
         color: #111827;
         word-break: break-word;
       }
 
       .gv-image-export-meta {
-        margin-top: 10px;
+        margin-top: 0.5em;
         color: #6b7280;
-        font-size: 18px;
+        font-size: 0.9em;
         display: grid;
-        gap: 8px;
+        gap: 0.4em;
       }
 
       .gv-image-export-report-content {
-        margin: 18px 0 24px;
+        margin: 0.9em 0 1.2em;
         color: #1a1a1a;
-        font-size: 20px;
+        font-size: 1em;
       }
 
       .gv-image-export-report-content p {
-        margin: 12px 0;
+        margin: 0.6em 0;
       }
 
       .gv-image-export-report-content img {
         max-width: 100%;
         height: auto;
         display: block;
-        margin: 12px 0;
+        margin: 0.6em 0;
       }
 
       .gv-image-export-report-content pre {
         background: rgba(0,0,0,0.05);
-        padding: 14px 16px;
+        padding: 0.7em 0.8em;
         border-radius: 8px;
         overflow-x: auto;
         white-space: pre-wrap;
         word-break: break-word;
-        font-size: 18px;
+        font-size: 0.9em;
         line-height: 1.8;
       }
 
       .gv-image-export-footer {
-        margin-top: 24px;
-        padding-top: 14px;
+        margin-top: 1.2em;
+        padding-top: 0.7em;
         border-top: 1px solid rgba(0,0,0,0.12);
         color: #6b7280;
-        font-size: 16px;
+        font-size: 0.8em;
         display: grid;
-        gap: 8px;
+        gap: 0.4em;
       }
     `;
 
@@ -399,7 +416,10 @@ export class ImageExportService {
 
       // Try content-script fetch first
       try {
-        const resp = await fetch(url, { credentials: 'include', mode: 'cors' as RequestMode });
+        const resp = await fetch(url, {
+          credentials: 'include',
+          mode: 'cors' as RequestMode,
+        });
         if (resp.ok) {
           const blob = await resp.blob();
           const data = await blobToDataUrl(blob);

--- a/src/features/export/services/__tests__/ConversationExportService.test.ts
+++ b/src/features/export/services/__tests__/ConversationExportService.test.ts
@@ -243,10 +243,19 @@ describe('ConversationExportService', () => {
       const result = await ConversationExportService.export(mockTurns, mockMetadata, {
         format: ExportFormat.PDF,
         layout: 'document' as ExportLayout,
+        fontSize: 15,
       });
 
       expect(result.success).toBe(true);
       expect(deepResearchPdfSpy).toHaveBeenCalledOnce();
+      expect(deepResearchPdfSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: mockMetadata.title,
+          url: mockMetadata.url,
+          exportedAt: mockMetadata.exportedAt,
+        }),
+        { fontSize: 15 },
+      );
       expect(pdfDocumentSpy).not.toHaveBeenCalled();
     });
 
@@ -261,10 +270,24 @@ describe('ConversationExportService', () => {
       const result = await ConversationExportService.export(mockTurns, mockMetadata, {
         format: ExportFormat.IMAGE,
         layout: 'document' as ExportLayout,
+        fontSize: 24,
+        imageWidth: 1360,
       });
 
       expect(result.success).toBe(true);
       expect(imageDocumentSpy).toHaveBeenCalledOnce();
+      expect(imageDocumentSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: mockMetadata.title,
+          url: mockMetadata.url,
+          exportedAt: mockMetadata.exportedAt,
+        }),
+        {
+          filename: 'Premier-League-Fantasy.png',
+          fontSize: 24,
+          imageWidth: 1360,
+        },
+      );
     });
 
     it('should handle unsupported format', async () => {

--- a/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
@@ -127,4 +127,26 @@ describe('DeepResearchPDFPrintService', () => {
     window.dispatchEvent(new Event('afterprint'));
     expect(document.body.classList.contains('gv-deep-research-pdf-safari-printing')).toBe(false);
   });
+
+  it('applies custom font size to deep research PDF print styles', async () => {
+    window.print = vi.fn();
+
+    await DeepResearchPDFPrintService.export(
+      {
+        title: 'Report',
+        url: 'https://gemini.google.com/app/abc12345',
+        exportedAt: new Date().toISOString(),
+        markdown: 'Body',
+        html: '<p>Body</p>',
+      },
+      { fontSize: 15 },
+    );
+
+    const style = document.getElementById('gv-deep-research-pdf-print-styles');
+    const styleText = style?.textContent || '';
+    expect(styleText).toContain('font-size: 15pt;');
+    expect(styleText).toContain('font-size: 49pt;');
+    expect(styleText).toContain('font-size: 16pt;');
+    expect(styleText).toContain('font-size: 13pt;');
+  });
 });

--- a/src/features/export/services/__tests__/ImageExportService.test.ts
+++ b/src/features/export/services/__tests__/ImageExportService.test.ts
@@ -177,4 +177,36 @@ describe('ImageExportService', () => {
     expect(firstTarget.querySelector('img')).not.toBeNull();
     expect(secondTarget.querySelector('img')).toBeNull();
   });
+
+  it('applies custom width and font size for document image exports', async () => {
+    let capturedWidth = '';
+    let capturedFontSize = '';
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockReset();
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (node: HTMLElement) => {
+        const container = node.parentElement as HTMLElement | null;
+        capturedWidth = container?.style.width ?? '';
+        capturedFontSize = container?.style.fontSize ?? '';
+        return new Blob(['x'], { type: 'image/png' });
+      },
+    );
+
+    await ImageExportService.exportDocument(
+      {
+        title: 'Report',
+        url: 'https://gemini.google.com/app/report',
+        exportedAt: '2026-01-01T00:00:00.000Z',
+        markdown: 'Body',
+        html: '<p>Body</p>',
+      },
+      {
+        filename: 'report.png',
+        fontSize: 24,
+        imageWidth: 1360,
+      },
+    );
+
+    expect(capturedWidth).toBe('1360px');
+    expect(capturedFontSize).toBe('24px');
+  });
 });

--- a/src/features/export/types/export.ts
+++ b/src/features/export/types/export.ts
@@ -64,6 +64,8 @@ export interface ExportOptions {
   embedImages?: 'inline' | 'none';
   // Font size for PDF (pt) and Image (px) exports
   fontSize?: number;
+  // Image width (px) for image exports
+  imageWidth?: number;
   /** Whether to include image source attribution in markdown (default: true) */
   includeImageSource?: boolean;
 }

--- a/src/features/export/ui/ExportDialog.ts
+++ b/src/features/export/ui/ExportDialog.ts
@@ -8,7 +8,7 @@ import { ConversationExportService } from '../services/ConversationExportService
 import type { ExportFormat } from '../types/export';
 
 export interface ExportDialogOptions {
-  onExport: (format: ExportFormat, fontSize?: number) => void;
+  onExport: (format: ExportFormat, fontSize?: number, imageWidth?: number) => void;
   onCancel: () => void;
   translations: {
     title: string;
@@ -20,6 +20,10 @@ export interface ExportDialogOptions {
     export: string;
     fontSizeLabel: string;
     fontSizePreview: string;
+    imageWidthLabel: string;
+    imageWidthNarrow: string;
+    imageWidthMedium: string;
+    imageWidthWide: string;
     formatDescriptions: Record<ExportFormat, string>;
   };
 }
@@ -35,10 +39,15 @@ const PDF_MAX = 16;
 const IMAGE_MIN = 14;
 const IMAGE_MAX = 28;
 
+const IMAGE_WIDTH_NARROW = 620;
+const IMAGE_WIDTH_MEDIUM = 960;
+const IMAGE_WIDTH_WIDE = 1360;
+
 export class ExportDialog {
   private overlay: HTMLElement | null = null;
   private selectedFormat: ExportFormat = 'markdown' as ExportFormat;
   private fontSize: number = PDF_DEFAULT_FONT_SIZE;
+  private imageWidth: number = IMAGE_WIDTH_NARROW;
 
   /**
    * Show export dialog
@@ -103,11 +112,15 @@ export class ExportDialog {
     // Font size section (visible only for PDF/Image)
     const fontSizeSection = this.createFontSizeSection(options);
 
+    // Image width section (visible only for Image)
+    const imageWidthSection = this.createImageWidthSection(options);
+
     // Buttons
     const buttons = document.createElement('div');
     buttons.className = 'gv-export-dialog-buttons';
 
     const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
     cancelBtn.className = 'gv-export-dialog-btn gv-export-dialog-btn-secondary';
     cancelBtn.textContent = options.translations.cancel;
     cancelBtn.addEventListener('click', () => {
@@ -116,13 +129,17 @@ export class ExportDialog {
     });
 
     const exportBtn = document.createElement('button');
+    exportBtn.type = 'button';
     exportBtn.className = 'gv-export-dialog-btn gv-export-dialog-btn-primary';
     exportBtn.textContent = options.translations.export;
     exportBtn.addEventListener('click', () => {
-      const isPdfOrImage =
-        this.selectedFormat === ('pdf' as ExportFormat) ||
-        this.selectedFormat === ('image' as ExportFormat);
-      options.onExport(this.selectedFormat, isPdfOrImage ? this.fontSize : undefined);
+      const isPdf = this.selectedFormat === ('pdf' as ExportFormat);
+      const isImage = this.selectedFormat === ('image' as ExportFormat);
+      options.onExport(
+        this.selectedFormat,
+        isPdf || isImage ? this.fontSize : undefined,
+        isImage ? this.imageWidth : undefined,
+      );
       this.hide();
     });
 
@@ -140,6 +157,7 @@ export class ExportDialog {
     }
     dialog.appendChild(formatsList);
     dialog.appendChild(fontSizeSection);
+    dialog.appendChild(imageWidthSection);
     dialog.appendChild(buttons);
     overlay.appendChild(dialog);
 
@@ -193,7 +211,7 @@ export class ExportDialog {
     radio.addEventListener('change', () => {
       if (radio.checked) {
         this.selectedFormat = formatInfo.format;
-        this.updateFontSizeSection();
+        this.updateOptionalSections();
       }
     });
 
@@ -291,46 +309,110 @@ export class ExportDialog {
   }
 
   /**
-   * Update font size section visibility and slider range based on selected format
+   * Create image width selection section
    */
-  private updateFontSizeSection(): void {
+  private createImageWidthSection(options: ExportDialogOptions): HTMLElement {
+    const section = document.createElement('div');
+    section.className = 'gv-export-imagewidth-section';
+    section.style.display = 'none';
+
+    const label = document.createElement('div');
+    label.className = 'gv-export-fontsize-label';
+    label.style.marginBottom = '8px';
+    label.textContent = options.translations.imageWidthLabel;
+
+    const group = document.createElement('div');
+    group.className = 'gv-export-width-group';
+    group.style.display = 'flex';
+    group.style.gap = '8px';
+
+    const widths = [
+      {
+        value: IMAGE_WIDTH_NARROW,
+        label: options.translations.imageWidthNarrow,
+      },
+      {
+        value: IMAGE_WIDTH_MEDIUM,
+        label: options.translations.imageWidthMedium,
+      },
+      { value: IMAGE_WIDTH_WIDE, label: options.translations.imageWidthWide },
+    ];
+
+    widths.forEach((w) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'gv-export-width-btn';
+      btn.textContent = w.label;
+      if (w.value === this.imageWidth) {
+        btn.classList.add('active');
+      }
+
+      btn.addEventListener('click', () => {
+        this.imageWidth = w.value;
+        group.querySelectorAll('.gv-export-width-btn').forEach((b) => b.classList.remove('active'));
+        btn.classList.add('active');
+      });
+
+      group.appendChild(btn);
+    });
+
+    section.appendChild(label);
+    section.appendChild(group);
+
+    return section;
+  }
+
+  /**
+   * Update optional sections visibility and slider range based on selected format
+   */
+  private updateOptionalSections(): void {
     if (!this.overlay) return;
 
-    const section = this.overlay.querySelector('.gv-export-fontsize-section') as HTMLElement | null;
-    if (!section) return;
+    const fontSizeSection = this.overlay.querySelector(
+      '.gv-export-fontsize-section',
+    ) as HTMLElement | null;
+    const imageWidthSection = this.overlay.querySelector(
+      '.gv-export-imagewidth-section',
+    ) as HTMLElement | null;
+
+    if (!fontSizeSection || !imageWidthSection) return;
 
     const isPdf = this.selectedFormat === ('pdf' as ExportFormat);
     const isImage = this.selectedFormat === ('image' as ExportFormat);
 
-    if (!isPdf && !isImage) {
-      section.style.display = 'none';
-      return;
-    }
+    fontSizeSection.style.display = isPdf || isImage ? 'block' : 'none';
+    imageWidthSection.style.display = isImage ? 'block' : 'none';
 
-    section.style.display = 'block';
+    if (isPdf || isImage) {
+      const slider = fontSizeSection.querySelector(
+        '.gv-export-fontsize-slider',
+      ) as HTMLInputElement | null;
+      const value = fontSizeSection.querySelector(
+        '.gv-export-fontsize-value',
+      ) as HTMLElement | null;
+      const preview = fontSizeSection.querySelector(
+        '.gv-export-fontsize-preview',
+      ) as HTMLElement | null;
 
-    const slider = section.querySelector('.gv-export-fontsize-slider') as HTMLInputElement | null;
-    const value = section.querySelector('.gv-export-fontsize-value') as HTMLElement | null;
-    const preview = section.querySelector('.gv-export-fontsize-preview') as HTMLElement | null;
-
-    if (isPdf) {
-      this.fontSize = PDF_DEFAULT_FONT_SIZE;
-      if (slider) {
-        slider.min = String(PDF_MIN);
-        slider.max = String(PDF_MAX);
-        slider.value = String(this.fontSize);
+      if (isPdf) {
+        this.fontSize = PDF_DEFAULT_FONT_SIZE;
+        if (slider) {
+          slider.min = String(PDF_MIN);
+          slider.max = String(PDF_MAX);
+          slider.value = String(this.fontSize);
+        }
+        if (value) value.textContent = `${this.fontSize}pt`;
+        if (preview) preview.style.fontSize = `${this.fontSize}pt`;
+      } else {
+        this.fontSize = IMAGE_DEFAULT_FONT_SIZE;
+        if (slider) {
+          slider.min = String(IMAGE_MIN);
+          slider.max = String(IMAGE_MAX);
+          slider.value = String(this.fontSize);
+        }
+        if (value) value.textContent = `${this.fontSize}px`;
+        if (preview) preview.style.fontSize = `${this.fontSize}px`;
       }
-      if (value) value.textContent = `${this.fontSize}pt`;
-      if (preview) preview.style.fontSize = `${this.fontSize}pt`;
-    } else {
-      this.fontSize = IMAGE_DEFAULT_FONT_SIZE;
-      if (slider) {
-        slider.min = String(IMAGE_MIN);
-        slider.max = String(IMAGE_MAX);
-        slider.value = String(this.fontSize);
-      }
-      if (value) value.textContent = `${this.fontSize}px`;
-      if (preview) preview.style.fontSize = `${this.fontSize}px`;
     }
   }
 }

--- a/src/features/export/ui/__tests__/ExportDialog.safariHint.test.ts
+++ b/src/features/export/ui/__tests__/ExportDialog.safariHint.test.ts
@@ -33,6 +33,10 @@ describe('ExportDialog (Safari hint)', () => {
       export: 'Export',
       fontSizeLabel: 'Font Size',
       fontSizePreview: 'The quick brown fox jumps over the lazy dog.',
+      imageWidthLabel: 'Image Width',
+      imageWidthNarrow: 'Narrow',
+      imageWidthMedium: 'Medium',
+      imageWidthWide: 'Wide',
       formatDescriptions: {
         json: 'JSON desc',
         markdown: 'MD desc',

--- a/src/features/export/ui/__tests__/ExportDialog.test.ts
+++ b/src/features/export/ui/__tests__/ExportDialog.test.ts
@@ -25,6 +25,10 @@ describe('ExportDialog', () => {
         export: 'Export',
         fontSizeLabel: 'Font Size',
         fontSizePreview: 'The quick brown fox jumps over the lazy dog.',
+        imageWidthLabel: 'Image Width',
+        imageWidthNarrow: 'Narrow',
+        imageWidthMedium: 'Medium',
+        imageWidthWide: 'Wide',
         formatDescriptions: {
           json: 'JSON format',
           markdown: 'Markdown format',
@@ -62,6 +66,10 @@ describe('ExportDialog', () => {
         export: 'Export',
         fontSizeLabel: 'Font Size',
         fontSizePreview: 'The quick brown fox jumps over the lazy dog.',
+        imageWidthLabel: 'Image Width',
+        imageWidthNarrow: 'Narrow',
+        imageWidthMedium: 'Medium',
+        imageWidthWide: 'Wide',
         formatDescriptions: {
           json: 'JSON format',
           markdown: 'Markdown format',

--- a/src/locales/ar/messages.json
+++ b/src/locales/ar/messages.json
@@ -1315,6 +1315,22 @@
     "message": "نص عربي لمعاينة حجم الخط في التصدير.",
     "description": "Preview text for font size slider in export dialog"
   },
+  "export_image_width_label": {
+    "message": "عرض الصورة",
+    "description": "Label for image width selection in export dialog"
+  },
+  "export_image_width_narrow": {
+    "message": "ضيق (هاتف)",
+    "description": "Narrow width option (e.g. mobile)"
+  },
+  "export_image_width_medium": {
+    "message": "متوسط (تابلت)",
+    "description": "Medium width option (e.g. tablet)"
+  },
+  "export_image_width_wide": {
+    "message": "عريض (كمبيوتر)",
+    "description": "Wide width option (e.g. desktop)"
+  },
   "export_error_generic": {
     "message": "فشل التصدير: {error}",
     "description": "رسالة فشل تصدير عامة مع السبب التفصيلي"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1315,6 +1315,22 @@
     "message": "The quick brown fox jumps over the lazy dog.",
     "description": "Preview text for font size slider in export dialog"
   },
+  "export_image_width_label": {
+    "message": "Image Width",
+    "description": "Label for image width selection in export dialog"
+  },
+  "export_image_width_narrow": {
+    "message": "Narrow",
+    "description": "Narrow width option (e.g. mobile)"
+  },
+  "export_image_width_medium": {
+    "message": "Medium",
+    "description": "Medium width option (e.g. tablet)"
+  },
+  "export_image_width_wide": {
+    "message": "Wide",
+    "description": "Wide width option (e.g. desktop)"
+  },
   "export_error_generic": {
     "message": "Export failed: {error}",
     "description": "Generic export failure with detailed reason"

--- a/src/locales/es/messages.json
+++ b/src/locales/es/messages.json
@@ -1315,6 +1315,22 @@
     "message": "El veloz murciélago hindú comía feliz cardillo y kiwi.",
     "description": "Preview text for font size slider in export dialog"
   },
+  "export_image_width_label": {
+    "message": "Ancho de imagen",
+    "description": "Label for image width selection in export dialog"
+  },
+  "export_image_width_narrow": {
+    "message": "Estrecho (Móvil)",
+    "description": "Narrow width option (e.g. mobile)"
+  },
+  "export_image_width_medium": {
+    "message": "Medio (Tableta)",
+    "description": "Medium width option (e.g. tablet)"
+  },
+  "export_image_width_wide": {
+    "message": "Ancho (PC)",
+    "description": "Wide width option (e.g. desktop)"
+  },
   "export_error_generic": {
     "message": "Error al exportar: {error}",
     "description": "Mensaje genérico de error de exportación con detalle"

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -1315,6 +1315,22 @@
     "message": "Le vif renard brun saute par-dessus le chien paresseux.",
     "description": "Preview text for font size slider in export dialog"
   },
+  "export_image_width_label": {
+    "message": "Largeur de l'image",
+    "description": "Label for image width selection in export dialog"
+  },
+  "export_image_width_narrow": {
+    "message": "Étroite (Mobile)",
+    "description": "Narrow width option (e.g. mobile)"
+  },
+  "export_image_width_medium": {
+    "message": "Moyenne (Tablette)",
+    "description": "Medium width option (e.g. tablet)"
+  },
+  "export_image_width_wide": {
+    "message": "Large (Ordinateur)",
+    "description": "Wide width option (e.g. desktop)"
+  },
   "export_error_generic": {
     "message": "Échec de l'exportation : {error}",
     "description": "Message d'échec d'export avec raison détaillée"

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -1315,6 +1315,22 @@
     "message": "吾輩は猫である。名前はまだない。",
     "description": "Preview text for font size slider in export dialog"
   },
+  "export_image_width_label": {
+    "message": "画像の幅",
+    "description": "Label for image width selection in export dialog"
+  },
+  "export_image_width_narrow": {
+    "message": "狭い (スマホ)",
+    "description": "Narrow width option (e.g. mobile)"
+  },
+  "export_image_width_medium": {
+    "message": "標準 (タブレット)",
+    "description": "Medium width option (e.g. tablet)"
+  },
+  "export_image_width_wide": {
+    "message": "広い (デスクトップ)",
+    "description": "Wide width option (e.g. desktop)"
+  },
   "export_error_generic": {
     "message": "エクスポートに失敗しました：{error}",
     "description": "詳細理由付きのエクスポート失敗メッセージ"

--- a/src/locales/ko/messages.json
+++ b/src/locales/ko/messages.json
@@ -1315,6 +1315,22 @@
     "message": "다람쥐 헌 쳇바퀴에 타고파.",
     "description": "Preview text for font size slider in export dialog"
   },
+  "export_image_width_label": {
+    "message": "이미지 너비",
+    "description": "Label for image width selection in export dialog"
+  },
+  "export_image_width_narrow": {
+    "message": "좁게 (모바일)",
+    "description": "Narrow width option (e.g. mobile)"
+  },
+  "export_image_width_medium": {
+    "message": "중간 (태블릿)",
+    "description": "Medium width option (e.g. tablet)"
+  },
+  "export_image_width_wide": {
+    "message": "넓게 (PC)",
+    "description": "Wide width option (e.g. desktop)"
+  },
   "export_error_generic": {
     "message": "내보내기 실패: {error}",
     "description": "상세 원인을 포함한 일반 내보내기 실패 메시지"

--- a/src/locales/pt/messages.json
+++ b/src/locales/pt/messages.json
@@ -1315,6 +1315,22 @@
     "message": "A rápida raposa marrom salta sobre o cão preguiçoso.",
     "description": "Preview text for font size slider in export dialog"
   },
+  "export_image_width_label": {
+    "message": "Largura da imagem",
+    "description": "Label for image width selection in export dialog"
+  },
+  "export_image_width_narrow": {
+    "message": "Estreita (Móvel)",
+    "description": "Narrow width option (e.g. mobile)"
+  },
+  "export_image_width_medium": {
+    "message": "Média (Tablet)",
+    "description": "Medium width option (e.g. tablet)"
+  },
+  "export_image_width_wide": {
+    "message": "Larga (PC)",
+    "description": "Wide width option (e.g. desktop)"
+  },
   "export_error_generic": {
     "message": "Falha na exportação: {error}",
     "description": "Mensagem genérica de falha na exportação com detalhe"

--- a/src/locales/ru/messages.json
+++ b/src/locales/ru/messages.json
@@ -1315,6 +1315,22 @@
     "message": "Съешь ещё этих мягких французских булок, да выпей чаю.",
     "description": "Preview text for font size slider in export dialog"
   },
+  "export_image_width_label": {
+    "message": "Ширина изображения",
+    "description": "Label for image width selection in export dialog"
+  },
+  "export_image_width_narrow": {
+    "message": "Узкая (Телефоны)",
+    "description": "Narrow width option (e.g. mobile)"
+  },
+  "export_image_width_medium": {
+    "message": "Средняя (Планшеты)",
+    "description": "Medium width option (e.g. tablet)"
+  },
+  "export_image_width_wide": {
+    "message": "Широкая (ПК)",
+    "description": "Wide width option (e.g. desktop)"
+  },
   "export_error_generic": {
     "message": "Не удалось экспортировать: {error}",
     "description": "Общее сообщение об ошибке экспорта с подробной причиной"

--- a/src/locales/zh/messages.json
+++ b/src/locales/zh/messages.json
@@ -1315,6 +1315,22 @@
     "message": "天地玄黄，宇宙洪荒。日月盈昃，辰宿列张。",
     "description": "Preview text for font size slider in export dialog"
   },
+  "export_image_width_label": {
+    "message": "导出图片宽度",
+    "description": "Label for image width selection in export dialog"
+  },
+  "export_image_width_narrow": {
+    "message": "窄（手机）",
+    "description": "Narrow width option (e.g. mobile)"
+  },
+  "export_image_width_medium": {
+    "message": "中（平板）",
+    "description": "Medium width option (e.g. tablet)"
+  },
+  "export_image_width_wide": {
+    "message": "宽（电脑）",
+    "description": "Wide width option (e.g. desktop)"
+  },
   "export_error_generic": {
     "message": "导出失败：{error}",
     "description": "带具体原因的导出失败提示"

--- a/src/locales/zh_TW/messages.json
+++ b/src/locales/zh_TW/messages.json
@@ -1315,6 +1315,22 @@
     "message": "天地玄黃，宇宙洪荒。日月盈昃，辰宿列張。",
     "description": "Preview text for font size slider in export dialog"
   },
+  "export_image_width_label": {
+    "message": "匯出圖片寬度",
+    "description": "Label for image width selection in export dialog"
+  },
+  "export_image_width_narrow": {
+    "message": "窄 (手機)",
+    "description": "Narrow width option (e.g. mobile)"
+  },
+  "export_image_width_medium": {
+    "message": "中 (平板)",
+    "description": "Medium width option (e.g. tablet)"
+  },
+  "export_image_width_wide": {
+    "message": "寬 (電腦)",
+    "description": "Wide width option (e.g. desktop)"
+  },
   "export_error_generic": {
     "message": "匯出失敗：{error}",
     "description": "附帶具體原因的匯出失敗提示"

--- a/src/pages/content/deepResearch/menuButton.ts
+++ b/src/pages/content/deepResearch/menuButton.ts
@@ -386,7 +386,7 @@ function handleSaveReport(dict: Dictionaries, lang: AppLanguage): void {
   const t = (key: TranslationKey) => dict[lang]?.[key] ?? dict.en?.[key] ?? key;
   const dialog = new ExportDialog();
   dialog.show({
-    onExport: async (format) => {
+    onExport: async (format, fontSize, imageWidth) => {
       const hideProgress = showDeepResearchExportProgressOverlay(t);
       try {
         const filename = buildReportFilename(format, reportTitle);
@@ -394,6 +394,8 @@ function handleSaveReport(dict: Dictionaries, lang: AppLanguage): void {
           format,
           filename,
           layout: 'document',
+          fontSize,
+          imageWidth,
         });
         const minVisiblePromise = new Promise((resolve) => setTimeout(resolve, 420));
         const [result] = await Promise.all([resultPromise, minVisiblePromise]);
@@ -420,6 +422,10 @@ function handleSaveReport(dict: Dictionaries, lang: AppLanguage): void {
       export: t('pm_export'),
       fontSizeLabel: t('export_fontsize_label'),
       fontSizePreview: t('export_fontsize_preview'),
+      imageWidthLabel: t('export_image_width_label'),
+      imageWidthNarrow: t('export_image_width_narrow'),
+      imageWidthMedium: t('export_image_width_medium'),
+      imageWidthWide: t('export_image_width_wide'),
       formatDescriptions: {
         json: t('export_format_json_description'),
         markdown: t('export_format_markdown_description'),

--- a/src/pages/content/draftSave/__tests__/draftSave.test.ts
+++ b/src/pages/content/draftSave/__tests__/draftSave.test.ts
@@ -81,7 +81,14 @@ function createContentEditable(): HTMLElement {
   el.setAttribute('role', 'textbox');
   // Make it "visible" for getBoundingClientRect
   Object.defineProperty(el, 'getBoundingClientRect', {
-    value: () => ({ height: 100, width: 500, top: 0, left: 0, bottom: 100, right: 500 }),
+    value: () => ({
+      height: 100,
+      width: 500,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 500,
+    }),
   });
   document.body.appendChild(el);
   return el;
@@ -96,7 +103,10 @@ describe('draftSave', () => {
 
     // Mock window.location
     Object.defineProperty(window, 'location', {
-      value: { pathname: '/app/test-conversation-123', hostname: 'gemini.google.com' },
+      value: {
+        pathname: '/app/test-conversation-123',
+        hostname: 'gemini.google.com',
+      },
       writable: true,
       configurable: true,
     });
@@ -124,7 +134,11 @@ describe('draftSave', () => {
     // Check that a draft was saved to local storage
     const draftKey = 'gvDraft_/app/test-conversation-123';
     expect(localStore[draftKey]).toBeDefined();
-    const draft = localStore[draftKey] as { content: string; timestamp: number; path: string };
+    const draft = localStore[draftKey] as {
+      content: string;
+      timestamp: number;
+      path: string;
+    };
     expect(draft.content).toBe('Hello, this is my draft');
     expect(draft.path).toBe('/app/test-conversation-123');
 
@@ -142,7 +156,9 @@ describe('draftSave', () => {
     input.dispatchEvent(new Event('input', { bubbles: true }));
     vi.advanceTimersByTime(1000);
 
-    const draft = localStore['gvDraft_/app/test-conversation-123'] as { content: string };
+    const draft = localStore['gvDraft_/app/test-conversation-123'] as {
+      content: string;
+    };
     expect(draft.content).toBe('User draft');
 
     cleanup();
@@ -213,7 +229,9 @@ describe('draftSave', () => {
     input.dispatchEvent(new Event('input', { bubbles: true }));
     vi.advanceTimersByTime(1000);
 
-    const draft = localStore['gvDraft_/app/test-conversation-123'] as { content: string };
+    const draft = localStore['gvDraft_/app/test-conversation-123'] as {
+      content: string;
+    };
     expect(draft?.content).toBe('after enable');
 
     cleanup();
@@ -267,11 +285,7 @@ describe('draftSave', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    expect(document.execCommand).toHaveBeenCalledWith(
-      'insertText',
-      false,
-      'Recovered user text',
-    );
+    expect(document.execCommand).toHaveBeenCalledWith('insertText', false, 'Recovered user text');
 
     cleanup();
   });

--- a/src/pages/content/export/index.ts
+++ b/src/pages/content/export/index.ts
@@ -57,6 +57,7 @@ let responseActionObserver: MutationObserver | null = null;
 interface PendingExportState {
   format: ExportFormat;
   fontSize?: number;
+  imageWidth?: number;
   initialSelectedMessageId?: string;
   attempt: number;
   url: string;
@@ -255,7 +256,9 @@ function dedupeByTextAndOffset(elements: HTMLElement[], firstTurnOffset: number)
 }
 
 function ensureTurnId(el: Element, index: number): string {
-  const asEl = el as HTMLElement & { dataset?: DOMStringMap & { turnId?: string } };
+  const asEl = el as HTMLElement & {
+    dataset?: DOMStringMap & { turnId?: string };
+  };
   let id = asEl.dataset?.turnId || '';
   if (!id) {
     const basis = normalizeText(asEl.textContent || '') || `user-${index}`;
@@ -946,9 +949,13 @@ async function getLanguage(): Promise<AppLanguage> {
         try {
           const win = window as Window & {
             chrome?: {
-              storage?: { sync?: { get: (key: string, cb: (r: unknown) => void) => void } };
+              storage?: {
+                sync?: { get: (key: string, cb: (r: unknown) => void) => void };
+              };
             };
-            browser?: { storage?: { sync?: { get: (key: string) => Promise<unknown> } } };
+            browser?: {
+              storage?: { sync?: { get: (key: string) => Promise<unknown> } };
+            };
           };
           if (win.chrome?.storage?.sync?.get) {
             win.chrome.storage.sync.get(StorageKeys.LANGUAGE, resolve);
@@ -1166,10 +1173,12 @@ async function executeExportSequence(
   paramState?: PendingExportState,
   fontSize?: number,
   initialSelectedMessageId?: string,
+  imageWidth?: number,
 ): Promise<void> {
   const state: PendingExportState = paramState || {
     format,
     fontSize,
+    imageWidth,
     initialSelectedMessageId,
     attempt: 0,
     url: location.href,
@@ -1205,7 +1214,14 @@ async function executeExportSequence(
   if (!topNode) {
     console.log('[Gemini Voyager] No top node found, proceeding to export directly.');
     sessionStorage.removeItem(SESSION_KEY_PENDING_EXPORT);
-    await performFinalExport(format, dict, lang, state.fontSize, state.initialSelectedMessageId);
+    await performFinalExport(
+      format,
+      dict,
+      lang,
+      state.fontSize,
+      state.initialSelectedMessageId,
+      state.imageWidth,
+    );
     return;
   }
 
@@ -1217,7 +1233,11 @@ async function executeExportSequence(
   // Update state before action to persist across potential reload
   sessionStorage.setItem(
     SESSION_KEY_PENDING_EXPORT,
-    JSON.stringify({ ...state, attempt: state.attempt + 1, timestamp: Date.now() }),
+    JSON.stringify({
+      ...state,
+      attempt: state.attempt + 1,
+      timestamp: Date.now(),
+    }),
   );
 
   // Dispatch click logic
@@ -1252,7 +1272,14 @@ async function executeExportSequence(
 
   console.log('[Gemini Voyager] No refresh or update detected. Exporting...');
   sessionStorage.removeItem(SESSION_KEY_PENDING_EXPORT);
-  await performFinalExport(format, dict, lang, state.fontSize, state.initialSelectedMessageId);
+  await performFinalExport(
+    format,
+    dict,
+    lang,
+    state.fontSize,
+    state.initialSelectedMessageId,
+    state.imageWidth,
+  );
 }
 
 async function executeExportSequenceWithProgress(
@@ -1262,11 +1289,20 @@ async function executeExportSequenceWithProgress(
   paramState?: PendingExportState,
   fontSize?: number,
   initialSelectedMessageId?: string,
+  imageWidth?: number,
 ): Promise<void> {
   const t = (key: TranslationKey) => dict[lang]?.[key] ?? dict.en?.[key] ?? key;
   const hideProgress = showExportProgressOverlay(t);
   try {
-    await executeExportSequence(format, dict, lang, paramState, fontSize, initialSelectedMessageId);
+    await executeExportSequence(
+      format,
+      dict,
+      lang,
+      paramState,
+      fontSize,
+      initialSelectedMessageId,
+      imageWidth,
+    );
   } finally {
     hideProgress();
   }
@@ -1281,6 +1317,7 @@ async function performFinalExport(
   lang: AppLanguage,
   fontSize?: number,
   initialSelectedMessageId?: string,
+  imageWidth?: number,
 ) {
   const t = (key: TranslationKey) => dict[lang]?.[key] ?? dict.en?.[key] ?? key;
 
@@ -1633,6 +1670,7 @@ async function performFinalExport(
         format,
         fontSize,
         includeImageSource,
+        imageWidth,
       });
       const minVisiblePromise = new Promise((resolve) => setTimeout(resolve, 420));
       const [result] = await Promise.all([resultPromise, minVisiblePromise]);
@@ -1640,7 +1678,9 @@ async function performFinalExport(
       if (!result.success) {
         alert(resolveExportErrorMessage(result.error, t));
       } else if (format === 'pdf' && isSafari()) {
-        showExportToast(t('export_toast_safari_pdf_ready'), { autoDismissMs: 5000 });
+        showExportToast(t('export_toast_safari_pdf_ready'), {
+          autoDismissMs: 5000,
+        });
       }
     } catch (err) {
       console.error('[Gemini Voyager] Export error:', err);
@@ -1740,6 +1780,7 @@ async function checkPendingExport() {
     const state: PendingExportState = {
       format: parsed.format,
       fontSize: typeof parsed.fontSize === 'number' ? parsed.fontSize : undefined,
+      imageWidth: typeof parsed.imageWidth === 'number' ? parsed.imageWidth : undefined,
       initialSelectedMessageId:
         typeof parsed.initialSelectedMessageId === 'string'
           ? parsed.initialSelectedMessageId
@@ -1765,7 +1806,15 @@ async function checkPendingExport() {
     const dict = await loadDictionaries();
     const lang = await getLanguage();
 
-    await executeExportSequenceWithProgress(state.format, dict, lang, state);
+    await executeExportSequenceWithProgress(
+      state.format,
+      dict,
+      lang,
+      state,
+      state.fontSize,
+      state.initialSelectedMessageId,
+      state.imageWidth,
+    );
   } catch (e) {
     console.error('[Gemini Voyager] Failed to resume pending export:', e);
     sessionStorage.removeItem(SESSION_KEY_PENDING_EXPORT);
@@ -1894,7 +1943,9 @@ async function handleResponseCopyImageClick(
       title: getConversationTitleForExport(),
     };
 
-    const blob = await ImageExportService.renderConversationBlob(turnsForExport, metadata, {});
+    const blob = await ImageExportService.renderConversationBlob(turnsForExport, metadata, {
+      imageWidth: 620,
+    });
     blobForFallback = blob;
     await copyImageBlobToClipboard(blob);
     showExportToast(texts.copied);
@@ -2307,7 +2358,7 @@ async function showExportDialog(
   const dialog = new ExportDialog();
 
   dialog.show({
-    onExport: async (format, fontSize) => {
+    onExport: async (format, fontSize, imageWidth) => {
       try {
         await executeExportSequenceWithProgress(
           format,
@@ -2316,6 +2367,7 @@ async function showExportDialog(
           undefined,
           fontSize,
           options?.initialSelectedMessageId || undefined,
+          imageWidth,
         );
       } catch (err) {
         console.error('[Gemini Voyager] Export error:', err);
@@ -2335,6 +2387,10 @@ async function showExportDialog(
       export: t('pm_export'),
       fontSizeLabel: t('export_fontsize_label'),
       fontSizePreview: t('export_fontsize_preview'),
+      imageWidthLabel: t('export_image_width_label'),
+      imageWidthNarrow: t('export_image_width_narrow'),
+      imageWidthMedium: t('export_image_width_medium'),
+      imageWidthWide: t('export_image_width_wide'),
       formatDescriptions: {
         json: t('export_format_json_description'),
         markdown: t('export_format_markdown_description'),

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -12,7 +12,6 @@ import { findChatInput } from '../chatInput/index';
 import { getFolderColor, isDarkMode } from '../folder/folderColors';
 import type { FolderManager } from '../folder/manager';
 import { setInputText } from '../utils/inputHelper';
-
 import {
   buildInstructionBlock,
   hasInstructionBlock,
@@ -124,7 +123,7 @@ export function waitForElement(selector: string, timeoutMs: number): Promise<HTM
 function readInputText(input: HTMLElement): string {
   return input instanceof HTMLTextAreaElement
     ? input.value
-    : input.innerText ?? input.textContent ?? '';
+    : (input.innerText ?? input.textContent ?? '');
 }
 
 function clearPendingSendState(): void {


### PR DESCRIPTION
This PR addresses #484 by adding an image width selection to the export dialog.

### Changes:
- Added Narrow (620px), Medium (960px), and Wide (1360px) width options to the export dialog.
- Updated `ImageExportService` and `ConversationExportService` to handle dynamic rendering widths.
- Integrated width selection into both standard chat export and Deep Research reports.
- Added localization for English and Chinese.
- Ensured width preference persists during multi-step exports (scrolling/reloading).

Fixes #484
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
