### PR TITLE
feat(menu): add 'Move to Folder' button to the conversation.

### DIFF
--- a/src/pages/content/folder/__tests__/topMenuInjection.test.ts
+++ b/src/pages/content/folder/__tests__/topMenuInjection.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FolderManager } from '../manager';
+
+vi.mock('@/utils/i18n', () => ({
+  getTranslationSync: (key: string) => key,
+  getTranslationSyncUnsafe: (key: string) => key,
+  initI18n: () => Promise.resolve(),
+}));
+
+type TestableManager = {
+  extractConversationInfoFromPage: () => { id: string; title: string; url: string } | null;
+};
+
+describe('extractConversationInfoFromPage', () => {
+  let manager: TestableManager;
+
+  beforeEach(() => {
+    manager = new FolderManager() as unknown as TestableManager;
+  });
+
+  afterEach(() => {
+    // Restore any mocked globals
+    vi.restoreAllMocks();
+    // Clean up any added DOM elements
+    document.querySelectorAll('.conversation-title-container, top-bar-actions').forEach((el) => {
+      el.remove();
+    });
+    // Reset location via JSDOM
+    window.history.pushState({}, '', '/');
+  });
+
+  it('returns null when URL has no conversation ID', () => {
+    window.history.pushState({}, '', '/');
+    expect(manager.extractConversationInfoFromPage()).toBeNull();
+  });
+
+  it('returns null on the homepage (/app)', () => {
+    window.history.pushState({}, '', '/app');
+    expect(manager.extractConversationInfoFromPage()).toBeNull();
+  });
+
+  it('returns null on /app/ with no hex ID', () => {
+    window.history.pushState({}, '', '/app/');
+    expect(manager.extractConversationInfoFromPage()).toBeNull();
+  });
+
+  it('extracts ID from /app/<hexId> URL', () => {
+    const hexId = 'a1b2c3d4e5f6a7b8';
+    window.history.pushState({}, '', `/app/${hexId}`);
+
+    // Add a title element to the DOM
+    const titleContainer = document.createElement('div');
+    titleContainer.className = 'conversation-title-container';
+    const titleSpan = document.createElement('span');
+    titleSpan.setAttribute('data-test-id', 'conversation-title');
+    titleSpan.textContent = 'My Chat Title';
+    titleContainer.appendChild(titleSpan);
+    document.body.appendChild(titleContainer);
+
+    const result = manager.extractConversationInfoFromPage();
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(hexId);
+    expect(result!.title).toBe('My Chat Title');
+    expect(result!.url).toContain(hexId);
+
+    titleContainer.remove();
+  });
+
+  it('extracts ID from /gem/<gemId>/<hexId> URL', () => {
+    const hexId = 'deadbeef12345678';
+    window.history.pushState({}, '', `/gem/my-gem/${hexId}`);
+
+    const titleContainer = document.createElement('div');
+    titleContainer.className = 'conversation-title-container';
+    const titleSpan = document.createElement('span');
+    titleSpan.setAttribute('data-test-id', 'conversation-title');
+    titleSpan.textContent = 'Gem Chat';
+    titleContainer.appendChild(titleSpan);
+    document.body.appendChild(titleContainer);
+
+    const result = manager.extractConversationInfoFromPage();
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(hexId);
+    expect(result!.url).toContain(`/gem/my-gem/${hexId}`);
+
+    titleContainer.remove();
+  });
+
+  it('extracts ID from /u/1/app/<hexId> (multi-user prefix)', () => {
+    const hexId = 'abcdef0123456789';
+    window.history.pushState({}, '', `/u/1/app/${hexId}`);
+
+    const el = document.createElement('div');
+    el.className = 'conversation-title-container';
+    const span = document.createElement('span');
+    span.setAttribute('data-test-id', 'conversation-title');
+    span.textContent = 'Multi-user chat';
+    el.appendChild(span);
+    document.body.appendChild(el);
+
+    const result = manager.extractConversationInfoFromPage();
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(hexId);
+
+    el.remove();
+  });
+
+  it('falls back to document.title when DOM title element is missing', () => {
+    const hexId = 'a1b2c3d4e5f6a7b8';
+    window.history.pushState({}, '', `/app/${hexId}`);
+
+    // No title element in DOM — simulate document.title set by Gemini
+    Object.defineProperty(document, 'title', {
+      value: 'Async Title - Gemini',
+      writable: true,
+      configurable: true,
+    });
+
+    const result = manager.extractConversationInfoFromPage();
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Async Title');
+    expect(result!.id).toBe(hexId);
+  });
+
+  it('falls back to "Untitled" when no title source is available', () => {
+    const hexId = 'a1b2c3d4e5f6a7b8';
+    window.history.pushState({}, '', `/app/${hexId}`);
+
+    // No title element, document.title is default
+    Object.defineProperty(document, 'title', {
+      value: 'Google Gemini',
+      writable: true,
+      configurable: true,
+    });
+
+    const result = manager.extractConversationInfoFromPage();
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Untitled');
+    expect(result!.id).toBe(hexId);
+  });
+
+  it('returns null for short hex IDs (less than 8 chars)', () => {
+    window.history.pushState({}, '', '/app/a1b2c3');
+    expect(manager.extractConversationInfoFromPage()).toBeNull();
+  });
+
+  it('returns null for non-hex IDs', () => {
+    window.history.pushState({}, '', '/app/not-a-valid-id');
+    expect(manager.extractConversationInfoFromPage()).toBeNull();
+  });
+
+  it('ignores disallowed titles like "New chat"', () => {
+    const hexId = 'a1b2c3d4e5f6a7b8';
+    window.history.pushState({}, '', `/app/${hexId}`);
+
+    const el = document.createElement('div');
+    el.className = 'conversation-title-container';
+    const span = document.createElement('span');
+    span.setAttribute('data-test-id', 'conversation-title');
+    span.textContent = 'New chat';
+    el.appendChild(span);
+    document.body.appendChild(el);
+
+    Object.defineProperty(document, 'title', {
+      value: 'Google Gemini',
+      writable: true,
+      configurable: true,
+    });
+
+    const result = manager.extractConversationInfoFromPage();
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Untitled');
+
+    el.remove();
+  });
+
+  it('uses second selector when first has disallowed title', () => {
+    const hexId = 'a1b2c3d4e5f6a7b8';
+    window.history.pushState({}, '', `/app/${hexId}`);
+
+    // First selector returns disallowed title
+    const el1 = document.createElement('div');
+    el1.className = 'conversation-title-container';
+    const span1 = document.createElement('span');
+    span1.setAttribute('data-test-id', 'conversation-title');
+    span1.textContent = 'Gemini';
+    el1.appendChild(span1);
+    document.body.appendChild(el1);
+
+    // Second selector returns valid title
+    const el2 = document.createElement('div');
+    el2.className = 'top-bar-actions';
+    const span2 = document.createElement('span');
+    span2.setAttribute('data-test-id', 'conversation-title');
+    span2.textContent = 'Valid Title';
+    el2.appendChild(span2);
+    document.body.appendChild(el2);
+
+    const result = manager.extractConversationInfoFromPage();
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Valid Title');
+
+    el1.remove();
+    el2.remove();
+  });
+});

