### PR TITLE
fix(ui): prevent duplicate elements on repeated clicks

### DIFF
--- a/src/pages/content/draftSave/__tests__/draftSave.test.ts
+++ b/src/pages/content/draftSave/__tests__/draftSave.test.ts
@@ -267,11 +267,7 @@ describe('draftSave', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    expect(document.execCommand).toHaveBeenCalledWith(
-      'insertText',
-      false,
-      'Recovered user text',
-    );
+    expect(document.execCommand).toHaveBeenCalledWith('insertText', false, 'Recovered user text');
 
     cleanup();
   });

--- a/src/pages/content/folder/__tests__/duplicateClickGuards.test.ts
+++ b/src/pages/content/folder/__tests__/duplicateClickGuards.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FolderManager } from '../manager';
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    storage: {
+      sync: {
+        get: vi.fn(),
+        set: vi.fn(),
+      },
+      onChanged: {
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      },
+    },
+    runtime: {
+      id: 'test-extension-id',
+      lastError: null,
+    },
+  },
+}));
+
+vi.mock('@/utils/i18n', () => ({
+  getTranslationSync: (key: string) => key,
+  getTranslationSyncUnsafe: (key: string) => key,
+  initI18n: () => Promise.resolve(),
+}));
+
+type TestableManager = {
+  containerElement: HTMLElement | null;
+  activeFolderInput: HTMLElement | null;
+  activeImportDialog: HTMLElement | null;
+  activeImportExportMenu: HTMLElement | null;
+  createFolder: (parentId?: string | null) => void;
+  showImportDialog: () => void;
+  showImportExportMenu: (event: MouseEvent) => void;
+};
+
+function mountFolderList(manager: TestableManager): HTMLElement {
+  const container = document.createElement('div');
+  const list = document.createElement('div');
+  list.className = 'gv-folder-list';
+  container.appendChild(list);
+  document.body.appendChild(container);
+  manager.containerElement = container;
+  return list;
+}
+
+describe('folder duplicate click guards', () => {
+  let manager: FolderManager | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    manager?.destroy();
+    manager = null;
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('reuses the active folder input instead of creating duplicates', () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+    mountFolderList(typedManager);
+
+    typedManager.createFolder();
+
+    const input = document.querySelector('.gv-folder-name-input') as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+    expect(document.querySelectorAll('.gv-folder-inline-input')).toHaveLength(1);
+    expect(typedManager.activeFolderInput).not.toBeNull();
+
+    const focusTrap = document.createElement('button');
+    document.body.appendChild(focusTrap);
+    focusTrap.focus();
+    expect(document.activeElement).toBe(focusTrap);
+
+    typedManager.createFolder();
+
+    expect(document.querySelectorAll('.gv-folder-inline-input')).toHaveLength(1);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('toggles the import/export menu instead of stacking duplicates', () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.showImportExportMenu(
+      new MouseEvent('click', { bubbles: true, clientX: 24, clientY: 16 }),
+    );
+
+    expect(document.querySelectorAll('.gv-folder-menu')).toHaveLength(1);
+    expect(typedManager.activeImportExportMenu).not.toBeNull();
+
+    typedManager.showImportExportMenu(
+      new MouseEvent('click', { bubbles: true, clientX: 28, clientY: 20 }),
+    );
+
+    expect(document.querySelectorAll('.gv-folder-menu')).toHaveLength(0);
+    expect(typedManager.activeImportExportMenu).toBeNull();
+
+    vi.runOnlyPendingTimers();
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    typedManager.showImportExportMenu(
+      new MouseEvent('click', { bubbles: true, clientX: 32, clientY: 24 }),
+    );
+
+    expect(document.querySelectorAll('.gv-folder-menu')).toHaveLength(1);
+    expect(typedManager.activeImportExportMenu).not.toBeNull();
+  });
+
+  it('keeps the import dialog singleton and reopens cleanly after closing', () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.showImportDialog();
+
+    expect(document.querySelectorAll('.gv-folder-dialog-overlay')).toHaveLength(1);
+    expect(typedManager.activeImportDialog).not.toBeNull();
+
+    typedManager.showImportDialog();
+
+    expect(document.querySelectorAll('.gv-folder-dialog-overlay')).toHaveLength(1);
+
+    const cancelBtn = document.querySelector(
+      '.gv-folder-dialog-btn-secondary',
+    ) as HTMLButtonElement | null;
+    expect(cancelBtn).not.toBeNull();
+
+    cancelBtn?.click();
+
+    expect(document.querySelectorAll('.gv-folder-dialog-overlay')).toHaveLength(0);
+    expect(typedManager.activeImportDialog).toBeNull();
+
+    typedManager.showImportDialog();
+
+    expect(document.querySelectorAll('.gv-folder-dialog-overlay')).toHaveLength(1);
+    expect(typedManager.activeImportDialog).not.toBeNull();
+  });
+});

