### PR TITLE
feat(sendBehavior): fix Safari double-Enter-to-send issue

### DIFF
--- a/src/core/services/SettingsBackupService.ts
+++ b/src/core/services/SettingsBackupService.ts
@@ -65,6 +65,7 @@ export const BACKUPABLE_SYNC_SETTINGS_DEFAULTS: Record<string, unknown> = {
   [StorageKeys.MERMAID_ENABLED]: true,
   [StorageKeys.QUOTE_REPLY_ENABLED]: true,
   [StorageKeys.CTRL_ENTER_SEND]: false,
+  [StorageKeys.SAFARI_ENTER_FIX]: false,
   [StorageKeys.INPUT_COLLAPSE_ENABLED]: false,
   [StorageKeys.INPUT_COLLAPSE_WHEN_NOT_EMPTY]: false,
   [StorageKeys.DRAFT_AUTO_SAVE]: false,

--- a/src/core/types/common.ts
+++ b/src/core/types/common.ts
@@ -82,6 +82,7 @@ export const StorageKeys = {
 
   // Input behavior
   CTRL_ENTER_SEND: 'gvCtrlEnterSend',
+  SAFARI_ENTER_FIX: 'gvSafariEnterFix',
   INPUT_COLLAPSE_ENABLED: 'gvInputCollapseEnabled',
   INPUT_COLLAPSE_WHEN_NOT_EMPTY: 'gvInputCollapseWhenNotEmpty',
   DRAFT_AUTO_SAVE: 'gvDraftAutoSave',

--- a/src/locales/ar/messages.json
+++ b/src/locales/ar/messages.json
@@ -1079,6 +1079,14 @@
     "message": "اضغط {modifier}+Enter لإرسال الرسائل، Enter لإضافة سطر جديد",
     "description": "Modifier+Enter to send feature hint. {modifier} is replaced with ⌘ on macOS and Ctrl on other platforms"
   },
+  "safariEnterFix": {
+    "message": "إصلاح مفتاح Enter في Safari",
+    "description": "Toggle label for Safari Enter key fix feature"
+  },
+  "safariEnterFixHint": {
+    "message": "إرسال الرسائل بضغطة واحدة على Enter (إصلاح مشكلة الضغط المزدوج في Safari)",
+    "description": "Hint text for Safari Enter key fix feature"
+  },
   "draftAutoSave": {
     "message": "حفظ المسودة تلقائيًا",
     "description": "Toggle label for input draft auto-save feature"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1079,6 +1079,14 @@
     "message": "Press {modifier}+Enter to send messages, Enter to add a new line",
     "description": "Modifier+Enter to send feature hint. {modifier} is replaced with ⌘ on macOS and Ctrl on other platforms"
   },
+  "safariEnterFix": {
+    "message": "Fix Enter key on Safari",
+    "description": "Toggle label for Safari Enter key fix feature"
+  },
+  "safariEnterFixHint": {
+    "message": "Send messages with a single Enter press (fixes Safari's double-Enter issue)",
+    "description": "Hint text for Safari Enter key fix feature"
+  },
   "draftAutoSave": {
     "message": "Draft auto-save",
     "description": "Toggle label for input draft auto-save feature"

--- a/src/locales/es/messages.json
+++ b/src/locales/es/messages.json
@@ -1079,6 +1079,14 @@
     "message": "Presiona {modifier}+Enter para enviar mensajes, Enter para agregar una nueva línea",
     "description": "Modifier+Enter to send feature hint. {modifier} is replaced with ⌘ on macOS and Ctrl on other platforms"
   },
+  "safariEnterFix": {
+    "message": "Corregir tecla Enter en Safari",
+    "description": "Toggle label for Safari Enter key fix feature"
+  },
+  "safariEnterFixHint": {
+    "message": "Enviar mensajes con una sola pulsación de Enter (corrige el problema de doble Enter en Safari)",
+    "description": "Hint text for Safari Enter key fix feature"
+  },
   "draftAutoSave": {
     "message": "Guardado automático de borrador",
     "description": "Toggle label for input draft auto-save feature"

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -1079,6 +1079,14 @@
     "message": "Appuyez sur {modifier}+Entrée pour envoyer, Entrée pour un saut de ligne",
     "description": "Modifier+Enter to send feature hint. {modifier} is replaced with ⌘ on macOS and Ctrl on other platforms"
   },
+  "safariEnterFix": {
+    "message": "Corriger la touche Entrée sur Safari",
+    "description": "Toggle label for Safari Enter key fix feature"
+  },
+  "safariEnterFixHint": {
+    "message": "Envoyer les messages avec une seule pression sur Entrée (corrige le problème du double Entrée sur Safari)",
+    "description": "Hint text for Safari Enter key fix feature"
+  },
   "draftAutoSave": {
     "message": "Sauvegarde automatique du brouillon",
     "description": "Toggle label for input draft auto-save feature"

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -1079,6 +1079,14 @@
     "message": "{modifier}+Enter でメッセージを送信、Enter で改行",
     "description": "Modifier+Enter to send feature hint. {modifier} is replaced with ⌘ on macOS and Ctrl on other platforms"
   },
+  "safariEnterFix": {
+    "message": "Safari の Enter キーを修正",
+    "description": "Safari Enter キー修正機能のトグルラベル"
+  },
+  "safariEnterFixHint": {
+    "message": "Enter を1回押すだけでメッセージを送信（Safari の2回押し問題を修正）",
+    "description": "Safari Enter キー修正機能のヒントテキスト"
+  },
   "draftAutoSave": {
     "message": "下書きの自動保存",
     "description": "Toggle label for input draft auto-save feature"

--- a/src/locales/ko/messages.json
+++ b/src/locales/ko/messages.json
@@ -1079,6 +1079,14 @@
     "message": "{modifier}+Enter 를 눌러 메시지를 전송하고, Enter 로 줄바꿈을 합니다",
     "description": "Modifier+Enter to send feature hint. {modifier} is replaced with ⌘ on macOS and Ctrl on other platforms"
   },
+  "safariEnterFix": {
+    "message": "Safari Enter 키 수정",
+    "description": "Safari Enter 키 수정 기능 토글 라벨"
+  },
+  "safariEnterFixHint": {
+    "message": "Enter 한 번으로 메시지 전송 (Safari의 Enter 두 번 눌러야 하는 문제 수정)",
+    "description": "Safari Enter 키 수정 기능 힌트 텍스트"
+  },
   "draftAutoSave": {
     "message": "임시 저장 자동 저장",
     "description": "Toggle label for input draft auto-save feature"

--- a/src/locales/pt/messages.json
+++ b/src/locales/pt/messages.json
@@ -1079,6 +1079,14 @@
     "message": "Pressione {modifier}+Enter para enviar mensagens, Enter para nova linha",
     "description": "Modifier+Enter to send feature hint. {modifier} is replaced with ⌘ on macOS and Ctrl on other platforms"
   },
+  "safariEnterFix": {
+    "message": "Corrigir tecla Enter no Safari",
+    "description": "Toggle label for Safari Enter key fix feature"
+  },
+  "safariEnterFixHint": {
+    "message": "Enviar mensagens com um único Enter (corrige o problema do duplo Enter no Safari)",
+    "description": "Hint text for Safari Enter key fix feature"
+  },
   "draftAutoSave": {
     "message": "Salvamento automático de rascunho",
     "description": "Toggle label for input draft auto-save feature"

--- a/src/locales/ru/messages.json
+++ b/src/locales/ru/messages.json
@@ -1079,6 +1079,14 @@
     "message": "Нажмите {modifier}+Enter для отправки сообщений, Enter для новой строки",
     "description": "Modifier+Enter to send feature hint. {modifier} is replaced with ⌘ on macOS and Ctrl on other platforms"
   },
+  "safariEnterFix": {
+    "message": "Исправить клавишу Enter в Safari",
+    "description": "Toggle label for Safari Enter key fix feature"
+  },
+  "safariEnterFixHint": {
+    "message": "Отправка сообщений одним нажатием Enter (исправление проблемы двойного Enter в Safari)",
+    "description": "Hint text for Safari Enter key fix feature"
+  },
   "draftAutoSave": {
     "message": "Автосохранение черновика",
     "description": "Toggle label for input draft auto-save feature"

--- a/src/locales/zh/messages.json
+++ b/src/locales/zh/messages.json
@@ -1079,6 +1079,14 @@
     "message": "按 {modifier}+Enter 发送消息，Enter 键仅换行",
     "description": "Modifier+Enter 发送功能提示。{modifier} 在 macOS 上替换为 ⌘，其他平台替换为 Ctrl"
   },
+  "safariEnterFix": {
+    "message": "修复 Safari 回车键",
+    "description": "Safari 回车键修复功能的开关标签"
+  },
+  "safariEnterFixHint": {
+    "message": "按一次 Enter 即可发送消息（修复 Safari 需要按两次 Enter 的问题）",
+    "description": "Safari 回车键修复功能的提示文本"
+  },
   "draftAutoSave": {
     "message": "草稿自动保存",
     "description": "Toggle label for input draft auto-save feature"

--- a/src/locales/zh_TW/messages.json
+++ b/src/locales/zh_TW/messages.json
@@ -1039,6 +1039,14 @@
     "message": "按 {modifier}+Enter 傳送訊息，Enter 鍵僅換行",
     "description": "Modifier+Enter 傳送功能提示。{modifier} 在 macOS 上替換為 ⌘，其他平台替換為 Ctrl"
   },
+  "safariEnterFix": {
+    "message": "修復 Safari Enter 鍵",
+    "description": "Safari Enter 鍵修復功能的開關標籤"
+  },
+  "safariEnterFixHint": {
+    "message": "按一次 Enter 即可傳送訊息（修復 Safari 需按兩次 Enter 的問題）",
+    "description": "Safari Enter 鍵修復功能的提示文字"
+  },
   "draftAutoSave": {
     "message": "草稿自動儲存",
     "description": "Toggle label for input draft auto-save feature"

--- a/src/pages/content/sendBehavior/__tests__/sendBehavior.test.ts
+++ b/src/pages/content/sendBehavior/__tests__/sendBehavior.test.ts
@@ -2,11 +2,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { StorageKeys } from '@/core/types/common';
 
+// Mock browser detection for Safari Enter Fix tests
+vi.mock('@/core/utils/browser', () => ({
+  isSafari: vi.fn(() => false),
+}));
+
 function markElementVisible(element: HTMLElement): void {
   Object.defineProperty(element, 'offsetParent', {
     configurable: true,
     value: document.body,
   });
+}
+
+function firePlainEnter(target: HTMLElement): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    code: 'Enter',
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
 }
 
 function fireCtrlEnter(target: HTMLElement): KeyboardEvent {
@@ -122,6 +138,128 @@ describe('sendBehavior', () => {
     const event = fireCtrlEnter(input);
 
     expect(buttonClickSpy).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+
+    cleanup();
+  });
+});
+
+describe('safariEnterFix', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+
+    // Enable Safari Enter Fix, disable Ctrl+Enter Send
+    (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (_defaults: Record<string, unknown>, callback: (result: Record<string, unknown>) => void) => {
+        callback({
+          [StorageKeys.CTRL_ENTER_SEND]: false,
+          [StorageKeys.SAFARI_ENTER_FIX]: true,
+        });
+      },
+    );
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('clicks send button on plain Enter when on Safari', async () => {
+    // Mock isSafari to return true
+    const { isSafari } = await import('@/core/utils/browser');
+    (isSafari as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const inputContainer = document.createElement('div');
+    inputContainer.className = 'text-input-field';
+
+    const input = document.createElement('div');
+    input.setAttribute('contenteditable', 'true');
+
+    const sendButton = document.createElement('button');
+    sendButton.setAttribute('aria-label', 'Send message');
+    markElementVisible(sendButton);
+
+    inputContainer.append(input, sendButton);
+    document.body.append(inputContainer);
+
+    const sendClickSpy = vi.spyOn(sendButton, 'click');
+
+    const { startSendBehavior } = await import('../index');
+    const cleanup = await startSendBehavior();
+
+    const event = firePlainEnter(input);
+
+    expect(sendClickSpy).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+
+    cleanup();
+  });
+
+  it('does not click send button on plain Enter when not on Safari', async () => {
+    // Mock isSafari to return false
+    const { isSafari } = await import('@/core/utils/browser');
+    (isSafari as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const inputContainer = document.createElement('div');
+    inputContainer.className = 'text-input-field';
+
+    const input = document.createElement('div');
+    input.setAttribute('contenteditable', 'true');
+
+    const sendButton = document.createElement('button');
+    sendButton.setAttribute('aria-label', 'Send message');
+    markElementVisible(sendButton);
+
+    inputContainer.append(input, sendButton);
+    document.body.append(inputContainer);
+
+    const sendClickSpy = vi.spyOn(sendButton, 'click');
+
+    const { startSendBehavior } = await import('../index');
+    const cleanup = await startSendBehavior();
+
+    const event = firePlainEnter(input);
+
+    expect(sendClickSpy).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+
+    cleanup();
+  });
+
+  it('does not intercept Shift+Enter on Safari', async () => {
+    const { isSafari } = await import('@/core/utils/browser');
+    (isSafari as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const inputContainer = document.createElement('div');
+    inputContainer.className = 'text-input-field';
+
+    const input = document.createElement('div');
+    input.setAttribute('contenteditable', 'true');
+
+    const sendButton = document.createElement('button');
+    sendButton.setAttribute('aria-label', 'Send message');
+    markElementVisible(sendButton);
+
+    inputContainer.append(input, sendButton);
+    document.body.append(inputContainer);
+
+    const sendClickSpy = vi.spyOn(sendButton, 'click');
+
+    const { startSendBehavior } = await import('../index');
+    const cleanup = await startSendBehavior();
+
+    // Fire Shift+Enter
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      code: 'Enter',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    input.dispatchEvent(event);
+
+    expect(sendClickSpy).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
 
     cleanup();

--- a/src/pages/content/sendBehavior/index.ts
+++ b/src/pages/content/sendBehavior/index.ts
@@ -381,10 +381,12 @@ function disconnectObserver(): void {
 // ============================================================================
 
 /**
- * Check if at least one mode requires active listeners
+ * Check if at least one mode requires active listeners.
+ * Safari Enter Fix only activates on Safari to avoid unnecessary
+ * overhead on Chrome/Firefox (e.g. when the setting is synced from Safari).
  */
 function shouldBeActive(): boolean {
-  return isCtrlEnterSendEnabled || isSafariEnterFixEnabled;
+  return isCtrlEnterSendEnabled || (isSafariEnterFixEnabled && isSafari());
 }
 
 /**

--- a/src/pages/content/sendBehavior/index.ts
+++ b/src/pages/content/sendBehavior/index.ts
@@ -1,18 +1,27 @@
 /**
  * Send Behavior Module
  *
- * Modifies Gemini's input behavior:
- * - Enter key inserts a newline instead of sending
- * - Ctrl+Enter sends the message
+ * Modifies Gemini's input behavior with two independent modes:
  *
- * This feature is controlled by the `gvCtrlEnterSend` storage setting.
+ * 1. Ctrl+Enter Send (all browsers):
+ *    - Enter key inserts a newline instead of sending
+ *    - Ctrl+Enter sends the message
+ *    - Controlled by `gvCtrlEnterSend` storage setting
+ *
+ * 2. Safari Enter Fix (Safari only):
+ *    - Fixes Gemini's double-Enter-to-send bug on Safari
+ *    - Single Enter directly clicks the send button
+ *    - Controlled by `gvSafariEnterFix` storage setting
+ *
+ * If both are enabled, Ctrl+Enter Send takes priority (Enter → newline).
  *
  * ARCHITECTURE:
- * - Observer and listeners are ONLY active when the feature is enabled
- * - When disabled, no DOM observation or event handling occurs (zero performance overhead)
+ * - Observer and listeners are ONLY active when at least one mode is enabled
+ * - When both are disabled, no DOM observation or event handling occurs (zero performance overhead)
  * - Storage listener remains active to respond to setting changes
  */
 import { StorageKeys } from '@/core/types/common';
+import { isSafari } from '@/core/utils/browser';
 import { isExtensionContextInvalidatedError } from '@/core/utils/extensionContext';
 
 import { getTextOffset, setCaretPosition } from './utils';
@@ -47,7 +56,9 @@ const LOG_PREFIX = '[SendBehavior]';
 // State
 // ============================================================================
 
-let isEnabled = false;
+let isCtrlEnterSendEnabled = false;
+let isSafariEnterFixEnabled = false;
+let isListenersActive = false;
 let observer: MutationObserver | null = null;
 let cleanupFns: (() => void)[] = [];
 let storageListener:
@@ -214,10 +225,16 @@ function insertNewlineInTextarea(textarea: HTMLTextAreaElement): void {
 
 /**
  * Handle keydown events on the input area
+ *
+ * Two modes:
+ * - Ctrl+Enter Send: Enter → newline, Ctrl/Cmd+Enter → send
+ * - Safari Enter Fix: Plain Enter → directly click send button (bypasses Safari double-Enter bug)
+ *
+ * If both modes are enabled, Ctrl+Enter Send takes priority.
  */
 function handleKeyDown(event: KeyboardEvent): void {
-  // Early exit if feature is disabled (should not happen, but defensive check)
-  if (!isEnabled) return;
+  // Early exit if no mode is active (should not happen, but defensive check)
+  if (!isCtrlEnterSendEnabled && !isSafariEnterFixEnabled) return;
 
   // Fix for Issue 260: Ignore events during IME composition
   if (event.isComposing) return;
@@ -236,29 +253,48 @@ function handleKeyDown(event: KeyboardEvent): void {
   // and pressing Enter there should trigger the default submit action
   if (!isContentEditable && !isTextarea) return;
 
-  // Ctrl+Enter or Cmd+Enter: Send the message
-  if (event.ctrlKey || event.metaKey) {
-    // Pass the current input target context so we only find its corresponding send button
+  // --- Ctrl+Enter Send mode ---
+  if (isCtrlEnterSendEnabled) {
+    // Ctrl+Enter or Cmd+Enter: Send the message
+    if (event.ctrlKey || event.metaKey) {
+      const sendButton = findSendButton(target);
+      if (sendButton) {
+        event.preventDefault();
+        event.stopPropagation();
+        sendButton.click();
+      }
+      return;
+    }
+
+    // Shift+Enter: Default behavior (already inserts newline in most cases)
+    if (event.shiftKey) return;
+
+    // Plain Enter: Insert a newline instead of sending
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (isContentEditable) {
+      insertNewlineInContentEditable(target);
+    } else if (isTextarea) {
+      insertNewlineInTextarea(target as HTMLTextAreaElement);
+    }
+    return;
+  }
+
+  // --- Safari Enter Fix mode ---
+  // Only active when Ctrl+Enter Send is NOT enabled and we're on Safari
+  if (isSafariEnterFixEnabled && isSafari()) {
+    // Only handle plain Enter (no modifiers)
+    if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return;
+
+    // Find and click the send button directly, bypassing Gemini's
+    // broken double-Enter behavior on Safari
     const sendButton = findSendButton(target);
     if (sendButton) {
       event.preventDefault();
       event.stopPropagation();
       sendButton.click();
     }
-    return;
-  }
-
-  // Shift+Enter: Default behavior (already inserts newline in most cases)
-  if (event.shiftKey) return;
-
-  // Plain Enter: Insert a newline instead of sending
-  event.preventDefault();
-  event.stopPropagation();
-
-  if (isContentEditable) {
-    insertNewlineInContentEditable(target);
-  } else if (isTextarea) {
-    insertNewlineInTextarea(target as HTMLTextAreaElement);
   }
 }
 
@@ -345,25 +381,34 @@ function disconnectObserver(): void {
 // ============================================================================
 
 /**
- * Enable the feature: attach listeners and start observing
+ * Check if at least one mode requires active listeners
  */
-function enableFeature(): void {
-  if (isEnabled) return;
-
-  isEnabled = true;
-  attachToAllInputs();
-  setupObserver();
-
-  console.log(LOG_PREFIX, 'Feature enabled');
+function shouldBeActive(): boolean {
+  return isCtrlEnterSendEnabled || isSafariEnterFixEnabled;
 }
 
 /**
- * Disable the feature: remove all listeners and stop observing
+ * Activate listeners: attach to inputs and start observing.
+ * Called when transitioning from no active modes to at least one active mode.
  */
-function disableFeature(): void {
-  if (!isEnabled) return;
+function activateListeners(): void {
+  if (isListenersActive) return;
 
-  isEnabled = false;
+  isListenersActive = true;
+  attachToAllInputs();
+  setupObserver();
+
+  console.log(LOG_PREFIX, 'Listeners activated');
+}
+
+/**
+ * Deactivate listeners: remove all listeners and stop observing.
+ * Called when transitioning from active modes to no active modes.
+ */
+function deactivateListeners(): void {
+  if (!isListenersActive) return;
+
+  isListenersActive = false;
 
   // Remove all event listeners
   cleanupFns.forEach((fn) => fn());
@@ -372,7 +417,19 @@ function disableFeature(): void {
   // Stop observing DOM changes
   disconnectObserver();
 
-  console.log(LOG_PREFIX, 'Feature disabled');
+  console.log(LOG_PREFIX, 'Listeners deactivated');
+}
+
+/**
+ * Reconcile listener state based on current mode flags.
+ * Activates or deactivates listeners as needed.
+ */
+function reconcileListeners(): void {
+  if (shouldBeActive()) {
+    activateListeners();
+  } else {
+    deactivateListeners();
+  }
 }
 
 // ============================================================================
@@ -380,26 +437,33 @@ function disableFeature(): void {
 // ============================================================================
 
 /**
- * Load the enabled state from storage
+ * Load the enabled state from storage for both modes
  */
-async function loadSettings(): Promise<boolean> {
+async function loadSettings(): Promise<void> {
   return new Promise((resolve) => {
     try {
       if (!chrome.storage?.sync?.get) {
-        resolve(false);
+        resolve();
         return;
       }
-      chrome.storage.sync.get({ [StorageKeys.CTRL_ENTER_SEND]: false }, (result) => {
-        const enabled = result?.[StorageKeys.CTRL_ENTER_SEND] === true;
-        resolve(enabled);
-      });
+      chrome.storage.sync.get(
+        {
+          [StorageKeys.CTRL_ENTER_SEND]: false,
+          [StorageKeys.SAFARI_ENTER_FIX]: false,
+        },
+        (result) => {
+          isCtrlEnterSendEnabled = result?.[StorageKeys.CTRL_ENTER_SEND] === true;
+          isSafariEnterFixEnabled = result?.[StorageKeys.SAFARI_ENTER_FIX] === true;
+          resolve();
+        },
+      );
     } catch (error) {
       if (isExtensionContextInvalidatedError(error)) {
-        resolve(false);
+        resolve();
         return;
       }
       console.warn(LOG_PREFIX, 'Failed to load settings:', error);
-      resolve(false);
+      resolve();
     }
   });
 }
@@ -414,15 +478,20 @@ function setupStorageListener(): void {
 
   storageListener = (changes, areaName) => {
     if (areaName !== 'sync') return;
-    if (!(StorageKeys.CTRL_ENTER_SEND in changes)) return;
 
-    const newValue = changes[StorageKeys.CTRL_ENTER_SEND].newValue === true;
+    const hasCtrlEnterChange = StorageKeys.CTRL_ENTER_SEND in changes;
+    const hasSafariFixChange = StorageKeys.SAFARI_ENTER_FIX in changes;
 
-    if (newValue && !isEnabled) {
-      enableFeature();
-    } else if (!newValue && isEnabled) {
-      disableFeature();
+    if (!hasCtrlEnterChange && !hasSafariFixChange) return;
+
+    if (hasCtrlEnterChange) {
+      isCtrlEnterSendEnabled = changes[StorageKeys.CTRL_ENTER_SEND].newValue === true;
     }
+    if (hasSafariFixChange) {
+      isSafariEnterFixEnabled = changes[StorageKeys.SAFARI_ENTER_FIX].newValue === true;
+    }
+
+    reconcileListeners();
   };
 
   try {
@@ -439,7 +508,9 @@ function setupStorageListener(): void {
  * Cleanup all resources
  */
 function cleanup(): void {
-  disableFeature();
+  isCtrlEnterSendEnabled = false;
+  isSafariEnterFixEnabled = false;
+  deactivateListeners();
 
   if (storageListener) {
     try {
@@ -465,12 +536,12 @@ export async function startSendBehavior(): Promise<() => void> {
   // Always setup storage listener first (to respond to setting changes)
   setupStorageListener();
 
-  // Load initial setting and enable if needed
-  const initialEnabled = await loadSettings();
-  if (initialEnabled) {
-    enableFeature();
-  } else {
-    console.log(LOG_PREFIX, 'Feature disabled, skipping initialization');
+  // Load initial settings and activate if any mode is enabled
+  await loadSettings();
+  reconcileListeners();
+
+  if (!shouldBeActive()) {
+    console.log(LOG_PREFIX, 'All modes disabled, skipping initialization');
   }
 
   return cleanup;

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -2240,9 +2240,7 @@ export default function Popup() {
                     >
                       {t('safariEnterFix')}
                     </Label>
-                    <p className="text-muted-foreground mt-1 text-xs">
-                      {t('safariEnterFixHint')}
-                    </p>
+                    <p className="text-muted-foreground mt-1 text-xs">{t('safariEnterFixHint')}</p>
                   </div>
                   <Switch
                     id="safari-enter-fix"

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -330,6 +330,7 @@ interface SettingsUpdate {
   mermaidEnabled?: boolean;
   quoteReplyEnabled?: boolean;
   ctrlEnterSendEnabled?: boolean;
+  safariEnterFixEnabled?: boolean;
   draftAutoSaveEnabled?: boolean;
   sidebarAutoHideEnabled?: boolean;
   sidebarFullHideEnabled?: boolean;
@@ -442,6 +443,7 @@ export default function Popup() {
   const [quoteReplyEnabled, setQuoteReplyEnabled] = useState<boolean>(true);
   const [folderProjectEnabled, setFolderProjectEnabled] = useState<boolean>(false);
   const [ctrlEnterSendEnabled, setCtrlEnterSendEnabled] = useState<boolean>(false);
+  const [safariEnterFixEnabled, setSafariEnterFixEnabled] = useState<boolean>(false);
   const [draftAutoSaveEnabled, setDraftAutoSaveEnabled] = useState<boolean>(false);
   const [sidebarAutoHideEnabled, setSidebarAutoHideEnabled] = useState<boolean>(false);
   const [sidebarFullHideEnabled, setSidebarFullHideEnabled] = useState<boolean>(false);
@@ -542,6 +544,8 @@ export default function Popup() {
         payload[StorageKeys.FOLDER_PROJECT_ENABLED] = settings.folderProjectEnabled;
       if (typeof settings.ctrlEnterSendEnabled === 'boolean')
         payload.gvCtrlEnterSend = settings.ctrlEnterSendEnabled;
+      if (typeof settings.safariEnterFixEnabled === 'boolean')
+        payload[StorageKeys.SAFARI_ENTER_FIX] = settings.safariEnterFixEnabled;
       if (typeof settings.draftAutoSaveEnabled === 'boolean')
         payload[StorageKeys.DRAFT_AUTO_SAVE] = settings.draftAutoSaveEnabled;
       if (typeof settings.sidebarAutoHideEnabled === 'boolean')
@@ -878,6 +882,7 @@ export default function Popup() {
           gvQuoteReplyEnabled: true,
           [StorageKeys.FOLDER_PROJECT_ENABLED]: false,
           gvCtrlEnterSend: false,
+          [StorageKeys.SAFARI_ENTER_FIX]: false,
           [StorageKeys.DRAFT_AUTO_SAVE]: false,
           gvSidebarAutoHide: false,
           gvSidebarFullHide: false,
@@ -934,6 +939,7 @@ export default function Popup() {
           setQuoteReplyEnabled(res?.gvQuoteReplyEnabled !== false);
           setFolderProjectEnabled(res?.[StorageKeys.FOLDER_PROJECT_ENABLED] === true);
           setCtrlEnterSendEnabled(res?.gvCtrlEnterSend === true);
+          setSafariEnterFixEnabled(res?.[StorageKeys.SAFARI_ENTER_FIX] === true);
           setDraftAutoSaveEnabled(res?.[StorageKeys.DRAFT_AUTO_SAVE] === true);
           setSidebarAutoHideEnabled(res?.gvSidebarAutoHide === true);
           setSidebarFullHideEnabled(res?.gvSidebarFullHide === true);
@@ -2224,6 +2230,30 @@ export default function Popup() {
                   }}
                 />
               </div>
+              {/* Safari Enter Fix - only shown on Safari */}
+              {isSafariBrowser && (
+                <div className="group flex items-center justify-between">
+                  <div className="flex-1">
+                    <Label
+                      htmlFor="safari-enter-fix"
+                      className="group-hover:text-primary cursor-pointer text-sm font-medium transition-colors"
+                    >
+                      {t('safariEnterFix')}
+                    </Label>
+                    <p className="text-muted-foreground mt-1 text-xs">
+                      {t('safariEnterFixHint')}
+                    </p>
+                  </div>
+                  <Switch
+                    id="safari-enter-fix"
+                    checked={safariEnterFixEnabled}
+                    onChange={(e) => {
+                      setSafariEnterFixEnabled(e.target.checked);
+                      apply({ safariEnterFixEnabled: e.target.checked });
+                    }}
+                  />
+                </div>
+              )}
               {/* Draft Auto-Save */}
               <div className="group flex items-center justify-between">
                 <div className="flex-1">


### PR DESCRIPTION
## Summary
- Adds a **Safari Enter Fix** mode to the `sendBehavior` module that intercepts a single Enter keypress and directly clicks the send button, bypassing Gemini's broken double-Enter behavior on Safari
- The toggle is only visible in the popup settings on Safari browsers, with a runtime `isSafari()` guard in the content script as well
- Translations added for all 10 locales

Closes #611

## Changes
- `src/core/types/common.ts` — new `SAFARI_ENTER_FIX` StorageKey
- `src/core/services/SettingsBackupService.ts` — default value
- `src/pages/content/sendBehavior/index.ts` — dual-mode architecture (Ctrl+Enter Send + Safari Enter Fix) with `reconcileListeners` for activation
- `src/pages/popup/Popup.tsx` — new toggle (Safari-only visibility)
- `src/locales/*/messages.json` (10 files) — `safariEnterFix` / `safariEnterFixHint`
- `sendBehavior/__tests__/sendBehavior.test.ts` — 3 new tests for Safari fix

## Test plan
- [ ] Verify `bun run typecheck` passes
- [ ] Verify `bun run lint` passes (0 errors)
- [ ] Verify `bun run test` — 760 tests pass (3 new)
- [ ] Verify `bun run build:chrome` succeeds
- [ ] On Safari: enable toggle → single Enter sends message
- [ ] On Safari: Shift+Enter still inserts newline
- [ ] On Chrome/Firefox: toggle is not visible in popup
- [ ] When both Ctrl+Enter Send and Safari Fix are enabled, Ctrl+Enter Send takes priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
