### PR TITLE
fix(ui): fix CtrlEnterSend bugs

### DIFF
--- a/src/pages/content/sendBehavior/__tests__/sendBehavior.test.ts
+++ b/src/pages/content/sendBehavior/__tests__/sendBehavior.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { StorageKeys } from '@/core/types/common';
 
+import { getTextOffset, setCaretPosition } from '../utils';
+
 // Mock browser detection for Safari Enter Fix tests
 vi.mock('@/core/utils/browser', () => ({
   isSafari: vi.fn(() => false),
@@ -37,6 +39,88 @@ function fireCtrlEnter(target: HTMLElement): KeyboardEvent {
   return event;
 }
 
+function mockExecCommand(implementation: Document['execCommand']): ReturnType<typeof vi.fn> {
+  const execCommand = vi.fn(implementation);
+  Object.defineProperty(document, 'execCommand', {
+    configurable: true,
+    writable: true,
+    value: execCommand,
+  });
+
+  return execCommand;
+}
+
+function mockAnimationFrame(): ReturnType<typeof vi.fn> {
+  const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback): number => {
+    callback(16);
+    return 1;
+  });
+
+  vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock);
+  return requestAnimationFrameMock;
+}
+
+function setSelection(node: Node, offset: number): void {
+  const selection = window.getSelection();
+  if (!selection) throw new Error('Selection API unavailable');
+
+  const range = document.createRange();
+  range.setStart(node, offset);
+  range.collapse(true);
+
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function getSelectionRange(): Range {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) throw new Error('Selection range unavailable');
+  return selection.getRangeAt(0);
+}
+
+function getTextNode(element: Element): Text {
+  const node = element.firstChild;
+  if (!(node instanceof Text)) throw new Error('Expected a text node');
+  return node;
+}
+
+function createContentEditable(html: string): HTMLElement {
+  const input = document.createElement('div');
+  input.setAttribute('contenteditable', 'true');
+  input.innerHTML = html;
+  document.body.append(input);
+  return input;
+}
+
+function splitCurrentParagraph(input: HTMLElement): void {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) throw new Error('Selection range unavailable');
+
+  const range = selection.getRangeAt(0);
+  if (!(range.startContainer instanceof Text)) throw new Error('Expected text selection');
+
+  const paragraph = range.startContainer.parentElement;
+  if (!(paragraph instanceof HTMLParagraphElement)) throw new Error('Expected paragraph');
+
+  const text = range.startContainer.textContent ?? '';
+  const beforeText = text.slice(0, range.startOffset);
+  const afterText = text.slice(range.startOffset);
+  const beforeParagraph = document.createElement('p');
+  const afterParagraph = document.createElement('p');
+
+  beforeParagraph.textContent = beforeText;
+  if (afterText.length > 0) {
+    afterParagraph.textContent = afterText;
+  } else {
+    afterParagraph.append(document.createElement('br'));
+  }
+
+  paragraph.replaceWith(beforeParagraph, afterParagraph);
+
+  // Simulate an editor/browser leaving the selection somewhere unhelpful; sendBehavior must restore it.
+  setSelection(input, input.childNodes.length);
+}
+
 describe('sendBehavior', () => {
   beforeEach(() => {
     vi.resetModules();
@@ -52,6 +136,7 @@ describe('sendBehavior', () => {
 
   afterEach(() => {
     document.body.innerHTML = '';
+    vi.unstubAllGlobals();
   });
 
   it('clicks the send button within the main chat container, ignoring stale update buttons elsewhere', async () => {
@@ -141,6 +226,138 @@ describe('sendBehavior', () => {
     expect(event.defaultPrevented).toBe(false);
 
     cleanup();
+  });
+
+  it('inserts a textarea newline through execCommand when the browser command succeeds', async () => {
+    const textarea = document.createElement('textarea');
+    textarea.value = 'hello';
+    textarea.selectionStart = 2;
+    textarea.selectionEnd = 4;
+    document.body.append(textarea);
+
+    const inputSpy = vi.fn();
+    textarea.addEventListener('input', inputSpy);
+
+    const execCommand = mockExecCommand((command, _showUI, value) => {
+      if (command !== 'insertText') return false;
+      textarea.setRangeText(value ?? '', textarea.selectionStart, textarea.selectionEnd, 'end');
+      return true;
+    });
+
+    const { startSendBehavior } = await import('../index');
+    const cleanup = await startSendBehavior();
+
+    const event = firePlainEnter(textarea);
+
+    expect(execCommand).toHaveBeenCalledWith('insertText', false, '\n');
+    expect(textarea.value).toBe('he\no');
+    expect(textarea.selectionStart).toBe(3);
+    expect(textarea.selectionEnd).toBe(3);
+    expect(inputSpy).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+
+    cleanup();
+  });
+
+  it('falls back to direct textarea assignment when insertText execCommand fails', async () => {
+    const textarea = document.createElement('textarea');
+    textarea.value = 'hello';
+    textarea.selectionStart = 2;
+    textarea.selectionEnd = 4;
+    document.body.append(textarea);
+
+    const inputSpy = vi.fn();
+    textarea.addEventListener('input', inputSpy);
+
+    const execCommand = mockExecCommand(() => false);
+
+    const { startSendBehavior } = await import('../index');
+    const cleanup = await startSendBehavior();
+
+    const event = firePlainEnter(textarea);
+
+    expect(execCommand).toHaveBeenCalledWith('insertText', false, '\n');
+    expect(textarea.value).toBe('he\no');
+    expect(textarea.selectionStart).toBe(3);
+    expect(textarea.selectionEnd).toBe(3);
+    expect(inputSpy).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+
+    cleanup();
+  });
+
+  it('uses insertParagraph for contenteditable newline insertion and creates a separate paragraph', async () => {
+    mockAnimationFrame();
+
+    const input = createContentEditable('<p>hello</p>');
+    const paragraph = input.querySelector('p');
+    if (!paragraph) throw new Error('Expected paragraph');
+
+    setSelection(getTextNode(paragraph), 5);
+
+    const execCommand = mockExecCommand((command) => {
+      if (command !== 'insertParagraph') return false;
+      splitCurrentParagraph(input);
+      return true;
+    });
+
+    const { startSendBehavior } = await import('../index');
+    const cleanup = await startSendBehavior();
+
+    const event = firePlainEnter(input);
+
+    expect(execCommand).toHaveBeenCalledWith('insertParagraph', false);
+    expect(Array.from(input.children).map((child) => child.tagName)).toEqual(['P', 'P']);
+    expect(input.children[0].textContent).toBe('hello');
+    expect(input.children[1].innerHTML).toBe('<br>');
+    expect(event.defaultPrevented).toBe(true);
+
+    cleanup();
+  });
+
+  it('restores the caret after insertParagraph splits text in the middle', async () => {
+    mockAnimationFrame();
+
+    const input = createContentEditable('<p>hello world</p>');
+    const paragraph = input.querySelector('p');
+    if (!paragraph) throw new Error('Expected paragraph');
+
+    setSelection(getTextNode(paragraph), 5);
+
+    mockExecCommand((command) => {
+      if (command !== 'insertParagraph') return false;
+      splitCurrentParagraph(input);
+      return true;
+    });
+
+    const { startSendBehavior } = await import('../index');
+    const cleanup = await startSendBehavior();
+
+    firePlainEnter(input);
+
+    const secondParagraph = input.children[1];
+    const secondTextNode = getTextNode(secondParagraph);
+    const selectionRange = getSelectionRange();
+
+    expect(secondParagraph.textContent).toBe(' world');
+    expect(selectionRange.startContainer).toBe(secondTextNode);
+    expect(selectionRange.startOffset).toBe(0);
+    expect(getTextOffset(input)).toBe(6);
+
+    cleanup();
+  });
+
+  it('sets the caret inside an empty paragraph instead of falling back to the root end', () => {
+    const input = createContentEditable('<p>hello</p><p><br></p>');
+    const emptyParagraph = input.children[1];
+
+    setCaretPosition(input, 6);
+
+    const selectionRange = getSelectionRange();
+
+    expect(selectionRange.startContainer).toBe(emptyParagraph);
+    expect(selectionRange.startOffset).toBe(0);
+    expect(getTextOffset(input)).toBe(6);
   });
 });
 

--- a/src/pages/content/sendBehavior/index.ts
+++ b/src/pages/content/sendBehavior/index.ts
@@ -145,7 +145,7 @@ function findSendButton(inputElement: HTMLElement): HTMLElement | null {
  * because it manages its own DOM state.
  *
  * Strategy:
- * 1. First try document.execCommand('insertLineBreak') - works in most browsers
+ * 1. First try document.execCommand - works in most browsers
  * 2. If that fails, simulate a Shift+Enter keypress which Quill handles natively
  */
 function insertNewlineInContentEditable(target: HTMLElement): void {

--- a/src/pages/content/sendBehavior/index.ts
+++ b/src/pages/content/sendBehavior/index.ts
@@ -187,7 +187,16 @@ function insertNewlineInContentEditable(target: HTMLElement): void {
 function insertNewlineInTextarea(textarea: HTMLTextAreaElement): void {
   // add this line to prevent focus loss in Angular's internal Textarea updates
   textarea.focus();
-  document.execCommand('insertText', false, '\n');
+  const success = document.execCommand('insertText', false, '\n');
+
+  if (!success) {
+    // Fallback: direct value manipulation (loses undo history but guarantees insertion)
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const value = textarea.value;
+    textarea.value = value.substring(0, start) + '\n' + value.substring(end);
+    textarea.selectionStart = textarea.selectionEnd = start + 1;
+  }
 
   // Trigger input event to notify any listeners
   textarea.dispatchEvent(new Event('input', { bubbles: true }));

--- a/src/pages/content/sendBehavior/index.ts
+++ b/src/pages/content/sendBehavior/index.ts
@@ -185,12 +185,12 @@ function insertNewlineInContentEditable(target: HTMLElement): void {
  * Insert a newline in a textarea
  */
 function insertNewlineInTextarea(textarea: HTMLTextAreaElement): void {
-  // 建议添加此行, 以防Angular内部更新Textarea导致焦点丢失等特殊情况
+  // add this line to prevent focus loss in Angular's internal Textarea updates
   textarea.focus();
   document.execCommand('insertText', false, '\n');
 
-  // 跟Quill不同, 这里不需要重复的input event, 会自动触发input事件
-  // textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  // Trigger input event to notify any listeners
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
 // ============================================================================

--- a/src/pages/content/sendBehavior/index.ts
+++ b/src/pages/content/sendBehavior/index.ts
@@ -24,6 +24,8 @@ import { StorageKeys } from '@/core/types/common';
 import { isSafari } from '@/core/utils/browser';
 import { isExtensionContextInvalidatedError } from '@/core/utils/extensionContext';
 
+import { getTextOffset, setCaretPosition } from './utils';
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -151,9 +153,19 @@ function findSendButton(inputElement: HTMLElement): HTMLElement | null {
 function insertNewlineInContentEditable(target: HTMLElement): void {
   // Method 1: Try execCommand (deprecated but still works in most browsers)
   // This is the most reliable method for contenteditable elements
+  const currentOffset = getTextOffset(target);
+
   // This might trigger a React re-render, creating a new DOM structure
   const success = document.execCommand('insertParagraph', false);
   if (success) {
+    if (currentOffset !== null) {
+      const newOffset = currentOffset + 1;
+      const restoreCaret = () => setCaretPosition(target, newOffset);
+
+      restoreCaret();
+      requestAnimationFrame(restoreCaret);
+    }
+
     // Trigger input event to notify listeners (ensure data sync)
     target.dispatchEvent(new Event('input', { bubbles: true }));
     return;

--- a/src/pages/content/sendBehavior/index.ts
+++ b/src/pages/content/sendBehavior/index.ts
@@ -24,8 +24,6 @@ import { StorageKeys } from '@/core/types/common';
 import { isSafari } from '@/core/utils/browser';
 import { isExtensionContextInvalidatedError } from '@/core/utils/extensionContext';
 
-import { getTextOffset, setCaretPosition } from './utils';
-
 // ============================================================================
 // Constants
 // ============================================================================
@@ -153,31 +151,10 @@ function findSendButton(inputElement: HTMLElement): HTMLElement | null {
 function insertNewlineInContentEditable(target: HTMLElement): void {
   // Method 1: Try execCommand (deprecated but still works in most browsers)
   // This is the most reliable method for contenteditable elements
-  // 1. SNAPSHOT: Remember where the cursor is (text offset)
-  const currentOffset = getTextOffset(target);
-
-  // 2. EXECUTE: Native command
   // This might trigger a React re-render, creating a new DOM structure
-  const success = document.execCommand('insertLineBreak', false);
-
+  const success = document.execCommand('insertParagraph', false);
   if (success) {
-    // 3. RESTORE: Put the cursor back where it belongs
-    // Use requestAnimationFrame to wait for any immediate React re-renders to settle
-    if (currentOffset !== null) {
-      // +1 to account for the newly inserted newline character
-      const newOffset = currentOffset + 1;
-
-      // Try immediate restore (for synchronous DOM updates)
-      setCaretPosition(target, newOffset);
-
-      // Also try next frame (for asynchronous React updates)
-      requestAnimationFrame(() => {
-        setCaretPosition(target, newOffset);
-      });
-    }
-
     // Trigger input event to notify listeners (ensure data sync)
-    // NOTE: Maintainer's code had this. We kept it but manage the cursor consequence.
     target.dispatchEvent(new Event('input', { bubbles: true }));
     return;
   }
@@ -208,15 +185,12 @@ function insertNewlineInContentEditable(target: HTMLElement): void {
  * Insert a newline in a textarea
  */
 function insertNewlineInTextarea(textarea: HTMLTextAreaElement): void {
-  const start = textarea.selectionStart;
-  const end = textarea.selectionEnd;
-  const value = textarea.value;
+  // 建议添加此行, 以防Angular内部更新Textarea导致焦点丢失等特殊情况
+  textarea.focus();
+  document.execCommand('insertText', false, '\n');
 
-  textarea.value = value.substring(0, start) + '\n' + value.substring(end);
-  textarea.selectionStart = textarea.selectionEnd = start + 1;
-
-  // Trigger input event to notify any listeners
-  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  // 跟Quill不同, 这里不需要重复的input event, 会自动触发input事件
+  // textarea.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
 // ============================================================================

--- a/src/pages/content/sendBehavior/utils.ts
+++ b/src/pages/content/sendBehavior/utils.ts
@@ -1,9 +1,48 @@
 /**
  * Selection/Cursor Helpers
  *
- * Provides utilities to get/set cursor position based on pure text offset via TreeWalker.
- * This is robust against DOM re-renders as long as the text content remains consistent.
+ * Provides utilities to get/set cursor position based on a logical text offset.
+ * Paragraph/div boundaries and <br> elements are counted as logical newlines so
+ * offsets survive Quill's block-oriented DOM updates after insertParagraph.
  */
+
+const BLOCK_TAG_NAMES = new Set(['P', 'DIV']);
+
+interface CaretPoint {
+  node: Node;
+  offset: number;
+}
+
+interface CaretAnchor {
+  offset: number;
+  point: CaretPoint;
+  priority: number;
+}
+
+interface TextSegment {
+  kind: 'text';
+  node: Text;
+  startOffset: number;
+  endOffset: number;
+  before: CaretPoint;
+  after: CaretPoint;
+}
+
+interface NewlineSegment {
+  kind: 'newline';
+  startOffset: number;
+  endOffset: number;
+  before: CaretPoint;
+  after: CaretPoint;
+}
+
+type LogicalSegment = TextSegment | NewlineSegment;
+
+interface LogicalModel {
+  anchors: CaretAnchor[];
+  segments: LogicalSegment[];
+  totalOffset: number;
+}
 
 /**
  * Get the current cursor position as a global text offset relative to the root element.
@@ -13,14 +52,12 @@ export function getTextOffset(root: HTMLElement): number | null {
   if (!selection || selection.rangeCount === 0) return null;
 
   const range = selection.getRangeAt(0);
+  if (range.endContainer !== root && !root.contains(range.endContainer)) return null;
 
-  // Create a range that spans from the start of the root to the cursor
-  const preCaretRange = range.cloneRange();
-  preCaretRange.selectNodeContents(root);
-  preCaretRange.setEnd(range.endContainer, range.endOffset);
-
-  // The length of the string in that range is our offset
-  return preCaretRange.toString().length;
+  return getLogicalOffset(root, {
+    node: range.endContainer,
+    offset: range.endOffset,
+  });
 }
 
 /**
@@ -30,37 +67,202 @@ export function setCaretPosition(root: HTMLElement, targetOffset: number): void 
   const selection = window.getSelection();
   if (!selection) return;
 
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+  const model = buildLogicalModel(root);
+  const clampedOffset = Math.min(Math.max(targetOffset, 0), model.totalOffset);
+  const point = findCaretPoint(model, clampedOffset) ?? {
+    node: root,
+    offset: root.childNodes.length,
+  };
+
+  const range = document.createRange();
+  range.setStart(point.node, point.offset);
+  range.collapse(true);
+
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function buildLogicalModel(root: HTMLElement): LogicalModel {
+  const anchors: CaretAnchor[] = [
+    {
+      offset: 0,
+      point: { node: root, offset: 0 },
+      priority: 0,
+    },
+  ];
+  const segments: LogicalSegment[] = [];
   let currentOffset = 0;
-  let found = false;
+  let hasVisualLine = false;
 
-  while (walker.nextNode()) {
-    const node = walker.currentNode;
-    const length = node.textContent?.length || 0;
+  const addAnchor = (offset: number, point: CaretPoint, priority: number): void => {
+    anchors.push({ offset, point, priority });
+  };
 
-    if (currentOffset + length >= targetOffset) {
-      // The target is inside this node
-      const range = document.createRange();
-      const relativeOffset = targetOffset - currentOffset;
+  const addNewline = (before: CaretPoint, after: CaretPoint): void => {
+    const startOffset = currentOffset;
+    currentOffset += 1;
+    segments.push({
+      kind: 'newline',
+      startOffset,
+      endOffset: currentOffset,
+      before,
+      after,
+    });
+    addAnchor(currentOffset, after, 2);
+    hasVisualLine = true;
+  };
 
-      range.setStart(node, relativeOffset);
-      range.collapse(true);
+  const addText = (node: Text): void => {
+    const text = node.textContent ?? '';
+    if (text.length === 0) return;
 
-      selection.removeAllRanges();
-      selection.addRange(range);
-      found = true;
-      break;
+    const startOffset = currentOffset;
+    currentOffset += text.length;
+    segments.push({
+      kind: 'text',
+      node,
+      startOffset,
+      endOffset: currentOffset,
+      before: { node, offset: 0 },
+      after: { node, offset: text.length },
+    });
+    hasVisualLine = true;
+  };
+
+  const walkChildren = (parent: Node): void => {
+    parent.childNodes.forEach((child, index) => walk(child, parent, index));
+  };
+
+  const walk = (node: Node, parent: Node, index: number): void => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      addText(node as Text);
+      return;
     }
 
-    currentOffset += length;
+    if (node instanceof HTMLBRElement) {
+      if (isPlaceholderBreak(node, root)) {
+        addAnchor(currentOffset, { node: parent, offset: index }, 1);
+        return;
+      }
+
+      addNewline({ node: parent, offset: index }, { node: parent, offset: index + 1 });
+      return;
+    }
+
+    if (!(node instanceof HTMLElement)) return;
+
+    if (isBlockElement(node, root)) {
+      if (hasVisualLine) {
+        addNewline({ node: parent, offset: index }, { node, offset: 0 });
+      } else {
+        addAnchor(currentOffset, { node, offset: 0 }, 1);
+      }
+
+      const blockStartOffset = currentOffset;
+      walkChildren(node);
+
+      if (currentOffset === blockStartOffset) {
+        addAnchor(currentOffset, { node, offset: 0 }, 3);
+      }
+
+      hasVisualLine = true;
+      return;
+    }
+
+    walkChildren(node);
+  };
+
+  walkChildren(root);
+  addAnchor(currentOffset, { node: root, offset: root.childNodes.length }, 0);
+
+  return {
+    anchors,
+    segments,
+    totalOffset: currentOffset,
+  };
+}
+
+function getLogicalOffset(root: HTMLElement, point: CaretPoint): number {
+  const model = buildLogicalModel(root);
+  let offset = 0;
+
+  for (const segment of model.segments) {
+    if (segment.kind === 'text' && segment.node === point.node) {
+      return segment.startOffset + Math.min(point.offset, segment.endOffset - segment.startOffset);
+    }
+
+    if (comparePoints(segment.after, point) <= 0) {
+      offset = segment.endOffset;
+      continue;
+    }
+
+    if (comparePoints(segment.before, point) <= 0) {
+      return segment.startOffset;
+    }
+
+    break;
   }
 
-  // Fallback: If targetOffset is beyond content length, set to end
-  if (!found) {
-    const range = document.createRange();
-    range.selectNodeContents(root);
-    range.collapse(false);
-    selection.removeAllRanges();
-    selection.addRange(range);
+  return offset;
+}
+
+function findCaretPoint(model: LogicalModel, targetOffset: number): CaretPoint | null {
+  for (const segment of model.segments) {
+    if (
+      segment.kind === 'text' &&
+      targetOffset >= segment.startOffset &&
+      targetOffset <= segment.endOffset
+    ) {
+      return {
+        node: segment.node,
+        offset: targetOffset - segment.startOffset,
+      };
+    }
   }
+
+  const newlineAfter = model.segments.find(
+    (segment): segment is NewlineSegment =>
+      segment.kind === 'newline' && segment.endOffset === targetOffset,
+  );
+  if (newlineAfter) return newlineAfter.after;
+
+  const newlineBefore = model.segments.find(
+    (segment): segment is NewlineSegment =>
+      segment.kind === 'newline' && segment.startOffset === targetOffset,
+  );
+  if (newlineBefore) return newlineBefore.before;
+
+  return (
+    model.anchors
+      .filter((anchor) => anchor.offset === targetOffset)
+      .sort((a, b) => b.priority - a.priority)[0]?.point ?? null
+  );
+}
+
+function comparePoints(first: CaretPoint, second: CaretPoint): number {
+  const firstRange = document.createRange();
+  firstRange.setStart(first.node, first.offset);
+  firstRange.collapse(true);
+
+  const secondRange = document.createRange();
+  secondRange.setStart(second.node, second.offset);
+  secondRange.collapse(true);
+
+  return firstRange.compareBoundaryPoints(Range.START_TO_START, secondRange);
+}
+
+function isBlockElement(element: HTMLElement, root: HTMLElement): boolean {
+  return element !== root && BLOCK_TAG_NAMES.has(element.tagName);
+}
+
+function isPlaceholderBreak(element: HTMLBRElement, root: HTMLElement): boolean {
+  const parent = element.parentElement;
+  if (!parent || parent === root || !BLOCK_TAG_NAMES.has(parent.tagName)) return false;
+
+  const meaningfulChildren = Array.from(parent.childNodes).filter((child) => {
+    if (child.nodeType !== Node.TEXT_NODE) return true;
+    return (child.textContent ?? '').length > 0;
+  });
+
+  return meaningfulChildren.length === 1 && meaningfulChildren[0] === element;
 }


### PR DESCRIPTION
## Description / 描述

本pr只针对选项里面的"Ctrl+Enter 发送"功能
修复了bug1和bug2

### bug1

问题描述: 对上一次的消息进行编辑时, 按下回车后无法撤销, 并且所有历史记录清空

### bug2

问题描述: 在新消息编辑栏编辑时, 最后一个回车无法显示

#### 复现过程
1. 打开新的聊天框
2. 然后开始正常打一些字(不能复制粘贴)
3. 如果删除最后一行的唯一一个字符, 则最后一行的回车不会显示, 并且光标退回到上一行行末
4. 请看visual proof最为直观

#### bug原理
原来的实现用的是`document.execCommand('insertLineBreak', false);`这样创造的Html是

```html
<p>test only
test second line
3
5
</p>
```

因此把'5'删除后, 剩下的就变成了, 这样在网页上是不显示的

```html
<p>test only
test second line
3
</p>
```

**解决方法**: 改成`document.execCommand('insertParagraph', false);`用多个`<p>`

### bug3

问题描述: 在两种编辑栏编辑时, 按回车无法让屏幕跟随光标滚动, `shift+enter`则没有这个问题
简单复现: 在新页面聊天框敲10次回车

## Related Issue / 相关 Issue

bug3算一个未解决的issue, 我的想法是, 新编辑框用method3可行, 旧编辑框则不太好处理
由于这个删除的讨论比较麻烦, 我就解决下前两个bug

## Visual Proof / 可视化证据

### bug1 描述的场景

<img width="1167" height="208" alt="image" src="https://github.com/user-attachments/assets/8566d186-d2c5-4c9a-a073-1cd0e0cd017a" />

### bug2

https://github.com/user-attachments/assets/1d262ccf-9c83-4a50-aca9-c946797907ea

## Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: 未测试

## Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

这里还想反馈下, windows上无法正常运行`bun run format`, 有环境问题, 上面的打勾是因为github action校验过了
然后在未经任何改动直接拿原项目main分支运行`bun run test`结果如下

```powershell
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/pages/content/folder/__tests__/folderNameInteraction.test.ts > folder name click/double-click interaction > toggles folder on single click after delay
TypeError: undefined is not a constructor (evaluating 'new __vi_import_0__.FolderManager()')
 ❯ src/pages/content/folder/__tests__/folderNameInteraction.test.ts:52:5
     50|
     51|   it('toggles folder on single click after delay', () => {
     52|     manager = new FolderManager();
       |     ^
     53|     const typedManager = manager as unknown as TestableManager;
     54|     const toggleSpy = vi.spyOn(typedManager, 'toggleFolder').mockImplementation(() => {});

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/5]⎯

 FAIL  src/pages/content/folder/__tests__/folderNameInteraction.test.ts > folder name click/double-click interaction > renames folder on double click without toggle flicker
TypeError: undefined is not a constructor (evaluating 'new __vi_import_0__.FolderManager()')
 ❯ src/pages/content/folder/__tests__/folderNameInteraction.test.ts:74:5
     72|
     73|   it('renames folder on double click without toggle flicker', () => {
     74|     manager = new FolderManager();
       |     ^
     75|     const typedManager = manager as unknown as TestableManager;
     76|     const toggleSpy = vi.spyOn(typedManager, 'toggleFolder').mockImplementation(() => {});

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/5]⎯

 FAIL  src/pages/content/folder/__tests__/folderNameInteraction.test.ts > folder name click/double-click interaction > builds conversation URL without embedding /u/{num} segment
TypeError: undefined is not a constructor (evaluating 'new __vi_import_0__.FolderManager()')
 ❯ src/pages/content/folder/__tests__/folderNameInteraction.test.ts:95:5
     93|
     94|   it('builds conversation URL without embedding /u/{num} segment', () => {
     95|     manager = new FolderManager();
       |     ^
     96|     const typedManager = manager as unknown as TestableManager & {
     97|       accountIsolationEnabled: boolean;

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/5]⎯

 FAIL  src/pages/content/quoteReply/__tests__/quoteReply.test.ts > quote reply > expands input collapse when using quote reply
TypeError: [Function expandInputCollapseIfNeeded] is not a spy or a call to a spy!
 ❯ src/pages/content/quoteReply/__tests__/quoteReply.test.ts:155:41
    153|     triggerQuoteReply();
    154|
    155|     expect(expandInputCollapseIfNeeded).toHaveBeenCalledTimes(1);
       |                                         ^
    156|
    157|     cleanup();

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/5]⎯

 FAIL  src/pages/content/watermarkRemover/__tests__/downloadToasts.test.ts > watermarkRemover download toasts > does not show large file warning until DOWNLOADING_LARGE arrives
Error: Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
 ❯ <anonymous> src/pages/content/watermarkRemover/__tests__/downloadToasts.test.ts:32:31
     30|     document.head.innerHTML = '';
     31|     document.body.innerHTML = '';
     32|     vi.useFakeTimers();
       |                               ^
     33|   });
     34|
 ❯ processTicksAndRejections unknown:7:39

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/5]⎯


 Test Files  3 failed | 114 passed (117)
      Tests  5 failed | 871 passed (876)
   Start at  21:52:42
   Duration  14.93s (transform 19.75s, setup 7.52s, collect 43.58s, tests 38.54s, environment 159.74s, prepare 3.00s)

error: script "test" exited with code 1
```

并且每次运行错的个数还不一样
我只确保报错原因里面没有我修改的那个文件
我让 claude opus 4.6(thinking) 还有 gemini 3.1pro(high) 修这些环境问题把我额度都用完了, 尽力了
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
