### PR TITLE
feat(folder): add 'New chat in this folder' context menu item

### DIFF
--- a/src/core/types/common.ts
+++ b/src/core/types/common.ts
@@ -154,6 +154,7 @@ export const StorageKeys = {
 
   // Folder as Project
   FOLDER_PROJECT_ENABLED: 'gvFolderProjectEnabled',
+  FOLDER_PROJECT_PENDING_FOLDER_ID: 'gvFolderProjectPendingFolderId',
 } as const;
 
 export type StorageKey = (typeof StorageKeys)[keyof typeof StorageKeys];

--- a/src/locales/ar/messages.json
+++ b/src/locales/ar/messages.json
@@ -1830,5 +1830,9 @@
   "floatingPanelGestureHint": {
     "message": "نقر مزدوج لإعادة التسمية · زر الفأرة الأيمن للتثبيت واللون والحذف.",
     "description": "Floating folder panel hint explaining folder gestures and context menu actions"
+  },
+  "folder_new_chat_in_folder": {
+    "message": "محادثة جديدة في هذا المجلد",
+    "description": "Folder context menu item to create a new chat and auto-assign it to this folder"
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1731,6 +1731,10 @@
     "message": "Collapse",
     "description": "Aria-label for the collapse button (screen readers)"
   },
+  "folder_new_chat_in_folder": {
+    "message": "New chat in this folder",
+    "description": "Folder context menu item to create a new chat and auto-assign it to this folder"
+  },
   "canvasExportCopyMarkdown": {
     "message": "Copy as Markdown",
     "description": "Canvas share menu item: copy canvas content as Markdown to clipboard"

--- a/src/locales/es/messages.json
+++ b/src/locales/es/messages.json
@@ -1830,5 +1830,9 @@
   "floatingPanelGestureHint": {
     "message": "Doble clic para renombrar · Clic derecho para fijar/color/eliminar.",
     "description": "Floating folder panel hint explaining folder gestures and context menu actions"
+  },
+  "folder_new_chat_in_folder": {
+    "message": "Nuevo chat en esta carpeta",
+    "description": "Folder context menu item to create a new chat and auto-assign it to this folder"
   }
 }

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -1830,5 +1830,9 @@
   "floatingPanelGestureHint": {
     "message": "Double-clic pour renommer · Clic droit : épingler / couleur / supprimer.",
     "description": "Floating folder panel hint explaining folder gestures and context menu actions"
+  },
+  "folder_new_chat_in_folder": {
+    "message": "Nouvelle conversation dans ce dossier",
+    "description": "Folder context menu item to create a new chat and auto-assign it to this folder"
   }
 }

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -1830,5 +1830,9 @@
   "floatingPanelGestureHint": {
     "message": "ダブルクリックで名前変更 · 右クリックで固定/色/削除。",
     "description": "Floating folder panel hint explaining folder gestures and context menu actions"
+  },
+  "folder_new_chat_in_folder": {
+    "message": "このフォルダで新規チャット",
+    "description": "Folder context menu item to create a new chat and auto-assign it to this folder"
   }
 }

--- a/src/locales/ko/messages.json
+++ b/src/locales/ko/messages.json
@@ -1830,5 +1830,9 @@
   "floatingPanelGestureHint": {
     "message": "더블 클릭으로 이름 변경 · 우클릭으로 고정/색상/삭제.",
     "description": "Floating folder panel hint explaining folder gestures and context menu actions"
+  },
+  "folder_new_chat_in_folder": {
+    "message": "이 폴더에서 새 채팅",
+    "description": "Folder context menu item to create a new chat and auto-assign it to this folder"
   }
 }

--- a/src/locales/pt/messages.json
+++ b/src/locales/pt/messages.json
@@ -1830,5 +1830,9 @@
   "floatingPanelGestureHint": {
     "message": "Duplo clique para renomear · Clique direito: fixar/cor/excluir.",
     "description": "Floating folder panel hint explaining folder gestures and context menu actions"
+  },
+  "folder_new_chat_in_folder": {
+    "message": "Novo chat nesta pasta",
+    "description": "Folder context menu item to create a new chat and auto-assign it to this folder"
   }
 }

--- a/src/locales/ru/messages.json
+++ b/src/locales/ru/messages.json
@@ -1830,5 +1830,9 @@
   "floatingPanelGestureHint": {
     "message": "Двойной клик — переименовать · ПКМ — закрепить/цвет/удалить.",
     "description": "Floating folder panel hint explaining folder gestures and context menu actions"
+  },
+  "folder_new_chat_in_folder": {
+    "message": "Новый чат в этой папке",
+    "description": "Folder context menu item to create a new chat and auto-assign it to this folder"
   }
 }

--- a/src/locales/zh/messages.json
+++ b/src/locales/zh/messages.json
@@ -1731,6 +1731,10 @@
     "message": "折叠",
     "description": "Aria-label for the collapse button (screen readers)"
   },