--- a/src/pages/content/folder/__tests__/duplicateClickGuards.test.ts
+++ b/src/pages/content/folder/__tests__/duplicateClickGuards.test.ts
@@ -32,7 +32,10 @@ type TestableManager = {
   activeFolderInput: HTMLElement | null;
   activeImportDialog: HTMLElement | null;
   activeImportExportMenu: HTMLElement | null;
+  reinitializePromise: Promise<void> | null;
   createFolder: (parentId?: string | null) => void;
+  initializeFolderUI: () => Promise<void>;
+  reinitializeFolderUI: () => void;
   showImportDialog: () => void;
   showImportExportMenu: (event: MouseEvent) => void;
 };
@@ -87,6 +90,30 @@ describe('folder duplicate click guards', () => {
     expect(document.activeElement).toBe(input);
   });
 
+  it('clears stale folder input state during reinitialize so creation stays usable', async () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+    mountFolderList(typedManager);
+
+    typedManager.createFolder();
+    expect(document.querySelectorAll('.gv-folder-inline-input')).toHaveLength(1);
+    expect(typedManager.activeFolderInput).not.toBeNull();
+
+    vi.spyOn(typedManager, 'initializeFolderUI').mockImplementation(async () => {
+      mountFolderList(typedManager);
+    });
+
+    typedManager.reinitializeFolderUI();
+    await typedManager.reinitializePromise;
+
+    expect(typedManager.activeFolderInput).toBeNull();
+
+    typedManager.createFolder();
+
+    expect(document.querySelectorAll('.gv-folder-inline-input')).toHaveLength(1);
+    expect(typedManager.activeFolderInput).not.toBeNull();
+  });
+
   it('toggles the import/export menu instead of stacking duplicates', () => {
     manager = new FolderManager();
     const typedManager = manager as unknown as TestableManager;
@@ -116,6 +143,33 @@ describe('folder duplicate click guards', () => {
     expect(typedManager.activeImportExportMenu).not.toBeNull();
   });
 
+  it('removes stale menu listeners when toggling closed before reopening', () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.showImportExportMenu(
+      new MouseEvent('click', { bubbles: true, clientX: 24, clientY: 16 }),
+    );
+    vi.runOnlyPendingTimers();
+
+    typedManager.showImportExportMenu(
+      new MouseEvent('click', { bubbles: true, clientX: 28, clientY: 20 }),
+    );
+    expect(typedManager.activeImportExportMenu).toBeNull();
+
+    typedManager.showImportExportMenu(
+      new MouseEvent('click', { bubbles: true, clientX: 32, clientY: 24 }),
+    );
+    vi.runOnlyPendingTimers();
+
+    const reopenedMenu = document.querySelector('.gv-folder-menu') as HTMLElement | null;
+    expect(reopenedMenu).not.toBeNull();
+    reopenedMenu?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(document.querySelectorAll('.gv-folder-menu')).toHaveLength(1);
+    expect(typedManager.activeImportExportMenu).toBe(reopenedMenu);
+  });
+
   it('keeps the import dialog singleton and reopens cleanly after closing', () => {
     manager = new FolderManager();
     const typedManager = manager as unknown as TestableManager;
@@ -143,5 +197,32 @@ describe('folder duplicate click guards', () => {
 
     expect(document.querySelectorAll('.gv-folder-dialog-overlay')).toHaveLength(1);
     expect(typedManager.activeImportDialog).not.toBeNull();
+  });
+
+  it('cleans up tracked UI overlays during destroy', () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+
+    mountFolderList(typedManager);
+    typedManager.createFolder();
+    typedManager.showImportDialog();
+    typedManager.showImportExportMenu(
+      new MouseEvent('click', { bubbles: true, clientX: 24, clientY: 16 }),
+    );
+    vi.runOnlyPendingTimers();
+
+    expect(document.querySelectorAll('.gv-folder-inline-input')).toHaveLength(1);
+    expect(document.querySelectorAll('.gv-folder-dialog-overlay')).toHaveLength(1);
+    expect(document.querySelectorAll('.gv-folder-menu')).toHaveLength(1);
+
+    manager.destroy();
+    manager = null;
+
+    expect(document.querySelectorAll('.gv-folder-inline-input')).toHaveLength(0);
+    expect(document.querySelectorAll('.gv-folder-dialog-overlay')).toHaveLength(0);
+    expect(document.querySelectorAll('.gv-folder-menu')).toHaveLength(0);
+    expect(typedManager.activeFolderInput).toBeNull();
+    expect(typedManager.activeImportDialog).toBeNull();
+    expect(typedManager.activeImportExportMenu).toBeNull();
   });
 });

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -139,6 +139,8 @@ export class FolderManager {
   private activeFolderInput: HTMLElement | null = null; // Currently open folder name input
   private activeImportExportMenu: HTMLElement | null = null; // Currently open import/export menu
   private activeImportDialog: HTMLElement | null = null; // Currently open import dialog
+  private activeImportExportMenuCloseHandler: ((e: MouseEvent) => void) | null = null;
+  private activeImportExportMenuListenerTimeout: number | null = null;
 
   // Cleanup references
   private routeChangeCleanup: (() => void) | null = null;
@@ -338,6 +340,10 @@ export class FolderManager {
       this.activeColorPickerFolderId = null;
     }
 
+    this.closeActiveImportExportMenu();
+    this.closeActiveImportDialog();
+    this.clearActiveFolderInput();
+
     // Remove container
     if (this.containerElement) {
       this.containerElement.remove();
@@ -353,6 +359,38 @@ export class FolderManager {
 
   private addCleanupTask(task: () => void): void {
     this.cleanupTasks.push(task);
+  }
+
+  private clearActiveFolderInput(): void {
+    this.activeFolderInput = null;
+  }
+
+  private closeActiveImportDialog(): void {
+    if (this.activeImportDialog) {
+      this.activeImportDialog.remove();
+      this.activeImportDialog = null;
+    }
+  }
+
+  private removeActiveImportExportMenuCloseHandler(): void {
+    if (this.activeImportExportMenuListenerTimeout !== null) {
+      clearTimeout(this.activeImportExportMenuListenerTimeout);
+      this.activeImportExportMenuListenerTimeout = null;
+    }
+
+    if (this.activeImportExportMenuCloseHandler) {
+      document.removeEventListener('click', this.activeImportExportMenuCloseHandler);
+      this.activeImportExportMenuCloseHandler = null;
+    }
+  }
+
+  private closeActiveImportExportMenu(): void {
+    if (this.activeImportExportMenu) {
+      this.activeImportExportMenu.remove();
+      this.activeImportExportMenu = null;
+    }
+
+    this.removeActiveImportExportMenuCloseHandler();
   }
 
   private async initializeFolderUI(): Promise<void> {
@@ -2006,6 +2044,10 @@ export class FolderManager {
         }
       }
 
+      this.closeActiveImportExportMenu();
+      this.closeActiveImportDialog();
+      this.clearActiveFolderInput();
+
       // Clear existing references so initialization starts from a clean slate
       this.containerElement = null;
       this.sidebarContainer = null;
@@ -2022,14 +2064,20 @@ export class FolderManager {
   }
 
   private createFolder(parentId: string | null = null): void {
+    if (this.activeFolderInput && !this.activeFolderInput.isConnected) {
+      this.clearActiveFolderInput();
+    }
+
     // Prevent creating multiple folder inputs simultaneously
     if (this.activeFolderInput) {
       // Focus existing input instead of creating a new one
       const existingInput = this.activeFolderInput.querySelector('input') as HTMLInputElement;
       if (existingInput) {
         existingInput.focus();
+        return;
       }
-      return;
+
+      this.clearActiveFolderInput();
     }
 
     // Create inline input for folder name
@@ -2062,7 +2110,7 @@ export class FolderManager {
       const name = input.value.trim();
       if (!name) {
         inputContainer.remove();
-        this.activeFolderInput = null;
+        this.clearActiveFolderInput();
         return;
       }
 
@@ -2087,7 +2135,7 @@ export class FolderManager {
 
     const cancel = () => {
       inputContainer.remove();
-      this.activeFolderInput = null;
+      this.clearActiveFolderInput();
     };
 
     saveBtn.addEventListener('click', save);
@@ -5243,7 +5291,7 @@ export class FolderManager {
     if (!this.containerElement) return;
 
     // Clear active folder input reference since the DOM will be replaced
-    this.activeFolderInput = null;
+    this.clearActiveFolderInput();
 
     // Find and update the folders list
     const oldList = this.containerElement.querySelector('.gv-folder-list');
@@ -6705,6 +6753,10 @@ export class FolderManager {
   }
 
   private showImportDialog(): void {
+    if (this.activeImportDialog && !this.activeImportDialog.isConnected) {
+      this.activeImportDialog = null;
+    }
+
     // Prevent creating multiple import dialogs simultaneously
     if (this.activeImportDialog) return;
 
@@ -6813,16 +6865,14 @@ export class FolderManager {
       } else {
         await this.handleImport(fileInput, strategy);
       }
-      overlay.remove();
-      this.activeImportDialog = null;
+      this.closeActiveImportDialog();
     });
 
     const cancelBtn = document.createElement('button');
     cancelBtn.className = 'gv-folder-dialog-btn gv-folder-dialog-btn-secondary';
     cancelBtn.textContent = this.t('pm_cancel');
     cancelBtn.addEventListener('click', () => {
-      overlay.remove();
-      this.activeImportDialog = null;
+      this.closeActiveImportDialog();
     });
 
     buttonsContainer.appendChild(cancelBtn);
@@ -6845,8 +6895,7 @@ export class FolderManager {
     // Close on overlay click
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) {
-        overlay.remove();
-        this.activeImportDialog = null;
+        this.closeActiveImportDialog();
       }
     });
   }
@@ -7190,10 +7239,14 @@ export class FolderManager {
   private showImportExportMenu(event: MouseEvent): void {
     event.stopPropagation();
 
+    if (this.activeImportExportMenu && !this.activeImportExportMenu.isConnected) {
+      this.activeImportExportMenu = null;
+      this.removeActiveImportExportMenuCloseHandler();
+    }
+
     // Remove existing menu if already open (toggle behavior)
     if (this.activeImportExportMenu) {
-      this.activeImportExportMenu.remove();
-      this.activeImportExportMenu = null;
+      this.closeActiveImportExportMenu();
       return;
     }
 
@@ -7223,9 +7276,8 @@ export class FolderManager {
 
       menuItem.innerHTML = `<mat-icon role="img" class="mat-icon notranslate google-symbols mat-ligature-font mat-icon-no-color" aria-hidden="true" style="font-size: 18px; line-height: 1; margin-right: 8px;">${item.icon}</mat-icon>${item.label}`;
       menuItem.addEventListener('click', () => {
+        this.closeActiveImportExportMenu();
         item.action();
-        menu.remove();
-        this.activeImportExportMenu = null;
       });
       menu.appendChild(menuItem);
     });
@@ -7238,12 +7290,14 @@ export class FolderManager {
     // Close menu on click outside
     const closeMenu = (e: MouseEvent) => {
       if (!menu.contains(e.target as Node)) {
-        menu.remove();
-        this.activeImportExportMenu = null;
-        document.removeEventListener('click', closeMenu);
+        this.closeActiveImportExportMenu();
       }
     };
-    setTimeout(() => document.addEventListener('click', closeMenu), 0);
+    this.activeImportExportMenuCloseHandler = closeMenu;
+    this.activeImportExportMenuListenerTimeout = window.setTimeout(() => {
+      document.addEventListener('click', closeMenu);
+      this.activeImportExportMenuListenerTimeout = null;
+    }, 0);
   }
 
   /**

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -134,6 +134,11 @@ export class FolderManager {
   private activeColorPickerFolderId: string | null = null; // Folder ID of currently open color picker
   private activeColorPickerCloseHandler: ((e: MouseEvent) => void) | null = null; // Event handler for closing color picker
 
+  // Track active UI elements to prevent duplicate creation
+  private activeFolderInput: HTMLElement | null = null; // Currently open folder name input
+  private activeImportExportMenu: HTMLElement | null = null; // Currently open import/export menu
+  private activeImportDialog: HTMLElement | null = null; // Currently open import dialog
+
   // Cleanup references
   private routeChangeCleanup: (() => void) | null = null;
   private sidebarClickListener: ((e: Event) => void) | null = null;
@@ -2016,6 +2021,16 @@ export class FolderManager {
   }
 
   private createFolder(parentId: string | null = null): void {
+    // Prevent creating multiple folder inputs simultaneously
+    if (this.activeFolderInput) {
+      // Focus existing input instead of creating a new one
+      const existingInput = this.activeFolderInput.querySelector('input') as HTMLInputElement;
+      if (existingInput) {
+        existingInput.focus();
+      }
+      return;
+    }
+
     // Create inline input for folder name
     const inputContainer = document.createElement('div');
     inputContainer.className = 'gv-folder-inline-input';
@@ -2046,6 +2061,7 @@ export class FolderManager {
       const name = input.value.trim();
       if (!name) {
         inputContainer.remove();
+        this.activeFolderInput = null;
         return;
       }
 
@@ -2070,6 +2086,7 @@ export class FolderManager {
 
     const cancel = () => {
       inputContainer.remove();
+      this.activeFolderInput = null;
     };
 
     saveBtn.addEventListener('click', save);
@@ -2100,6 +2117,9 @@ export class FolderManager {
       }
 
       input.focus();
+
+      // Track this input as the active one
+      this.activeFolderInput = inputContainer;
     }
   }
 
@@ -5221,6 +5241,9 @@ export class FolderManager {
   private refresh(): void {
     if (!this.containerElement) return;
 
+    // Clear active folder input reference since the DOM will be replaced
+    this.activeFolderInput = null;
+
     // Find and update the folders list
     const oldList = this.containerElement.querySelector('.gv-folder-list');
     if (oldList) {
@@ -6619,6 +6642,9 @@ export class FolderManager {
   }
 
   private showImportDialog(): void {
+    // Prevent creating multiple import dialogs simultaneously
+    if (this.activeImportDialog) return;
+
     // Create dialog overlay
     const overlay = document.createElement('div');
     overlay.className = 'gv-folder-dialog-overlay';
@@ -6725,12 +6751,16 @@ export class FolderManager {
         await this.handleImport(fileInput, strategy);
       }
       overlay.remove();
+      this.activeImportDialog = null;
     });
 
     const cancelBtn = document.createElement('button');
     cancelBtn.className = 'gv-folder-dialog-btn gv-folder-dialog-btn-secondary';
     cancelBtn.textContent = this.t('pm_cancel');
-    cancelBtn.addEventListener('click', () => overlay.remove());
+    cancelBtn.addEventListener('click', () => {
+      overlay.remove();
+      this.activeImportDialog = null;
+    });
 
     buttonsContainer.appendChild(cancelBtn);
     buttonsContainer.appendChild(importBtn);
@@ -6746,10 +6776,14 @@ export class FolderManager {
     // Add to body
     document.body.appendChild(overlay);
 
+    // Track this dialog as the active one
+    this.activeImportDialog = overlay;
+
     // Close on overlay click
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) {
         overlay.remove();
+        this.activeImportDialog = null;
       }
     });
   }
@@ -7093,6 +7127,13 @@ export class FolderManager {
   private showImportExportMenu(event: MouseEvent): void {
     event.stopPropagation();
 
+    // Remove existing menu if already open (toggle behavior)
+    if (this.activeImportExportMenu) {
+      this.activeImportExportMenu.remove();
+      this.activeImportExportMenu = null;
+      return;
+    }
+
     // Create context menu
     const menu = document.createElement('div');
     menu.className = 'gv-folder-menu';
@@ -7121,16 +7162,21 @@ export class FolderManager {
       menuItem.addEventListener('click', () => {
         item.action();
         menu.remove();
+        this.activeImportExportMenu = null;
       });
       menu.appendChild(menuItem);
     });
 
     document.body.appendChild(menu);
 
+    // Track this menu as the active one
+    this.activeImportExportMenu = menu;
+
     // Close menu on click outside
     const closeMenu = (e: MouseEvent) => {
       if (!menu.contains(e.target as Node)) {
         menu.remove();
+        this.activeImportExportMenu = null;
         document.removeEventListener('click', closeMenu);
       }
     };

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -12,7 +12,6 @@ import { findChatInput } from '../chatInput/index';
 import { getFolderColor, isDarkMode } from '../folder/folderColors';
 import type { FolderManager } from '../folder/manager';
 import { setInputText } from '../utils/inputHelper';
-
 import {
   buildInstructionBlock,
   hasInstructionBlock,
@@ -124,7 +123,7 @@ export function waitForElement(selector: string, timeoutMs: number): Promise<HTM
 function readInputText(input: HTMLElement): string {
   return input instanceof HTMLTextAreaElement
     ? input.value
-    : input.innerText ?? input.textContent ?? '';
+    : (input.innerText ?? input.textContent ?? '');
 }
 
 function clearPendingSendState(): void {


### PR DESCRIPTION
### Description / 描述

修复了在文件夹模块下，“导入/导出文件夹”和“创建文件夹”两个按钮多次点击后会被多次触发导致窗口多开的问题。

主要更改 (Changes Made)：
1. **引入状态锁 (State Tracking)**：在 `FolderManager` 中添加实例变量（`activeFolderInput`, `activeImportExportMenu`, `activeImportDialog`）来严格跟踪当前活跃的 UI 元素，实现单例行为。
2. **优化交互体验 (UX Improvements)**：
   - **添加文件夹**：如果输入框已存在，再次点击会聚焦现有输入框，而不是创建新的。
   - **导入/导出菜单**：实现了标准的 Toggle 逻辑，打开时再次点击即可关闭。
   - **导入对话框**：当模态框已激活时，静默拦截重复的触发事件。
3. **架构与性能优化 (Architecture & Performance)**：移除了原先依赖于全局 `MutationObserver` 监听 `document.body` 的实现方案。将状态清理逻辑明确绑定到相关 DOM 元素的 `.remove()` 生命周期中（如保存、取消或点击外部区域时），从根本上避免了潜在的内存泄漏和性能衰退。

### Related Issue / 相关 Issue

我已提出相关bug修复的[Issue #597](https://github.com/Nagi-ovo/gemini-voyager/issues/597)。

### Visual Proof / 可视化证据

问题图片已经在Issue中给出，这里只做在Firefox和Chrome浏览器上修复后的效果展示。
Firefox展示录屏如下：

https://github.com/user-attachments/assets/1f24e5d6-9866-459c-8890-095ae79f252c


Chrome界面展示录屏如下：

https://github.com/user-attachments/assets/eb49f22d-c77a-4967-b4f1-76314ffc9c25



### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [x] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
