### PR TITLE
fix(ui): timeline level3 dot clippath and box-shadow conflict

### DIFF
--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -255,17 +255,20 @@ html.dark .timeline-dot:not(.active):not(.starred)::after,
 }
 
 .timeline-dot[data-level='3']:hover::before {
-  transform: scale(1.15);
+  transform: translate(-50%, -50%) scale(1.15);
 }
 
 /* triangle fix due to conflict in the triangle clip-path and box-shadow */
 .timeline-dot[data-level='3'].active::before {
   content: '';
   position: absolute;
-  inset: 4px;
+  inset: -3px;
+  left: 50%; 
+  top: 50%; 
+  transform: translate(-50%, -50%) ;
   background: var(--timeline-dot-active-color);
   /* use 90% to make the base of the triangular shadow less thick. */
-  clip-path: polygon(50% 0%, 0% 90%, 100% 90%);
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
 }
 
 /* ===== Timeline Context Menu ===== */

--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -272,6 +272,11 @@ html.dark .timeline-dot:not(.active):not(.starred)::after,
   clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
 }
 
+/* triangle clip-path also clips box-shadow, so use drop-shadow for focus-visible glow */
+.timeline-dot[data-level='3']:focus-visible::after {
+  filter: drop-shadow(0 0 6px var(--timeline-dot-active-color));
+}
+
 /* ===== Timeline Context Menu ===== */
 .timeline-context-menu {
   position: fixed;

--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -254,6 +254,20 @@ html.dark .timeline-dot:not(.active):not(.starred)::after,
   clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
 }
 
+.timeline-dot[data-level='3']:hover::before {
+  transform: scale(1.15);
+}
+
+/* triangle fix due to conflict in the triangle clip-path and box-shadow */
+.timeline-dot[data-level='3'].active::before {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  background: var(--timeline-dot-active-color);
+  /* use 90% to make the base of the triangular shadow less thick. */
+  clip-path: polygon(50% 0%, 0% 90%, 100% 90%);
+}
+
 /* ===== Timeline Context Menu ===== */
 .timeline-context-menu {
   position: fixed;

--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -262,10 +262,11 @@ html.dark .timeline-dot:not(.active):not(.starred)::after,
 .timeline-dot[data-level='3'].active::before {
   content: '';
   position: absolute;
-  inset: -3px;
   left: 50%; 
   top: 50%; 
-  transform: translate(-50%, -50%) ;
+  width: calc(var(--timeline-dot-size) + 6px);
+  height: calc(var(--timeline-dot-size) + 6px);
+  transform: translate(-50%, -50%);
   background: var(--timeline-dot-active-color);
   /* use 90% to make the base of the triangular shadow less thick. */
   clip-path: polygon(50% 0%, 0% 100%, 100% 100%);

--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -262,8 +262,8 @@ html.dark .timeline-dot:not(.active):not(.starred)::after,
 .timeline-dot[data-level='3'].active::before {
   content: '';
   position: absolute;
-  left: 50%; 
-  top: 50%; 
+  left: 50%;
+  top: 50%;
   width: calc(var(--timeline-dot-size) + 6px);
   height: calc(var(--timeline-dot-size) + 6px);
   transform: translate(-50%, -50%);


### PR DESCRIPTION
### Description / 描述

现在的第三层级节点是三角形, 在active之后没有阴影效果, 这是因为clippath和box-shadow冲突了
css加个before解决

#### bug1

复现方法: 设置节点为三角形, 点击该节点, 发现无高亮
我用人工微调的方法修复了下, 尽可能做到了最接近正方形和圆形的样式

#### bug2(我不知道怎么解决)

复现方法: 设置节点为三角形,, 按tab聚焦到该节点的时候, 发现没有圆环阴影
这个我没解决, 感觉很难复现和正方形和圆形节点一样的 focus-visible 效果

### Visual Proof / 可视化证据

如图, 移动到最顶部(其实这还有个bug, 如果对话太短不会高亮第一个)的时候, 无法高亮

<img width="232" height="311" alt="image" src="https://github.com/user-attachments/assets/a1c69ce0-52ab-465a-8b9e-3150c28ceb8b" />

修复后

<img width="304" height="487" alt="image" src="https://github.com/user-attachments/assets/1c718999-652c-4610-9e3e-37d6128b9d83" />

### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: 未测试

### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

[代码校验记录](https://github.com/u5n/gemini-voyager/actions/runs/24930128739/job/73006426219)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