+  "folder_new_chat_in_folder": {
+    "message": "在此文件夹新建对话",
+    "description": "Folder context menu item to create a new chat and auto-assign it to this folder"
+  },
   "canvasExportCopyMarkdown": {
     "message": "复制为 Markdown",
     "description": "Canvas 分享菜单项：将 Canvas 内容作为 Markdown 复制到剪贴板"

--- a/src/locales/zh_TW/messages.json
+++ b/src/locales/zh_TW/messages.json
@@ -1830,5 +1830,9 @@
   "floatingPanelGestureHint": {
     "message": "雙擊重新命名 · 右鍵可置頂 / 改色 / 刪除。",
     "description": "Floating folder panel hint explaining folder gestures and context menu actions"
+  },
+  "folder_new_chat_in_folder": {
+    "message": "在此資料夾新增對話",
+    "description": "Folder context menu item to create a new chat and auto-assign it to this folder"
   }
 }

--- a/src/pages/content/folder/__tests__/createNewChatInFolder.test.ts
+++ b/src/pages/content/folder/__tests__/createNewChatInFolder.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { StorageKeys } from '@/core/types/common';
+
+import { FolderManager } from '../manager';
+
+const { mockBrowserStorage } = vi.hoisted(() => ({
+  mockBrowserStorage: {
+    local: { set: vi.fn(), get: vi.fn(), remove: vi.fn() },
+    sync: { get: vi.fn(), set: vi.fn() },
+    onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
+  },
+}));
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: {
+      onMessage: { addListener: vi.fn(), removeListener: vi.fn() },
+    },
+    storage: mockBrowserStorage,
+  },
+}));
+
+vi.mock('@/utils/i18n', () => ({
+  getTranslationSync: (key: string) => key,
+  getTranslationSyncUnsafe: (key: string) => key,
+  initI18n: () => Promise.resolve(),
+}));
+
+type TestableManager = {
+  createNewChatInFolder: (folderId: string) => void;
+};
+
+interface LocationMock {
+  pathname: string;
+  origin: string;
+  href: string;
+  reload: ReturnType<typeof vi.fn>;
+}
+
+describe('createNewChatInFolder', () => {
+  let manager: FolderManager | null = null;
+  let locationMock: LocationMock;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    locationMock = {
+      pathname: '/app',
+      origin: 'https://gemini.google.com',
+      href: '',
+      reload: vi.fn(),
+    };
+    Object.defineProperty(window, 'location', {
+      value: locationMock,
+      writable: true,
+      configurable: true,
+    });
+    mockBrowserStorage.local.set.mockReset();
+    mockBrowserStorage.local.set.mockResolvedValue(undefined);
+    mockBrowserStorage.sync.get.mockResolvedValue({});
+    mockBrowserStorage.local.get.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+    manager?.destroy();
+    manager = null;
+    vi.restoreAllMocks();
+  });
+
+  it('writes the pending folder ID to storage.local', async () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockBrowserStorage.local.set).toHaveBeenCalledWith({
+      [StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]: 'folder-1',
+    });
+  });
+
+  it('reloads when already on /app', async () => {
+    locationMock.pathname = '/app';
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(locationMock.reload).toHaveBeenCalledTimes(1);
+    expect(locationMock.href).toBe('');
+  });
+
+  it('navigates to /app from a conversation page', async () => {
+    locationMock.pathname = '/app/abc123def456';
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(locationMock.href).toBe('https://gemini.google.com/app');
+    expect(locationMock.reload).not.toHaveBeenCalled();
+  });
+
+  it('preserves the multi-account user prefix (/u/N/app)', async () => {
+    locationMock.pathname = '/u/2/c/abc';
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(locationMock.href).toBe('https://gemini.google.com/u/2/app');
+  });
+
+  it('falls back to navigating when storage.set rejects with a generic error', async () => {
+    mockBrowserStorage.local.set.mockRejectedValue(new Error('quota exceeded'));
+    locationMock.pathname = '/app/abc';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(locationMock.href).toBe('https://gemini.google.com/app');
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('does not navigate when extension context is invalidated', async () => {
+    mockBrowserStorage.local.set.mockRejectedValue(
+      new Error('Extension context invalidated.'),
+    );
+    locationMock.pathname = '/app/abc';
+
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(locationMock.href).toBe('');
+    expect(locationMock.reload).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/content/folder/__tests__/createNewChatInFolder.test.ts
+++ b/src/pages/content/folder/__tests__/createNewChatInFolder.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { StorageKeys } from '@/core/types/common';
 
@@ -31,22 +31,43 @@ type TestableManager = {
   createNewChatInFolder: (folderId: string) => void;
 };
 
+interface LocationMock {
+  pathname: string;
+  origin: string;
+  href: string;
+  reload: ReturnType<typeof vi.fn>;
+}
+
 describe('createNewChatInFolder', () => {
   let manager: FolderManager | null = null;
-  let pushStateSpy: MockInstance<typeof window.history.pushState>;
-  let dispatchSpy: MockInstance<typeof window.dispatchEvent>;
+  let locationMock: LocationMock;
+  let originalLocation: Location;
 
   beforeEach(() => {
-    window.history.replaceState({}, '', '/app');
+    originalLocation = window.location;
+    locationMock = {
+      pathname: '/app',
+      origin: 'https://gemini.google.com',
+      href: '',
+      reload: vi.fn(),
+    };
+    Object.defineProperty(window, 'location', {
+      value: locationMock,
+      writable: true,
+      configurable: true,
+    });
     mockBrowserStorage.local.set.mockReset();
     mockBrowserStorage.local.set.mockResolvedValue(undefined);
     mockBrowserStorage.sync.get.mockResolvedValue({});
     mockBrowserStorage.local.get.mockResolvedValue({});
-    pushStateSpy = vi.spyOn(window.history, 'pushState');
-    dispatchSpy = vi.spyOn(window, 'dispatchEvent');
   });
 
   afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
     manager?.destroy();
     manager = null;
     vi.restoreAllMocks();
@@ -54,7 +75,9 @@ describe('createNewChatInFolder', () => {
 
   it('writes the pending folder ID to storage.local', async () => {
     manager = new FolderManager();
-    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
 
@@ -63,76 +86,77 @@ describe('createNewChatInFolder', () => {
     });
   });
 
-  it('dispatches the apply-pending custom event when already on /app', async () => {
-    window.history.replaceState({}, '', '/app');
+  it('reloads when already on /app', async () => {
+    locationMock.pathname = '/app';
     manager = new FolderManager();
-    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
 
-    const customEventCalls = dispatchSpy.mock.calls.filter(
-      (call) => (call[0] as Event).type === 'gv:folder-project:apply-pending',
-    );
-    expect(customEventCalls).toHaveLength(1);
-    expect(pushStateSpy).not.toHaveBeenCalled();
+    expect(locationMock.reload).toHaveBeenCalledTimes(1);
+    expect(locationMock.href).toBe('');
   });
 
-  it('uses pushState + popstate to SPA-navigate from a conversation page', async () => {
-    window.history.replaceState({}, '', '/app/abc123def456');
+  it('navigates to /app from a conversation page', async () => {
+    locationMock.pathname = '/app/abc123def456';
     manager = new FolderManager();
-    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(pushStateSpy).toHaveBeenCalledWith({}, '', '/app');
-    const popstateCalls = dispatchSpy.mock.calls.filter(
-      (call) => (call[0] as Event).type === 'popstate',
-    );
-    expect(popstateCalls).toHaveLength(1);
+    expect(locationMock.href).toBe('https://gemini.google.com/app');
+    expect(locationMock.reload).not.toHaveBeenCalled();
   });
 
-  it('preserves the multi-account user prefix when pushing state', async () => {
-    window.history.replaceState({}, '', '/u/2/c/abc');
+  it('preserves the multi-account user prefix (/u/N/app)', async () => {
+    locationMock.pathname = '/u/2/c/abc';
     manager = new FolderManager();
-    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(pushStateSpy).toHaveBeenCalledWith({}, '', '/u/2/app');
+    expect(locationMock.href).toBe('https://gemini.google.com/u/2/app');
   });
 
   it('falls back to navigating when storage.set rejects with a generic error', async () => {
     mockBrowserStorage.local.set.mockRejectedValue(new Error('quota exceeded'));
-    window.history.replaceState({}, '', '/app/abc');
+    locationMock.pathname = '/app/abc';
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     manager = new FolderManager();
-    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(pushStateSpy).toHaveBeenCalledWith({}, '', '/app');
+    expect(locationMock.href).toBe('https://gemini.google.com/app');
     expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('does not navigate when extension context is invalidated', async () => {
     mockBrowserStorage.local.set.mockRejectedValue(
       new Error('Extension context invalidated.'),
     );
-    window.history.replaceState({}, '', '/app/abc');
+    locationMock.pathname = '/app/abc';
 
     manager = new FolderManager();
-    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
+    const typedManager = manager as unknown as TestableManager;
+
+    typedManager.createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(pushStateSpy).not.toHaveBeenCalled();
-    const navEvents = dispatchSpy.mock.calls.filter((call) => {
-      const t = (call[0] as Event).type;
-      return t === 'popstate' || t === 'gv:folder-project:apply-pending';
-    });
-    expect(navEvents).toHaveLength(0);
+    expect(locationMock.href).toBe('');
+    expect(locationMock.reload).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/content/folder/__tests__/createNewChatInFolder.test.ts
+++ b/src/pages/content/folder/__tests__/createNewChatInFolder.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 import { StorageKeys } from '@/core/types/common';
 
@@ -31,43 +31,22 @@ type TestableManager = {
   createNewChatInFolder: (folderId: string) => void;
 };
 
-interface LocationMock {
-  pathname: string;
-  origin: string;
-  href: string;
-  reload: ReturnType<typeof vi.fn>;
-}
-
 describe('createNewChatInFolder', () => {
   let manager: FolderManager | null = null;
-  let locationMock: LocationMock;
-  let originalLocation: Location;
+  let pushStateSpy: MockInstance<typeof window.history.pushState>;
+  let dispatchSpy: MockInstance<typeof window.dispatchEvent>;
 
   beforeEach(() => {
-    originalLocation = window.location;
-    locationMock = {
-      pathname: '/app',
-      origin: 'https://gemini.google.com',
-      href: '',
-      reload: vi.fn(),
-    };
-    Object.defineProperty(window, 'location', {
-      value: locationMock,
-      writable: true,
-      configurable: true,
-    });
+    window.history.replaceState({}, '', '/app');
     mockBrowserStorage.local.set.mockReset();
     mockBrowserStorage.local.set.mockResolvedValue(undefined);
     mockBrowserStorage.sync.get.mockResolvedValue({});
     mockBrowserStorage.local.get.mockResolvedValue({});
+    pushStateSpy = vi.spyOn(window.history, 'pushState');
+    dispatchSpy = vi.spyOn(window, 'dispatchEvent');
   });
 
   afterEach(() => {
-    Object.defineProperty(window, 'location', {
-      value: originalLocation,
-      writable: true,
-      configurable: true,
-    });
     manager?.destroy();
     manager = null;
     vi.restoreAllMocks();
@@ -75,9 +54,7 @@ describe('createNewChatInFolder', () => {
 
   it('writes the pending folder ID to storage.local', async () => {
     manager = new FolderManager();
-    const typedManager = manager as unknown as TestableManager;
-
-    typedManager.createNewChatInFolder('folder-1');
+    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
 
@@ -86,77 +63,76 @@ describe('createNewChatInFolder', () => {
     });
   });
 
-  it('reloads when already on /app', async () => {
-    locationMock.pathname = '/app';
+  it('dispatches the apply-pending custom event when already on /app', async () => {
+    window.history.replaceState({}, '', '/app');
     manager = new FolderManager();
-    const typedManager = manager as unknown as TestableManager;
-
-    typedManager.createNewChatInFolder('folder-1');
+    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(locationMock.reload).toHaveBeenCalledTimes(1);
-    expect(locationMock.href).toBe('');
+    const customEventCalls = dispatchSpy.mock.calls.filter(
+      (call) => (call[0] as Event).type === 'gv:folder-project:apply-pending',
+    );
+    expect(customEventCalls).toHaveLength(1);
+    expect(pushStateSpy).not.toHaveBeenCalled();
   });
 
-  it('navigates to /app from a conversation page', async () => {
-    locationMock.pathname = '/app/abc123def456';
+  it('uses pushState + popstate to SPA-navigate from a conversation page', async () => {
+    window.history.replaceState({}, '', '/app/abc123def456');
     manager = new FolderManager();
-    const typedManager = manager as unknown as TestableManager;
-
-    typedManager.createNewChatInFolder('folder-1');
+    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(locationMock.href).toBe('https://gemini.google.com/app');
-    expect(locationMock.reload).not.toHaveBeenCalled();
+    expect(pushStateSpy).toHaveBeenCalledWith({}, '', '/app');
+    const popstateCalls = dispatchSpy.mock.calls.filter(
+      (call) => (call[0] as Event).type === 'popstate',
+    );
+    expect(popstateCalls).toHaveLength(1);
   });
 
-  it('preserves the multi-account user prefix (/u/N/app)', async () => {
-    locationMock.pathname = '/u/2/c/abc';
+  it('preserves the multi-account user prefix when pushing state', async () => {
+    window.history.replaceState({}, '', '/u/2/c/abc');
     manager = new FolderManager();
-    const typedManager = manager as unknown as TestableManager;
-
-    typedManager.createNewChatInFolder('folder-1');
+    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(locationMock.href).toBe('https://gemini.google.com/u/2/app');
+    expect(pushStateSpy).toHaveBeenCalledWith({}, '', '/u/2/app');
   });
 
   it('falls back to navigating when storage.set rejects with a generic error', async () => {
     mockBrowserStorage.local.set.mockRejectedValue(new Error('quota exceeded'));
-    locationMock.pathname = '/app/abc';
+    window.history.replaceState({}, '', '/app/abc');
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     manager = new FolderManager();
-    const typedManager = manager as unknown as TestableManager;
-
-    typedManager.createNewChatInFolder('folder-1');
+    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(locationMock.href).toBe('https://gemini.google.com/app');
+    expect(pushStateSpy).toHaveBeenCalledWith({}, '', '/app');
     expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 
   it('does not navigate when extension context is invalidated', async () => {
     mockBrowserStorage.local.set.mockRejectedValue(
       new Error('Extension context invalidated.'),
     );
-    locationMock.pathname = '/app/abc';
+    window.history.replaceState({}, '', '/app/abc');
 
     manager = new FolderManager();
-    const typedManager = manager as unknown as TestableManager;
-
-    typedManager.createNewChatInFolder('folder-1');
+    (manager as unknown as TestableManager).createNewChatInFolder('folder-1');
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(locationMock.href).toBe('');
-    expect(locationMock.reload).not.toHaveBeenCalled();
+    expect(pushStateSpy).not.toHaveBeenCalled();
+    const navEvents = dispatchSpy.mock.calls.filter((call) => {
+      const t = (call[0] as Event).type;
+      return t === 'popstate' || t === 'gv:folder-project:apply-pending';
+    });
+    expect(navEvents).toHaveLength(0);
   });
 });

--- a/src/pages/content/folder/__tests__/createNewChatInFolder.test.ts
+++ b/src/pages/content/folder/__tests__/createNewChatInFolder.test.ts
@@ -143,9 +143,7 @@ describe('createNewChatInFolder', () => {
   });
 
   it('does not navigate when extension context is invalidated', async () => {
-    mockBrowserStorage.local.set.mockRejectedValue(
-      new Error('Extension context invalidated.'),
-    );
+    mockBrowserStorage.local.set.mockRejectedValue(new Error('Extension context invalidated.'));
     locationMock.pathname = '/app/abc';
 
     manager = new FolderManager();

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -4393,29 +4393,40 @@ export class FolderManager {
    * Navigate to a new chat page and pre-select this folder via the
    * Folder-as-Project picker. Stores the folder ID in local storage so the
    * picker can auto-select it after the page loads.
+   *
+   * Uses SPA-style navigation (pushState + popstate) so the right-side folder
+   * panel doesn't flash. When already on /app, the picker is already mounted
+   * — dispatch a custom event so it re-reads the pending folder ID without
+   * any navigation.
    */
   private createNewChatInFolder(folderId: string): void {
-    const navigate = () => {
+    const apply = () => {
       const userPrefix = window.location.pathname.match(/^\/u\/\d+/)?.[0] ?? '';
       const targetPath = `${userPrefix}/app`;
-      if (
+      const alreadyOnTarget =
         window.location.pathname === targetPath ||
-        window.location.pathname === `${targetPath}/`
-      ) {
-        window.location.reload();
-      } else {
-        window.location.href = `${window.location.origin}${targetPath}`;
+        window.location.pathname === `${targetPath}/`;
+
+      if (alreadyOnTarget) {
+        // Picker is already mounted — nudge it to re-read pending folder ID
+        window.dispatchEvent(new CustomEvent('gv:folder-project:apply-pending'));
+        return;
       }
+
+      // SPA navigation: pushState updates the URL bar; popstate dispatch
+      // lets Angular Router observe the change. No full page reload.
+      window.history.pushState({}, '', targetPath);
+      window.dispatchEvent(new PopStateEvent('popstate'));
     };
 
     browser.storage.local
       .set({ [StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]: folderId })
-      .then(navigate)
+      .then(apply)
       .catch((error) => {
         if (isExtensionContextInvalidatedError(error)) return;
         // storage failed — still navigate so the user isn't stranded; they can pick the folder manually
         console.warn('[folder] failed to set pending folder ID', error);
-        navigate();
+        apply();
       });
   }
 

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -4353,6 +4353,10 @@ export class FolderManager {
     // Only show instructions editor when Folder-as-Project is enabled
     if (this.folderProjectEnabled) {
       menuItems.push({
+        label: this.t('folder_new_chat_in_folder'),
+        action: () => this.createNewChatInFolder(folderId),
+      });
+      menuItems.push({
         label: folder.instructions
           ? this.t('folderAsProject_editInstructions')
           : this.t('folderAsProject_setInstructions'),
@@ -4383,6 +4387,28 @@ export class FolderManager {
       }
     };
     setTimeout(() => document.addEventListener('click', closeMenu), 0);
+  }
+
+  /**
+   * Navigate to a new chat page and pre-select this folder via the
+   * Folder-as-Project picker. Stores the folder ID in local storage so the
+   * picker can auto-select it after the page loads.
+   */
+  private createNewChatInFolder(folderId: string): void {
+    browser.storage.local
+      .set({ [StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]: folderId })
+      .then(() => {
+        const userPrefix = window.location.pathname.match(/^\/u\/\d+/)?.[0] ?? '';
+        const targetPath = `${userPrefix}/app`;
+        if (
+          window.location.pathname === targetPath ||
+          window.location.pathname === `${targetPath}/`
+        ) {
+          window.location.reload();
+        } else {
+          window.location.href = `${window.location.origin}${targetPath}`;
+        }
+      });
   }
 
   /**

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -4393,40 +4393,29 @@ export class FolderManager {
    * Navigate to a new chat page and pre-select this folder via the
    * Folder-as-Project picker. Stores the folder ID in local storage so the
    * picker can auto-select it after the page loads.
-   *
-   * Uses SPA-style navigation (pushState + popstate) so the right-side folder
-   * panel doesn't flash. When already on /app, the picker is already mounted
-   * — dispatch a custom event so it re-reads the pending folder ID without
-   * any navigation.
    */
   private createNewChatInFolder(folderId: string): void {
-    const apply = () => {
+    const navigate = () => {
       const userPrefix = window.location.pathname.match(/^\/u\/\d+/)?.[0] ?? '';
       const targetPath = `${userPrefix}/app`;
-      const alreadyOnTarget =
+      if (
         window.location.pathname === targetPath ||
-        window.location.pathname === `${targetPath}/`;
-
-      if (alreadyOnTarget) {
-        // Picker is already mounted — nudge it to re-read pending folder ID
-        window.dispatchEvent(new CustomEvent('gv:folder-project:apply-pending'));
-        return;
+        window.location.pathname === `${targetPath}/`
+      ) {
+        window.location.reload();
+      } else {
+        window.location.href = `${window.location.origin}${targetPath}`;
       }
-
-      // SPA navigation: pushState updates the URL bar; popstate dispatch
-      // lets Angular Router observe the change. No full page reload.
-      window.history.pushState({}, '', targetPath);
-      window.dispatchEvent(new PopStateEvent('popstate'));
     };
 
     browser.storage.local
       .set({ [StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]: folderId })
-      .then(apply)
+      .then(navigate)
       .catch((error) => {
         if (isExtensionContextInvalidatedError(error)) return;
         // storage failed — still navigate so the user isn't stranded; they can pick the folder manually
         console.warn('[folder] failed to set pending folder ID', error);
-        apply();
+        navigate();
       });
   }
 

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -4395,19 +4395,27 @@ export class FolderManager {
    * picker can auto-select it after the page loads.
    */
   private createNewChatInFolder(folderId: string): void {
+    const navigate = () => {
+      const userPrefix = window.location.pathname.match(/^\/u\/\d+/)?.[0] ?? '';
+      const targetPath = `${userPrefix}/app`;
+      if (
+        window.location.pathname === targetPath ||
+        window.location.pathname === `${targetPath}/`
+      ) {
+        window.location.reload();
+      } else {
+        window.location.href = `${window.location.origin}${targetPath}`;
+      }
+    };
+
     browser.storage.local
       .set({ [StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]: folderId })
-      .then(() => {
-        const userPrefix = window.location.pathname.match(/^\/u\/\d+/)?.[0] ?? '';
-        const targetPath = `${userPrefix}/app`;
-        if (
-          window.location.pathname === targetPath ||
-          window.location.pathname === `${targetPath}/`
-        ) {
-          window.location.reload();
-        } else {
-          window.location.href = `${window.location.origin}${targetPath}`;
-        }
+      .then(navigate)
+      .catch((error) => {
+        if (isExtensionContextInvalidatedError(error)) return;
+        // storage failed — still navigate so the user isn't stranded; they can pick the folder manually
+        console.warn('[folder] failed to set pending folder ID', error);
+        navigate();
       });
   }
 

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -4,16 +4,6 @@ import { StorageKeys } from '@/core/types/common';
 
 import { extractConvId, isNewChatPath, waitForElement } from '../index';
 
-// Ensure chrome.storage.local is mocked for pending-folder tests
-if (!chrome.storage.local) {
-  (chrome.storage as unknown as Record<string, unknown>).local = {
-    get: vi.fn(),
-    set: vi.fn(),
-    remove: vi.fn(),
-    clear: vi.fn(),
-  };
-}
-
 // Mock getTranslationSyncUnsafe used inside the module
 vi.mock('@/utils/i18n', () => ({
   getTranslationSyncUnsafe: (key: string) => key,

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -4,6 +4,16 @@ import { StorageKeys } from '@/core/types/common';
 
 import { extractConvId, isNewChatPath, waitForElement } from '../index';
 
+// Ensure chrome.storage.local is mocked for pending-folder tests
+if (!chrome.storage.local) {
+  (chrome.storage as unknown as Record<string, unknown>).local = {
+    get: vi.fn(),
+    set: vi.fn(),
+    remove: vi.fn(),
+    clear: vi.fn(),
+  };
+}
+
 // Mock getTranslationSyncUnsafe used inside the module
 vi.mock('@/utils/i18n', () => ({
   getTranslationSyncUnsafe: (key: string) => key,
@@ -276,5 +286,105 @@ describe('startFolderProject — runtime toggle', () => {
     }
 
     expect(document.querySelector('.gv-fp-picker-container')).toBeNull();
+  });
+});
+
+// ============================================================================
+// applyPendingFolderSelection
+// ============================================================================
+
+describe('applyPendingFolderSelection', () => {
+  const mockFolders = [
+    { id: 'folder-1', name: 'Work', instructions: 'Be professional', parentId: null },
+    { id: 'folder-2', name: 'Personal', instructions: null, parentId: null },
+  ];
+
+  let chip: HTMLButtonElement;
+
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = '';
+    chip = document.createElement('button');
+    chip.className = 'gv-fp-chip';
+    chip.textContent = 'Select folder…';
+    // Clear call history on local storage mocks
+    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (chrome.storage.local.remove as unknown as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('auto-selects folder when pending ID exists in storage', async () => {
+    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      [StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]: 'folder-1',
+    });
+    (chrome.storage.local.remove as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      undefined,
+    );
+
+    const { applyPendingFolderSelection } = await import('../index');
+    const mockManager = {
+      getFolders: vi.fn().mockReturnValue(mockFolders),
+      ensureDataLoaded: vi.fn().mockResolvedValue(undefined),
+      addConversationToFolderFromNative: vi.fn(),
+    };
+
+    await applyPendingFolderSelection(
+      mockManager as unknown as Parameters<typeof applyPendingFolderSelection>[0],
+      chip,
+    );
+
+    expect(chip.textContent).toBe('📁 Work');
+    expect(chip.dataset.selected).toBe('folder-1');
+    expect(chrome.storage.local.remove).toHaveBeenCalledWith([
+      StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID,
+    ]);
+  });
+
+  it('does nothing when no pending folder ID exists', async () => {
+    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    const { applyPendingFolderSelection } = await import('../index');
+    const mockManager = {
+      getFolders: vi.fn().mockReturnValue(mockFolders),
+      ensureDataLoaded: vi.fn().mockResolvedValue(undefined),
+      addConversationToFolderFromNative: vi.fn(),
+    };
+
+    await applyPendingFolderSelection(
+      mockManager as unknown as Parameters<typeof applyPendingFolderSelection>[0],
+      chip,
+    );
+
+    expect(chip.textContent).toBe('Select folder…');
+    expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+  });
+
+  it('clears pending ID even when folder ID does not match any folder', async () => {
+    (chrome.storage.local.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      [StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]: 'nonexistent',
+    });
+    (chrome.storage.local.remove as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      undefined,
+    );
+
+    const { applyPendingFolderSelection } = await import('../index');
+    const mockManager = {
+      getFolders: vi.fn().mockReturnValue(mockFolders),
+      ensureDataLoaded: vi.fn().mockResolvedValue(undefined),
+      addConversationToFolderFromNative: vi.fn(),
+    };
+
+    await applyPendingFolderSelection(
+      mockManager as unknown as Parameters<typeof applyPendingFolderSelection>[0],
+      chip,
+    );
+
+    expect(chip.textContent).toBe('Select folder…');
+    expect(chrome.storage.local.remove).toHaveBeenCalledWith([
+      StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID,
+    ]);
   });
 });

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -28,6 +28,8 @@ let selectedFolderName: string | null = null;
 let selectedFolderInstructions: string | null = null;
 let pickerContainer: HTMLElement | null = null;
 let pickerCleanup: (() => void) | null = null;
+let activeChip: HTMLButtonElement | null = null;
+let activeManager: FolderManager | null = null;
 let lastHref = '';
 let urlWatcherInterval: ReturnType<typeof setInterval> | null = null;
 let urlWatcherCheckFn: (() => void) | null = null;
@@ -426,6 +428,19 @@ function buildFolderPicker(manager: FolderManager): {
 // ============================================================================
 
 /**
+ * Custom event manager.ts dispatches when the user picks "New chat in this
+ * folder" while already on /app — there's no SPA navigation, so we nudge the
+ * already-mounted picker to re-read the pending folder ID.
+ */
+export const FOLDER_PROJECT_APPLY_PENDING_EVENT = 'gv:folder-project:apply-pending';
+
+window.addEventListener(FOLDER_PROJECT_APPLY_PENDING_EVENT, () => {
+  if (activeChip && activeManager) {
+    void applyPendingFolderSelection(activeManager, activeChip);
+  }
+});
+
+/**
  * Reads a pending folder ID written by the folder manager's
  * "New chat in this folder" menu item. When found, auto-selects the folder
  * in the picker and clears the pending value.
@@ -464,6 +479,8 @@ function removePicker(): void {
   pickerCleanup = null;
   pickerContainer?.remove();
   pickerContainer = null;
+  activeChip = null;
+  activeManager = null;
 }
 
 async function injectPicker(manager: FolderManager): Promise<void> {
@@ -484,6 +501,8 @@ async function injectPicker(manager: FolderManager): Promise<void> {
     modelPicker.parentElement.insertBefore(element, modelPicker);
     pickerContainer = element;
     pickerCleanup = cleanup;
+    activeChip = chip;
+    activeManager = manager;
     void applyPendingFolderSelection(manager, chip);
     return;
   }
@@ -499,6 +518,8 @@ async function injectPicker(manager: FolderManager): Promise<void> {
     parent.insertBefore(element, richTextarea);
     pickerContainer = element;
     pickerCleanup = cleanup;
+    activeChip = chip;
+    activeManager = manager;
     void applyPendingFolderSelection(manager, chip);
   }
 }

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -648,6 +648,8 @@ export function startFolderProject(manager: FolderManager): void {
       selectedFolderId = null;
       selectedFolderName = null;
       selectedFolderInstructions = null;
+      // Drop any pending folder selection so re-enabling later doesn't auto-select a stale folder
+      void chrome.storage?.local?.remove([StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]);
     }
   });
 }

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -370,6 +370,7 @@ async function populateDropdown(
 
 function buildFolderPicker(manager: FolderManager): {
   element: HTMLElement;
+  chip: HTMLButtonElement;
   cleanup: () => void;
 } {
   const container = document.createElement('div');
@@ -415,8 +416,43 @@ function buildFolderPicker(manager: FolderManager): {
   container.appendChild(dropdown);
   return {
     element: container,
+    chip,
     cleanup: () => document.removeEventListener('click', closeOnOutsideClick),
   };
+}
+
+// ============================================================================
+// Pending folder selection (from "New chat in folder" menu)
+// ============================================================================
+
+/**
+ * Reads a pending folder ID written by the folder manager's
+ * "New chat in this folder" menu item. When found, auto-selects the folder
+ * in the picker and clears the pending value.
+ */
+export async function applyPendingFolderSelection(
+  manager: FolderManager,
+  chip: HTMLButtonElement,
+): Promise<void> {
+  if (!chrome.storage?.local) return;
+
+  const result = await chrome.storage.local.get([StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]);
+  const pendingId = result?.[StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID];
+  if (!pendingId) return;
+
+  // Clear immediately to avoid re-application
+  await chrome.storage.local.remove([StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]);
+
+  await manager.ensureDataLoaded();
+  const folder = manager.getFolders().find((f) => f.id === pendingId);
+  if (!folder) return;
+
+  selectedFolderId = folder.id;
+  selectedFolderName = folder.name;
+  selectedFolderInstructions = folder.instructions ?? null;
+
+  chip.textContent = `📁 ${folder.name}`;
+  chip.dataset.selected = folder.id;
 }
 
 // ============================================================================
@@ -441,13 +477,14 @@ async function injectPicker(manager: FolderManager): Promise<void> {
   // Guard: don't inject twice
   if (document.querySelector('.gv-fp-picker-container')) return;
 
-  const { element, cleanup } = buildFolderPicker(manager);
+  const { element, cleanup, chip } = buildFolderPicker(manager);
 
   if (modelPicker?.parentElement) {
     // Insert before the model picker in trailing-actions-wrapper
     modelPicker.parentElement.insertBefore(element, modelPicker);
     pickerContainer = element;
     pickerCleanup = cleanup;
+    void applyPendingFolderSelection(manager, chip);
     return;
   }
 
@@ -462,6 +499,7 @@ async function injectPicker(manager: FolderManager): Promise<void> {
     parent.insertBefore(element, richTextarea);
     pickerContainer = element;
     pickerCleanup = cleanup;
+    void applyPendingFolderSelection(manager, chip);
   }
 }
 

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -28,8 +28,6 @@ let selectedFolderName: string | null = null;
 let selectedFolderInstructions: string | null = null;
 let pickerContainer: HTMLElement | null = null;
 let pickerCleanup: (() => void) | null = null;
-let activeChip: HTMLButtonElement | null = null;
-let activeManager: FolderManager | null = null;
 let lastHref = '';
 let urlWatcherInterval: ReturnType<typeof setInterval> | null = null;
 let urlWatcherCheckFn: (() => void) | null = null;
@@ -428,19 +426,6 @@ function buildFolderPicker(manager: FolderManager): {
 // ============================================================================
 
 /**
- * Custom event manager.ts dispatches when the user picks "New chat in this
- * folder" while already on /app — there's no SPA navigation, so we nudge the
- * already-mounted picker to re-read the pending folder ID.
- */
-export const FOLDER_PROJECT_APPLY_PENDING_EVENT = 'gv:folder-project:apply-pending';
-
-window.addEventListener(FOLDER_PROJECT_APPLY_PENDING_EVENT, () => {
-  if (activeChip && activeManager) {
-    void applyPendingFolderSelection(activeManager, activeChip);
-  }
-});
-
-/**
  * Reads a pending folder ID written by the folder manager's
  * "New chat in this folder" menu item. When found, auto-selects the folder
  * in the picker and clears the pending value.
@@ -479,8 +464,6 @@ function removePicker(): void {
   pickerCleanup = null;
   pickerContainer?.remove();
   pickerContainer = null;
-  activeChip = null;
-  activeManager = null;
 }
 
 async function injectPicker(manager: FolderManager): Promise<void> {
@@ -501,8 +484,6 @@ async function injectPicker(manager: FolderManager): Promise<void> {
     modelPicker.parentElement.insertBefore(element, modelPicker);
     pickerContainer = element;
     pickerCleanup = cleanup;
-    activeChip = chip;
-    activeManager = manager;
     void applyPendingFolderSelection(manager, chip);
     return;
   }
@@ -518,8 +499,6 @@ async function injectPicker(manager: FolderManager): Promise<void> {
     parent.insertBefore(element, richTextarea);
     pickerContainer = element;
     pickerCleanup = cleanup;
-    activeChip = chip;
-    activeManager = manager;
     void applyPendingFolderSelection(manager, chip);
   }
 }

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -13,6 +13,12 @@ globalThis.chrome = {
       remove: vi.fn(),
       clear: vi.fn(),
     },
+    local: {
+      get: vi.fn(),
+      set: vi.fn(),
+      remove: vi.fn(),
+      clear: vi.fn(),
+    },
     onChanged: {
       addListener: vi.fn(),
       removeListener: vi.fn(),


### PR DESCRIPTION
### 🚫 AI Policy / AI 政策

- Claude Code 辅助编写，所有代码已经过人工逐行理解和验证。
- 已添加单元测试并通过（858 tests passed）。
- 已在 Chrome 和 Firefox 上手动测试功能正常。

---

### Description / 描述

Implements "New chat in this folder" feature — adds a context menu item to each folder that navigates to a new chat page with the folder pre-selected in the Folder-as-Project picker.

实现"从选中文件夹新建对话"功能 — 在每个文件夹的上下文菜单中添加"在此文件夹新建对话"选项，点击后跳转到新对话页面并自动选中该文件夹，用户无需手动在对话框下方的文件夹选择器中重新选择。我认为这样符合用户的使用习惯。

原有的功能：
  - 新对话页面下方有文件夹选择器（picker UI）—— 用户手动点击选择文件夹

我新增的功能：
  - 文件夹右键菜单中新增"在此文件夹新建对话"选项
  - 点击后跳转到新对话页面并自动选中该文件夹

**Changes:**

- Added `FOLDER_PROJECT_PENDING_FOLDER_ID` storage key for cross-navigation folder selection
- Added `createNewChatInFolder()` method to `FolderManager` (writes pending folder ID → navigates to `/app`)
- Added `applyPendingFolderSelection()` in `folderProject/index.ts` (reads pending ID → auto-selects folder in picker → clears pending value)
- Added `folder_new_chat_in_folder` i18n key to all 10 locales
- Added 3 unit tests for `applyPendingFolderSelection`

### Related Issue / 相关 Issue

Closes #210

### Visual Proof / 可视化证据
<img width="1920" height="712" alt="p1" src="https://github.com/user-attachments/assets/194a39ea-f015-4924-8fb1-b2703b3e5bae" />
<img width="1920" height="991" alt="p2" src="https://github.com/user-attachments/assets/957ea7f0-1e2b-4d06-bd49-65b51ba14f48" />
<img width="1920" height="989" alt="p3" src="https://github.com/user-attachments/assets/7d887c56-9f68-4c18-9ed1-ee2906d2f8bc" />
<img width="1920" height="995" alt="p4" src="https://github.com/user-attachments/assets/0de01203-f541-4f99-ac5c-46f3fbc8db93" />




### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Not tested (no environment). Code uses only standard WebExtension APIs (`storage.local`, DOM manipulation) — no Safari-specific incompatibilities expected. / 未测试（无环境）。代码仅使用标准 WebExtension API，无 Safari 兼容性问题。

### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过。

请大佬斧正指导！
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