--- a/src/pages/content/folder/__tests__/topMenuInjection.test.ts
+++ b/src/pages/content/folder/__tests__/topMenuInjection.test.ts
@@ -175,6 +175,41 @@ describe('extractConversationInfoFromPage', () => {
     el.remove();
   });
 
+  it.each([
+    '新对话',
+    '新對話',
+    '新しいチャット',
+    '새 채팅',
+    'Nuevo chat',
+    'Nouveau chat',
+    'Novo chat',
+    'Новый чат',
+    'محادثة جديدة',
+  ])('ignores localized "New chat" placeholder: %s', (placeholder) => {
+    const hexId = 'a1b2c3d4e5f6a7b8';
+    window.history.pushState({}, '', `/app/${hexId}`);
+
+    const el = document.createElement('div');
+    el.className = 'conversation-title-container';
+    const span = document.createElement('span');
+    span.setAttribute('data-test-id', 'conversation-title');
+    span.textContent = placeholder;
+    el.appendChild(span);
+    document.body.appendChild(el);
+
+    Object.defineProperty(document, 'title', {
+      value: 'Google Gemini',
+      writable: true,
+      configurable: true,
+    });
+
+    const result = manager.extractConversationInfoFromPage();
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Untitled');
+
+    el.remove();
+  });
+
   it('uses second selector when first has disallowed title', () => {
     const hexId = 'a1b2c3d4e5f6a7b8';
     window.history.pushState({}, '', `/app/${hexId}`);

--- a/src/pages/content/folder/__tests__/treeIndent.test.ts
+++ b/src/pages/content/folder/__tests__/treeIndent.test.ts
@@ -34,10 +34,17 @@ describe('folder tree indentation', () => {
   it('calculates folder and conversation paddings from indent and level', () => {
     expect(calculateFolderHeaderPaddingLeft(2, 16)).toBe(40); // 2 * 16 + 8
     expect(calculateFolderConversationPaddingLeft(2, 16)).toBe(56); // 2 * 16 + 24
-    expect(calculateFolderDialogPaddingLeft(2, 16)).toBe(44); // 2 * 16 + 12
     expect(calculateFolderHeaderPaddingLeft(2, -16)).toBe(0);
     expect(calculateFolderConversationPaddingLeft(3, -16)).toBe(0);
-    expect(calculateFolderDialogPaddingLeft(2, -16)).toBe(0);
+  });
+
+  it('dialog padding always indents subfolders further than parents', () => {
+    // Dialog is a flat list — uses a fixed positive per-level indent (16px),
+    // independent of the sidebar's folderTreeIndent setting (which can be
+    // negative to compact the nested tree view).
+    expect(calculateFolderDialogPaddingLeft(0)).toBe(12); // 0 * 16 + 12
+    expect(calculateFolderDialogPaddingLeft(1)).toBe(28); // 1 * 16 + 12
+    expect(calculateFolderDialogPaddingLeft(2)).toBe(44); // 2 * 16 + 12
   });
 
   it('updates indent and refreshes render when setting changes', () => {

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -80,8 +80,13 @@ export function calculateFolderConversationPaddingLeft(level: number, indent: nu
   return Math.max(0, level * indent + 24);
 }
 
-export function calculateFolderDialogPaddingLeft(level: number, indent: number): number {
-  return Math.max(0, level * indent + 12);
+// Move-to-folder dialog renders a flat list (no DOM nesting), so it needs its
+// own positive per-level indent. The sidebar's `folderTreeIndent` (which can
+// be negative to compact the nested tree view) doesn't apply here — using it
+// directly inverts the hierarchy in the dialog.
+const FOLDER_DIALOG_INDENT_PER_LEVEL = 16;
+export function calculateFolderDialogPaddingLeft(level: number): number {
+  return level * FOLDER_DIALOG_INDENT_PER_LEVEL + 12;
 }
 
 /**
@@ -4577,7 +4582,7 @@ export class FolderManager {
       sortedFolders.forEach((folder) => {
         const folderItem = document.createElement('button');
         folderItem.className = 'gv-folder-dialog-item';
-        folderItem.style.paddingLeft = `${calculateFolderDialogPaddingLeft(level, this.folderTreeIndent)}px`;
+        folderItem.style.paddingLeft = `${calculateFolderDialogPaddingLeft(level)}px`;
 
         // Folder icon
         const icon = document.createElement('mat-icon');

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -4834,7 +4834,12 @@ export class FolderManager {
       this.nativeMenuObserver.disconnect();
     }
 
-    // Observe the document for menu appearance and disappearance
+    // Observe the global overlay container for menu panels.
+    // Angular Material renders menus into .cdk-overlay-container which is a
+    // direct child of <body>. Observing at this level catches all menu
+    // insertions without being overwhelmed by unrelated DOM mutations.
+    const observeTarget = document.querySelector('.cdk-overlay-container') ?? document.body;
+
     this.nativeMenuObserver = new MutationObserver((mutations) => {
       if (this.isDestroyed) return;
       mutations.forEach((mutation) => {
@@ -4847,6 +4852,20 @@ export class FolderManager {
               // Check if this is a conversation menu (not model selection menu or other menus)
               if (this.isConversationMenu(node)) {
                 this.debug('Observer: conversation menu detected, preparing to inject');
+
+                // Sidebar menus have conversation info pre-populated by click tracking.
+                // Top-right (header) menus do NOT — extract independently from page.
+                if (!this.lastClickedConversationInfo) {
+                  const pageInfo = this.extractConversationInfoFromPage();
+                  if (pageInfo) {
+                    this.lastClickedConversationInfo = pageInfo;
+                    this.debug('Observer: populated info from page for top menu');
+                  } else {
+                    this.debug('Observer: page URL has no valid conversation ID, skipping');
+                    return;
+                  }
+                }
+
                 this.injectMoveToFolderButton(menuContent as HTMLElement);
               } else {
                 this.debug('Observer: non-conversation menu detected, skipping injection');
@@ -4874,7 +4893,7 @@ export class FolderManager {
       });
     });
 
-    this.nativeMenuObserver.observe(document.body, {
+    this.nativeMenuObserver.observe(observeTarget, {
       childList: true,
       subtree: true,
     });
@@ -6751,6 +6770,84 @@ export class FolderManager {
     }
 
     return null;
+  }
+
+  /**
+   * Extract conversation info from the current page URL and top-bar title.
+   * Used exclusively for the top-right conversation header menu (not sidebar).
+   *
+   * Returns null ONLY when the URL does not contain a valid conversation ID,
+   * in which case injection is skipped entirely.
+   * Title always has a fallback — never returns null for title.
+   */
+  private extractConversationInfoFromPage(): { id: string; title: string; url: string } | null {
+    // --- Robust URL parsing ---
+    let path: string;
+    try {
+      path = window.location.pathname;
+    } catch {
+      this.debugWarn('extractConversationInfoFromPage: failed to read location.pathname');
+      return null;
+    }
+
+    // Support multi-user prefix /u/<n>/, /app/<hexId>, and /gem/<gemId>/<hexId>
+    const hexMatch = path.match(/\/(?:app|gem\/[^/?#]+)\/([a-f0-9]{8,})/i);
+    if (!hexMatch?.[1]) {
+      this.debug('extractConversationInfoFromPage: no valid conversation ID in URL');
+      return null;
+    }
+    const id = hexMatch[1];
+    const url = window.location.href;
+
+    // --- Defensive title extraction ---
+    // Gemini generates titles asynchronously; the DOM element may not be ready yet.
+    // Try multiple selectors, then fallback to document.title, then to a default string.
+    const titleSelectors = [
+      '.conversation-title-container [data-test-id="conversation-title"]',
+      'top-bar-actions [data-test-id="conversation-title"]',
+      '.top-bar-actions [data-test-id="conversation-title"]',
+      '.conversation-title-container .conversation-title.gds-title-m',
+      'top-bar-actions .conversation-title.gds-title-m',
+    ];
+
+    const DISALLOWED_TITLES = new Set(['New chat', 'Gemini', 'Google Gemini', '']);
+
+    let title: string | null = null;
+    for (const sel of titleSelectors) {
+      try {
+        const el = document.querySelector(sel);
+        const text = el?.textContent?.trim();
+        if (text && !DISALLOWED_TITLES.has(text)) {
+          title = text;
+          break;
+        }
+      } catch {
+        // Continue to next selector
+      }
+    }
+
+    // Fallback 1: document.title (Gemini sets "Title - Gemini" format)
+    if (!title) {
+      try {
+        const docTitle = document.title?.trim();
+        if (docTitle) {
+          const cleaned = docTitle.replace(/\s*[-–—]\s*Gemini\s*$/i, '').trim();
+          if (cleaned && !DISALLOWED_TITLES.has(cleaned)) {
+            title = cleaned;
+          }
+        }
+      } catch {
+        // Continue to default
+      }
+    }
+
+    // Fallback 2: safe default — never return empty/null title
+    if (!title) {
+      title = 'Untitled';
+    }
+
+    this.debug('extractConversationInfoFromPage:', { id, title, url });
+    return { id, title, url };
   }
 
   private findNativeConversationLinkById(conversationId: string): HTMLAnchorElement | null {

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -6810,7 +6810,24 @@ export class FolderManager {
       'top-bar-actions .conversation-title.gds-title-m',
     ];
 
-    const DISALLOWED_TITLES = new Set(['New chat', 'Gemini', 'Google Gemini', '']);
+    // Placeholder strings Gemini shows before the chat is auto-titled.
+    // Must cover every locale Gemini supports — the DOM text is localized
+    // even though the brand name "Gemini" is not.
+    const DISALLOWED_TITLES = new Set([
+      '',
+      'Gemini',
+      'Google Gemini',
+      'New chat', // en
+      '新对话', // zh-CN
+      '新對話', // zh-TW
+      '新しいチャット', // ja
+      '새 채팅', // ko
+      'Nuevo chat', // es
+      'Nouveau chat', // fr
+      'Novo chat', // pt
+      'Новый чат', // ru
+      'محادثة جديدة', // ar
+    ]);
 
     let title: string | null = null;
     for (const sel of titleSelectors) {


### PR DESCRIPTION

### Description / 描述

在对话列表的菜单栏中有“移动到文件夹”功能，而对话界面没有，此PR在对话界面的菜单栏中也添加了“移动到文件夹”功能，这样在回看较早的对话时不用在对话列表中一直翻到当时的对话再移动到对应的文件夹。

通过 MutationObserver 独立监听右上角菜单的展开。当检测到该菜单且当前页面 URL 包含有效的对话 ID 时，直接从 window.location 提取对话 ID、从页面标题 DOM 提取对话名称，完成按钮注入。与侧边栏的点击追踪逻辑完全解耦，互不影响。

并且进行了边界处理：

- 标题异步生成场景下有多级 fallback（DOM 选择器 → document.title → 默认值 "Untitled"）
- URL 无法解析出对话 ID 时直接跳过，不注入
- Observer 挂载在 .cdk-overlay-container（Angular Material 全局菜单容器），确保可靠捕获菜单 DOM 插入

### Related Issue / 相关 Issue

已提交相关Issue #631 。

### Visual Proof / 可视化证据

在firefox和chrome中均验证了功能修改无误，以下为firefox上的功能验证展示录屏：

https://github.com/user-attachments/assets/2a1bc3e7-ba5c-4fa7-8785-e7606d2d4468

### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
