### PR TITLE
feat(sidebarAutoHide): smooth animation and predictive aiming

### DIFF
--- a/src/pages/content/sidebarAutoHide/__tests__/SidebarAutoHide.test.ts
+++ b/src/pages/content/sidebarAutoHide/__tests__/SidebarAutoHide.test.ts
@@ -215,7 +215,10 @@ describe('sidebarAutoHide', () => {
       document.body.appendChild(toggleButton);
 
       (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-        (_defaults: Record<string, unknown>, callback: (result: Record<string, unknown>) => void) => {
+        (
+          _defaults: Record<string, unknown>,
+          callback: (result: Record<string, unknown>) => void,
+        ) => {
           callback({ gvSidebarAutoHide: true });
         },
       );
@@ -260,7 +263,10 @@ describe('sidebarAutoHide', () => {
       document.body.appendChild(toggleButton);
 
       (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-        (_defaults: Record<string, unknown>, callback: (result: Record<string, unknown>) => void) => {
+        (
+          _defaults: Record<string, unknown>,
+          callback: (result: Record<string, unknown>) => void,
+        ) => {
           callback({ gvSidebarAutoHide: true });
         },
       );
@@ -272,9 +278,7 @@ describe('sidebarAutoHide', () => {
 
       // Slow movement: x drops from 90 to 80 over 60ms.
       // Velocity: (80 - 90) / 60 = -0.17 px/ms — below -0.5 threshold.
-      vi.spyOn(performance, 'now')
-        .mockReturnValueOnce(2000)
-        .mockReturnValueOnce(2060);
+      vi.spyOn(performance, 'now').mockReturnValueOnce(2000).mockReturnValueOnce(2060);
 
       dispatchMouseMove(90);
       dispatchMouseMove(80);
@@ -302,7 +306,10 @@ describe('sidebarAutoHide', () => {
       document.body.appendChild(toggleButton);
 
       (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-        (_defaults: Record<string, unknown>, callback: (result: Record<string, unknown>) => void) => {
+        (
+          _defaults: Record<string, unknown>,
+          callback: (result: Record<string, unknown>) => void,
+        ) => {
           callback({ gvSidebarAutoHide: true });
         },
       );
@@ -313,9 +320,7 @@ describe('sidebarAutoHide', () => {
       vi.advanceTimersByTime(600);
 
       // Trigger predictive expand
-      vi.spyOn(performance, 'now')
-        .mockReturnValueOnce(3000)
-        .mockReturnValueOnce(3060);
+      vi.spyOn(performance, 'now').mockReturnValueOnce(3000).mockReturnValueOnce(3060);
 
       dispatchMouseMove(200);
       dispatchMouseMove(60);

--- a/src/pages/content/sidebarAutoHide/__tests__/SidebarAutoHide.test.ts
+++ b/src/pages/content/sidebarAutoHide/__tests__/SidebarAutoHide.test.ts
@@ -92,7 +92,7 @@ describe('sidebarAutoHide', () => {
     startSidebarAutoHide();
 
     sidenav.dispatchEvent(new Event('mouseenter'));
-    vi.advanceTimersByTime(150);
+    vi.advanceTimersByTime(80); // shorter than new ENTER_DELAY_MS (150ms) — timer must not fire
     sidenav.dispatchEvent(new Event('mouseleave'));
     vi.advanceTimersByTime(400);
 
@@ -171,20 +171,162 @@ describe('sidebarAutoHide', () => {
     const { startSidebarAutoHide } = await import('../index');
     startSidebarAutoHide();
 
-    vi.advanceTimersByTime(300);
+    // Advance past the 500ms initial-collapse timer (enable()) so it fires on an already-collapsed
+    // sidebar (no-op). This prevents it from interfering after the edge trigger expand.
+    vi.advanceTimersByTime(600);
     const edgeTrigger = document.getElementById('gv-sidebar-edge-trigger');
     expect(edgeTrigger).not.toBeNull();
 
     edgeTrigger?.dispatchEvent(new Event('mouseenter'));
-    vi.advanceTimersByTime(300);
+    vi.advanceTimersByTime(200); // new ENTER_DELAY_MS is 150ms — timer fires within this window
 
     expect(toggleSpy).toHaveBeenCalledTimes(1);
     expect(collapsedContainer.classList.contains('collapsed')).toBe(false);
 
     sidenav.dispatchEvent(new Event('mouseleave'));
-    vi.advanceTimersByTime(600);
+    vi.advanceTimersByTime(500); // new LEAVE_DELAY_MS is 400ms — timer fires within this window
 
     expect(toggleSpy).toHaveBeenCalledTimes(2);
     expect(collapsedContainer.classList.contains('collapsed')).toBe(true);
+  });
+
+  describe('predictive aiming', () => {
+    function dispatchMouseMove(x: number): void {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: 400 }));
+    }
+
+    it('expands sidebar when mouse approaches left edge at high velocity', async () => {
+      const sidenav = document.createElement('bard-sidenav');
+      mockVisibleRect(sidenav, 320, 800);
+
+      const sideNavigationContent = document.createElement('side-navigation-content');
+      const collapsedContainer = document.createElement('div');
+      collapsedContainer.className = 'collapsed';
+      sideNavigationContent.appendChild(collapsedContainer);
+      sidenav.appendChild(sideNavigationContent);
+      document.body.appendChild(sidenav);
+
+      const toggleButton = document.createElement('button');
+      toggleButton.setAttribute('data-test-id', 'side-nav-menu-button');
+      const toggleSpy = vi.fn(() => {
+        collapsedContainer.classList.toggle('collapsed');
+      });
+      toggleButton.addEventListener('click', toggleSpy);
+      document.body.appendChild(toggleButton);
+
+      (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        (_defaults: Record<string, unknown>, callback: (result: Record<string, unknown>) => void) => {
+          callback({ gvSidebarAutoHide: true });
+        },
+      );
+
+      const { startSidebarAutoHide } = await import('../index');
+      startSidebarAutoHide();
+
+      // Let initial collapse timer fire (sidebar already collapsed → no-op)
+      vi.advanceTimersByTime(600);
+      expect(toggleSpy).not.toHaveBeenCalled();
+
+      // Simulate mouse moving fast toward the left edge:
+      // Two samples 60ms apart (> 50ms throttle), x drops from 200 to 60.
+      // Velocity: (60 - 200) / 60 = -2.33 px/ms — well past -0.5 threshold.
+      // Second sample x=60 is inside the 100px predictive zone.
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(1000) // first sample
+        .mockReturnValueOnce(1060); // second sample — 60ms later
+
+      dispatchMouseMove(200); // first sample: establishes baseline, no trigger
+      dispatchMouseMove(60); // second sample: in zone + fast enough → trigger!
+
+      expect(toggleSpy).toHaveBeenCalledTimes(1);
+      expect(collapsedContainer.classList.contains('collapsed')).toBe(false);
+    });
+
+    it('does not expand when mouse is slow (below velocity threshold)', async () => {
+      const sidenav = document.createElement('bard-sidenav');
+      mockVisibleRect(sidenav, 320, 800);
+
+      const sideNavigationContent = document.createElement('side-navigation-content');
+      const collapsedContainer = document.createElement('div');
+      collapsedContainer.className = 'collapsed';
+      sideNavigationContent.appendChild(collapsedContainer);
+      sidenav.appendChild(sideNavigationContent);
+      document.body.appendChild(sidenav);
+
+      const toggleButton = document.createElement('button');
+      toggleButton.setAttribute('data-test-id', 'side-nav-menu-button');
+      const toggleSpy = vi.fn();
+      toggleButton.addEventListener('click', toggleSpy);
+      document.body.appendChild(toggleButton);
+
+      (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        (_defaults: Record<string, unknown>, callback: (result: Record<string, unknown>) => void) => {
+          callback({ gvSidebarAutoHide: true });
+        },
+      );
+
+      const { startSidebarAutoHide } = await import('../index');
+      startSidebarAutoHide();
+
+      vi.advanceTimersByTime(600);
+
+      // Slow movement: x drops from 90 to 80 over 60ms.
+      // Velocity: (80 - 90) / 60 = -0.17 px/ms — below -0.5 threshold.
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(2000)
+        .mockReturnValueOnce(2060);
+
+      dispatchMouseMove(90);
+      dispatchMouseMove(80);
+
+      expect(toggleSpy).not.toHaveBeenCalled();
+    });
+
+    it('auto-collapses via safety timer when mouse never enters sidebar', async () => {
+      const sidenav = document.createElement('bard-sidenav');
+      mockVisibleRect(sidenav, 320, 800);
+
+      const sideNavigationContent = document.createElement('side-navigation-content');
+      const collapsedContainer = document.createElement('div');
+      collapsedContainer.className = 'collapsed';
+      sideNavigationContent.appendChild(collapsedContainer);
+      sidenav.appendChild(sideNavigationContent);
+      document.body.appendChild(sidenav);
+
+      const toggleButton = document.createElement('button');
+      toggleButton.setAttribute('data-test-id', 'side-nav-menu-button');
+      const toggleSpy = vi.fn(() => {
+        collapsedContainer.classList.toggle('collapsed');
+      });
+      toggleButton.addEventListener('click', toggleSpy);
+      document.body.appendChild(toggleButton);
+
+      (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        (_defaults: Record<string, unknown>, callback: (result: Record<string, unknown>) => void) => {
+          callback({ gvSidebarAutoHide: true });
+        },
+      );
+
+      const { startSidebarAutoHide } = await import('../index');
+      startSidebarAutoHide();
+
+      vi.advanceTimersByTime(600);
+
+      // Trigger predictive expand
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(3000)
+        .mockReturnValueOnce(3060);
+
+      dispatchMouseMove(200);
+      dispatchMouseMove(60);
+
+      expect(toggleSpy).toHaveBeenCalledTimes(1); // expanded
+      expect(collapsedContainer.classList.contains('collapsed')).toBe(false);
+
+      // User never enters the sidebar → safety collapse fires after 1200ms
+      vi.advanceTimersByTime(1300);
+      expect(toggleSpy).toHaveBeenCalledTimes(2); // collapsed back
+      expect(collapsedContainer.classList.contains('collapsed')).toBe(true);
+    });
   });
 });

--- a/src/pages/content/sidebarAutoHide/index.ts
+++ b/src/pages/content/sidebarAutoHide/index.ts
@@ -433,7 +433,13 @@ function resetPredictiveState(): void {
 function handlePredictiveMouseMove(e: MouseEvent): void {
   if (!enabled && !fullHideEnabled) return;
   if (!isSidebarCollapsed()) return;
-  if (predictiveTriggered) return;
+  // If the sidebar is collapsed while the flag is still set, it was collapsed
+  // by an external path (manual toggle, full-hide sync, etc.) that did not
+  // call resetPredictiveState(). Clear the stale latch so the next swipe works.
+  if (predictiveTriggered) {
+    resetPredictiveState();
+    return;
+  }
   if (isPaused()) return;
 
   const now = performance.now();
@@ -466,13 +472,11 @@ function handlePredictiveMouseMove(e: MouseEvent): void {
         // Safety net: if the mouse never actually enters the sidebar
         // (user changed direction mid-flight), auto-collapse after a
         // generous window. handleMouseEnter will clear this if triggered.
-        if (enabled) {
-          leaveTimeoutId = window.setTimeout(() => {
-            leaveTimeoutId = null;
-            if (!enabled) return;
-            collapseSidebar();
-          }, PREDICTIVE_SAFETY_COLLAPSE_MS);
-        }
+        leaveTimeoutId = window.setTimeout(() => {
+          leaveTimeoutId = null;
+          if (!enabled && !fullHideEnabled) return;
+          collapseSidebar();
+        }, PREDICTIVE_SAFETY_COLLAPSE_MS);
 
         lastMouseX = x;
         lastMouseTime = now;

--- a/src/pages/content/sidebarAutoHide/index.ts
+++ b/src/pages/content/sidebarAutoHide/index.ts
@@ -20,11 +20,11 @@ const FULL_HIDE_COLLAPSED_CLASS = 'gv-sidebar-full-hide-collapsed';
 const SIDEBAR_TOGGLE_BUTTON_SELECTOR =
   'button[data-test-id="side-nav-menu-button"], side-nav-menu-button button';
 const SIDEBAR_TOGGLE_BUTTON_MATCH_SELECTOR = `${SIDEBAR_TOGGLE_BUTTON_SELECTOR}, side-nav-menu-button`;
-const SIDEBAR_STATE_SYNC_DELAYS_MS = [0, 120, 360] as const;
+const SIDEBAR_STATE_SYNC_DELAYS_MS = [0, 300, 500] as const;
 
 // Debounce delay to avoid rapid toggling
-const LEAVE_DELAY_MS = 500;
-const ENTER_DELAY_MS = 300;
+const LEAVE_DELAY_MS = 400;
+const ENTER_DELAY_MS = 150;
 // Interval to check for sidenav element reappearing
 const SIDENAV_CHECK_INTERVAL_MS = 1000;
 // Debounce delay for resize events
@@ -33,6 +33,16 @@ const RESIZE_DEBOUNCE_MS = 200;
 const MENU_CLICK_PAUSE_MS = 1500;
 // Width of the invisible edge trigger zone (px)
 const EDGE_TRIGGER_WIDTH = 6;
+// ── Predictive aiming ──
+// When the mouse is within this distance (px) from the left edge AND moving
+// leftward faster than the velocity threshold, we pre-trigger expansion before
+// mouseenter fires, eliminating the perceived "wait" completely.
+const PREDICTIVE_ZONE_WIDTH = 100;
+const PREDICTIVE_VELOCITY_THRESHOLD = -0.5; // px/ms (negative = leftward)
+const PREDICTIVE_THROTTLE_MS = 50;
+// If mouse triggers predictive expand but never enters the sidebar, auto-collapse
+// after this safety window.
+const PREDICTIVE_SAFETY_COLLAPSE_MS = 1200;
 const CUSTOM_POPUP_SELECTORS = [
   '.gv-folder-dialog',
   '.gv-folder-dialog-overlay',
@@ -53,6 +63,13 @@ let pausedUntil = 0;
 // Full-hide state
 let fullHideEnabled = false;
 let edgeTriggerElement: HTMLElement | null = null;
+
+// Predictive aiming state
+let predictiveTriggered = false;
+let lastMouseX: number | null = null;
+let lastMouseTime: number | null = null;
+let lastMoveProcessedTime = 0;
+let predictiveMouseMoveHandler: ((e: MouseEvent) => void) | null = null;
 
 // Shared infrastructure
 let observer: MutationObserver | null = null;
@@ -80,7 +97,8 @@ function getTransitionStyle(): string {
     bard-sidenav,
     bard-sidenav side-navigation-content,
     bard-sidenav side-navigation-content > div {
-      transition: width 0.25s ease, transform 0.25s ease !important;
+      transition: width 0.22s cubic-bezier(0.4, 0, 0.2, 1), transform 0.22s cubic-bezier(0.4, 0, 0.2, 1) !important;
+      will-change: width, transform;
     }
   `;
 }
@@ -385,6 +403,7 @@ function collapseSidebar(): void {
   if (!isSidebarCollapsed()) {
     if (clickToggleButton()) {
       autoCollapsed = true;
+      resetPredictiveState();
     }
   }
 }
@@ -393,9 +412,90 @@ function expandSidebar(): void {
   if (isSidebarCollapsed()) {
     clickToggleButton();
     autoCollapsed = false;
-    // Schedule a reattach so auto-hide listeners are re-added after expansion
-    setTimeout(() => checkAndReattach(), 350);
+    // Schedule a reattach so auto-hide listeners are re-added after expansion.
+    // Must fire after the 220ms CSS transition completes to avoid mid-animation DOM updates.
+    setTimeout(() => checkAndReattach(), 450);
   }
+}
+
+// ─── Predictive Aiming ────────────────────────────────────────────────
+// Inspired by the "Amazon mega-menu" trick: track mouse velocity on
+// document-level mousemove. When the cursor is near the left edge AND
+// heading leftward fast, pre-trigger expand *before* mouseenter fires,
+// removing the perceptual gap entirely.
+
+function resetPredictiveState(): void {
+  predictiveTriggered = false;
+  lastMouseX = null;
+  lastMouseTime = null;
+}
+
+function handlePredictiveMouseMove(e: MouseEvent): void {
+  if (!enabled && !fullHideEnabled) return;
+  if (!isSidebarCollapsed()) return;
+  if (predictiveTriggered) return;
+  if (isPaused()) return;
+
+  const now = performance.now();
+  if (now - lastMoveProcessedTime < PREDICTIVE_THROTTLE_MS) return;
+  lastMoveProcessedTime = now;
+
+  const x = e.clientX;
+
+  if (lastMouseX !== null && lastMouseTime !== null) {
+    const dt = now - lastMouseTime;
+    // Only use recent samples; ignore stale data (e.g. after tab switch)
+    if (dt > 0 && dt < 200) {
+      const vx = (x - lastMouseX) / dt; // px/ms, negative = leftward
+
+      if (x <= PREDICTIVE_ZONE_WIDTH && vx <= PREDICTIVE_VELOCITY_THRESHOLD) {
+        predictiveTriggered = true;
+
+        // Cancel any pending enter/leave timers to avoid double-action
+        if (enterTimeoutId !== null) {
+          window.clearTimeout(enterTimeoutId);
+          enterTimeoutId = null;
+        }
+        if (leaveTimeoutId !== null) {
+          window.clearTimeout(leaveTimeoutId);
+          leaveTimeoutId = null;
+        }
+
+        expandSidebar();
+
+        // Safety net: if the mouse never actually enters the sidebar
+        // (user changed direction mid-flight), auto-collapse after a
+        // generous window. handleMouseEnter will clear this if triggered.
+        if (enabled) {
+          leaveTimeoutId = window.setTimeout(() => {
+            leaveTimeoutId = null;
+            if (!enabled) return;
+            collapseSidebar();
+          }, PREDICTIVE_SAFETY_COLLAPSE_MS);
+        }
+
+        lastMouseX = x;
+        lastMouseTime = now;
+        return;
+      }
+    }
+  }
+
+  lastMouseX = x;
+  lastMouseTime = now;
+}
+
+function attachPredictiveListener(): void {
+  if (predictiveMouseMoveHandler) return;
+  predictiveMouseMoveHandler = handlePredictiveMouseMove;
+  document.addEventListener('mousemove', predictiveMouseMoveHandler, { passive: true });
+}
+
+function detachPredictiveListener(): void {
+  if (!predictiveMouseMoveHandler) return;
+  document.removeEventListener('mousemove', predictiveMouseMoveHandler);
+  predictiveMouseMoveHandler = null;
+  resetPredictiveState();
 }
 
 // ─── Mouse Event Handlers ──────────────────────────────────────────────
@@ -590,6 +690,7 @@ function enable(): void {
   insertTransitionStyle();
   attachEventListeners();
   ensureMenuClickHandler();
+  attachPredictiveListener();
 
   setupInfrastructure();
 
@@ -626,6 +727,7 @@ function disable(): void {
 
   if (!fullHideEnabled) {
     removeTransitionStyle();
+    detachPredictiveListener();
   }
 
   maybeRemoveMenuClickHandler();
@@ -661,6 +763,7 @@ function enableFullHide(): void {
   insertFullHideStyle();
   createEdgeTrigger();
   ensureMenuClickHandler();
+  attachPredictiveListener();
 
   setupInfrastructure();
   syncFullHideState();
@@ -683,6 +786,7 @@ function disableFullHide(): void {
 
   if (!enabled) {
     removeTransitionStyle();
+    detachPredictiveListener();
   }
 
   maybeRemoveMenuClickHandler();


### PR DESCRIPTION
## Summary
- **CSS 过渡优化**: 缓动曲线从 `ease` 改为 Material Design 标准 `cubic-bezier(0.4, 0, 0.2, 1)`，添加 `will-change` 提示浏览器预合成
- **时序调优**: 展开延迟 300→150ms，收起延迟 500→400ms，过渡时长 0.25→0.22s，状态同步避开动画中途
- **预测性触发 (Predictive Aiming)**: 借鉴"亚马逊菜单"算法，监测鼠标速度向量——当光标在左侧 100px 区域内高速向左移动时，跳过 mouseenter + delay 直接展开侧边栏，从根本上消除感知延迟

Closes #601

## Test plan
- [x] `bun run typecheck` 通过
- [x] `bun run lint` 零 error
- [x] `bun run test` 760 tests 全通过（含 3 个新增预测性触发测试）
- [x] `bun run build:chrome` 构建成功
- [ ] 手动测试：鼠标快速甩向左侧边缘，侧边栏应在鼠标到达前开始展开
- [ ] 手动测试：鼠标缓慢移到左侧，不应误触发预测展开
- [ ] 手动测试：预测展开后鼠标改变方向未进入侧边栏，1.2s 后应自动收起

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
