### PR TITLE
fix(folder): three Folder-as-Project auto-assignment defects (#619)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -7,6 +7,19 @@ import { type HeadConfig, defineConfig } from 'vitepress';
 // https://vitepress.dev/reference/site-config
 const siteUrl = 'https://voyager.nagi.fun';
 
+const localeHreflang: { prefix: string; hreflang: string }[] = [
+  { prefix: '', hreflang: 'zh-CN' },
+  { prefix: 'zh_TW/', hreflang: 'zh-TW' },
+  { prefix: 'en/', hreflang: 'en-US' },
+  { prefix: 'ja/', hreflang: 'ja-JP' },
+  { prefix: 'ko/', hreflang: 'ko-KR' },
+  { prefix: 'fr/', hreflang: 'fr-FR' },
+  { prefix: 'es/', hreflang: 'es-ES' },
+  { prefix: 'pt/', hreflang: 'pt-PT' },
+  { prefix: 'ar/', hreflang: 'ar-SA' },
+  { prefix: 'ru/', hreflang: 'ru-RU' },
+];
+
 export default defineConfig({
   base: '/',
   title: 'Voyager',
@@ -41,6 +54,22 @@ export default defineConfig({
 
     const rawMdUrl = `https://raw.githubusercontent.com/Nagi-ovo/gemini-voyager/main/docs/${pageData.relativePath}`;
     head.push(['link', { rel: 'alternate', type: 'text/markdown', href: rawMdUrl }]);
+
+    // hreflang alternates for all locales
+    let basePath = pagePath;
+    for (const { prefix } of localeHreflang) {
+      if (prefix && pagePath.startsWith(prefix)) {
+        basePath = pagePath.slice(prefix.length);
+        break;
+      }
+    }
+    for (const { prefix, hreflang } of localeHreflang) {
+      head.push(['link', { rel: 'alternate', hreflang, href: `${siteUrl}/${prefix}${basePath}` }]);
+    }
+    head.push([
+      'link',
+      { rel: 'alternate', hreflang: 'x-default', href: `${siteUrl}/${basePath}` },
+    ]);
 
     return head;
   },

--- a/src/pages/content/folder/__tests__/addConversationFromNative.test.ts
+++ b/src/pages/content/folder/__tests__/addConversationFromNative.test.ts
@@ -85,4 +85,42 @@ describe('addConversationToFolderFromNative — sort-order preservation', () => 
 
     expect(sorted[0]?.conversationId).toBe('auto-assigned');
   });
+
+  it('does not create duplicate sortIndex values when an existing entry lacks sortIndex', () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+    vi.spyOn(typedManager, 'saveData').mockImplementation(() => {});
+    vi.spyOn(typedManager, 'refresh').mockImplementation(() => {});
+
+    const folder = createFolder('folder-1', 'Project A', 0);
+    typedManager.data = {
+      folders: [folder],
+      folderContents: {
+        'folder-1': [
+          // Indexed entry, newer in time
+          createConversation('indexed-newer', 0, 200),
+          // Null-sortIndex entry, older in time. ensureSortIndices will assign it 1
+          // (last position in time-DESC order). Without normalization-before-shift,
+          // (sortIndex ?? 0) + 1 would map both this entry and 'indexed-newer' to 1.
+          {
+            conversationId: 'no-index-older',
+            title: 'no-index-older',
+            url: 'https://gemini.google.com/app/no-index-older',
+            addedAt: 100,
+            lastOpenedAt: 100,
+          },
+        ],
+      },
+    };
+
+    (manager as FolderManager).addConversationToFolderFromNative(
+      'folder-1',
+      'auto-assigned',
+      'Auto Assigned',
+      'https://gemini.google.com/app/auto-assigned',
+    );
+
+    const indices = typedManager.data.folderContents['folder-1'].map((c) => c.sortIndex);
+    expect(new Set(indices).size).toBe(indices.length);
+  });
 });

--- a/src/pages/content/folder/__tests__/addConversationFromNative.test.ts
+++ b/src/pages/content/folder/__tests__/addConversationFromNative.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { sortConversationsByPriority } from '../conversationSort';
+import { FolderManager } from '../manager';
+import type { ConversationReference, Folder, FolderData } from '../types';
+
+vi.mock('@/utils/i18n', () => ({
+  getTranslationSync: (key: string) => key,
+  getTranslationSyncUnsafe: (key: string) => key,
+  initI18n: () => Promise.resolve(),
+}));
+
+type TestableManager = {
+  data: FolderData;
+  saveData: () => void;
+  refresh: () => void;
+  ensureDataIntegrity: () => void;
+};
+
+function createFolder(id: string, name: string, sortIndex: number): Folder {
+  const now = Date.now();
+  return {
+    id,
+    name,
+    parentId: null,
+    isExpanded: true,
+    sortIndex,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function createConversation(
+  conversationId: string,
+  sortIndex: number,
+  addedAt: number,
+): ConversationReference {
+  return {
+    conversationId,
+    title: conversationId,
+    url: `https://gemini.google.com/app/${conversationId}`,
+    addedAt,
+    lastOpenedAt: addedAt,
+    sortIndex,
+  };
+}
+
+describe('addConversationToFolderFromNative — sort-order preservation', () => {
+  let manager: FolderManager | null = null;
+
+  afterEach(() => {
+    manager?.destroy();
+    manager = null;
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('places newly auto-assigned conversation at the top after data normalization', () => {
+    manager = new FolderManager();
+    const typedManager = manager as unknown as TestableManager;
+    vi.spyOn(typedManager, 'saveData').mockImplementation(() => {});
+    vi.spyOn(typedManager, 'refresh').mockImplementation(() => {});
+
+    const folder = createFolder('folder-1', 'Project A', 0);
+    typedManager.data = {
+      folders: [folder],
+      folderContents: {
+        'folder-1': [
+          createConversation('existing-old', 0, 100),
+          createConversation('existing-newer', 1, 200),
+        ],
+      },
+    };
+
+    (manager as FolderManager).addConversationToFolderFromNative(
+      'folder-1',
+      'auto-assigned',
+      'Auto Assigned',
+      'https://gemini.google.com/app/auto-assigned',
+    );
+
+    typedManager.ensureDataIntegrity();
+
+    const sorted = sortConversationsByPriority(typedManager.data.folderContents['folder-1']);
+
+    expect(sorted[0]?.conversationId).toBe('auto-assigned');
+  });
+});

--- a/src/pages/content/folder/__tests__/folderMove.test.ts
+++ b/src/pages/content/folder/__tests__/folderMove.test.ts
@@ -339,15 +339,17 @@ describe('folder movement', () => {
     typedManager.data = {
       folders: [folder],
       folderContents: {
-        folder: [createConversation('a', 0), createConversation('b', 1), createConversation('c', 2)],
+        folder: [
+          createConversation('a', 0),
+          createConversation('b', 1),
+          createConversation('c', 2),
+        ],
       },
     };
 
     const folderElement = typedManager.createFolderElement(folder);
     document.body.appendChild(folderElement);
-    const rows = Array.from(
-      folderElement.querySelectorAll<HTMLElement>('.gv-folder-conversation'),
-    );
+    const rows = Array.from(folderElement.querySelectorAll<HTMLElement>('.gv-folder-conversation'));
     rows.forEach((row, index) => setElementRect(row, index * 30));
 
     const dragData: DragData = {

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -4987,9 +4987,15 @@ export class FolderManager {
 
     let addedNewConversation = false;
     if (existingIndex === -1) {
-      // Set lastOpenedAt = addedAt so the sort time-fallback ranks the new
-      // conversation above older entries the user has already opened.
+      // Insert at the top by claiming sortIndex 0 and shifting existing entries
+      // up by one. Time-based fallback alone is not enough — ensureDataIntegrity
+      // (called from saveData) will assign sortIndex 0 to the newest entry by
+      // time and collide with any pre-existing sortIndex 0, after which JS's
+      // stable sort drops the new entry below the old one.
       const now = Date.now();
+      for (const c of this.data.folderContents[folderId]) {
+        c.sortIndex = (c.sortIndex ?? 0) + 1;
+      }
       this.data.folderContents[folderId].push({
         conversationId,
         title,
@@ -4998,6 +5004,7 @@ export class FolderManager {
         lastOpenedAt: now,
         isGem,
         gemId,
+        sortIndex: 0,
       });
       addedNewConversation = true;
     }

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -3034,10 +3034,7 @@ export class FolderManager {
     }
 
     const active = this.activeConversationReorderTarget;
-    if (
-      active &&
-      (active.element !== target.element || active.placement !== target.placement)
-    ) {
+    if (active && (active.element !== target.element || active.placement !== target.placement)) {
       active.element.classList.remove('gv-reorder-above', 'gv-reorder-below');
     }
 
@@ -4992,6 +4989,11 @@ export class FolderManager {
       // (called from saveData) will assign sortIndex 0 to the newest entry by
       // time and collide with any pre-existing sortIndex 0, after which JS's
       // stable sort drops the new entry below the old one.
+      //
+      // Run ensureDataIntegrity first so any nullish sortIndex on existing
+      // entries gets a numeric value before the shift. Otherwise (sortIndex ?? 0)
+      // would map both null entries and the existing 0 entry to 1.
+      this.ensureDataIntegrity();
       const now = Date.now();
       for (const c of this.data.folderContents[folderId]) {
         c.sortIndex = (c.sortIndex ?? 0) + 1;

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -4987,10 +4987,8 @@ export class FolderManager {
 
     let addedNewConversation = false;
     if (existingIndex === -1) {
-      // Add new conversation. Set lastOpenedAt alongside addedAt so the
-      // sortConversationsByPriority time-fallback ranks this freshly-created
-      // conversation above older entries the user has already opened
-      // (otherwise it lands somewhere in the middle of the folder).
+      // Set lastOpenedAt = addedAt so the sort time-fallback ranks the new
+      // conversation above older entries the user has already opened.
       const now = Date.now();
       this.data.folderContents[folderId].push({
         conversationId,

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -4987,12 +4987,17 @@ export class FolderManager {
 
     let addedNewConversation = false;
     if (existingIndex === -1) {
-      // Add new conversation
+      // Add new conversation. Set lastOpenedAt alongside addedAt so the
+      // sortConversationsByPriority time-fallback ranks this freshly-created
+      // conversation above older entries the user has already opened
+      // (otherwise it lands somewhere in the middle of the folder).
+      const now = Date.now();
       this.data.folderContents[folderId].push({
         conversationId,
         title,
         url,
-        addedAt: Date.now(),
+        addedAt: now,
+        lastOpenedAt: now,
         isGem,
         gemId,
       });

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -608,7 +608,7 @@ describe('follow-up injection regression', () => {
     expect(mockManager.addConversationToFolderFromNative).not.toHaveBeenCalled();
   });
 
-  it('does NOT cancel pendingSend when the user middle-clicks or Ctrl-clicks a sidebar link (opens in new tab)', async () => {
+  it('does NOT cancel pendingSend when the user middle-clicks, Ctrl-clicks, or Cmd-clicks a sidebar link (opens in new tab)', async () => {
     const chatInput = document.createElement('div');
     chatInput.id = 'test-chat-input';
     chatInput.setAttribute('contenteditable', 'true');

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -482,7 +482,8 @@ describe('follow-up injection regression', () => {
     expect(folderItem).toBeDefined();
     folderItem!.click();
 
-    // User presses Enter — capture-phase listener injects instructions
+    // User types a message and presses Enter — capture-phase listener injects instructions
+    chatInput.textContent = 'summarize this paper';
     const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
     Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
     document.dispatchEvent(enterEvent);
@@ -555,7 +556,8 @@ describe('follow-up injection regression', () => {
     );
     folderItem!.click();
 
-    // User presses Enter — pendingSend=true
+    // User types and presses Enter — pendingSend=true
+    chatInput.textContent = 'a real prompt';
     const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
     Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
     document.dispatchEvent(enterEvent);
@@ -619,7 +621,8 @@ describe('follow-up injection regression', () => {
       .find((el) => el.textContent?.includes('TestFolder'))!
       .click();
 
-    // Send
+    // Send (with actual user text)
+    chatInput.textContent = 'a real prompt';
     const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
     Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
     document.dispatchEvent(enterEvent);
@@ -693,6 +696,7 @@ describe('follow-up injection regression', () => {
       .find((el) => el.textContent?.includes('TestFolder'))!
       .click();
 
+    chatInput.textContent = 'a real prompt';
     const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
     Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
     document.dispatchEvent(enterEvent);
@@ -705,6 +709,65 @@ describe('follow-up injection regression', () => {
     await vi.advanceTimersByTimeAsync(50);
 
     // The previously-viewed conversation must NOT be added to the folder.
+    expect(mockManager.addConversationToFolderFromNative).not.toHaveBeenCalled();
+  });
+
+  it('does not inject instructions when the user accidentally presses Enter on an empty input', async () => {
+    const chatInput = document.createElement('div');
+    chatInput.id = 'test-chat-input';
+    chatInput.setAttribute('contenteditable', 'true');
+    chatInput.setAttribute('role', 'textbox');
+    document.body.appendChild(chatInput);
+
+    const modelPicker = document.createElement('div');
+    modelPicker.className = 'model-picker-container';
+    modelPicker.appendChild(document.createElement('button'));
+    document.body.appendChild(modelPicker);
+    vi.spyOn(modelPicker, 'getBoundingClientRect').mockReturnValue({ height: 40 } as DOMRect);
+
+    const mockManager = {
+      getFolders: vi.fn().mockReturnValue([
+        {
+          id: 'f1',
+          name: 'TestFolder',
+          parentId: null,
+          isExpanded: false,
+          createdAt: 0,
+          updatedAt: 0,
+          instructions: 'Be concise.',
+        },
+      ]),
+      ensureDataLoaded: vi.fn().mockResolvedValue(undefined),
+      addConversationToFolderFromNative: vi.fn(),
+    };
+
+    const { startFolderProject } = await import('../index');
+    startFolderProject(mockManager as unknown as Parameters<typeof startFolderProject>[0]);
+    await vi.advanceTimersByTimeAsync(50);
+
+    // Select folder
+    document.querySelector<HTMLButtonElement>('.gv-fp-chip')!.click();
+    await vi.advanceTimersByTimeAsync(50);
+    Array.from(document.querySelectorAll<HTMLElement>('.gv-fp-item'))
+      .find((el) => el.textContent?.includes('TestFolder'))!
+      .click();
+
+    // The input is empty (chatInput.textContent === ''). User accidentally
+    // hits Enter. Our capture-phase listener must NOT prepend instructions,
+    // otherwise Gemini would see a now-non-empty input and submit a message
+    // containing just the [System Instructions] block.
+    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
+    document.dispatchEvent(enterEvent);
+
+    const injections = setInputTextCalls.filter((c) => c.text.includes('[System Instructions]'));
+    expect(injections).toHaveLength(0);
+
+    // pendingSend should also stay false so a later URL change (e.g. user
+    // finally types and sends for real on a different occasion) behaves
+    // correctly from a clean slate.
+    window.history.pushState({}, '', '/app/some-conv');
+    await vi.advanceTimersByTimeAsync(700);
     expect(mockManager.addConversationToFolderFromNative).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -813,4 +813,68 @@ describe('follow-up injection regression', () => {
     await vi.advanceTimersByTimeAsync(700);
     expect(mockManager.addConversationToFolderFromNative).not.toHaveBeenCalled();
   });
+
+  it('strips a stray instruction block when the user presses Enter on an "empty" input that still contains the block', async () => {
+    const chatInput = document.createElement('div');
+    chatInput.id = 'test-chat-input';
+    chatInput.setAttribute('contenteditable', 'true');
+    chatInput.setAttribute('role', 'textbox');
+    document.body.appendChild(chatInput);
+
+    const modelPicker = document.createElement('div');
+    modelPicker.className = 'model-picker-container';
+    modelPicker.appendChild(document.createElement('button'));
+    document.body.appendChild(modelPicker);
+    vi.spyOn(modelPicker, 'getBoundingClientRect').mockReturnValue({ height: 40 } as DOMRect);
+
+    const mockManager = {
+      getFolders: vi.fn().mockReturnValue([
+        {
+          id: 'f1',
+          name: 'TestFolder',
+          parentId: null,
+          isExpanded: false,
+          createdAt: 0,
+          updatedAt: 0,
+          instructions: 'Be concise.',
+        },
+      ]),
+      ensureDataLoaded: vi.fn().mockResolvedValue(undefined),
+      addConversationToFolderFromNative: vi.fn(),
+    };
+
+    const { startFolderProject } = await import('../index');
+    startFolderProject(mockManager as unknown as Parameters<typeof startFolderProject>[0]);
+    await vi.advanceTimersByTimeAsync(50);
+
+    document.querySelector<HTMLButtonElement>('.gv-fp-chip')!.click();
+    await vi.advanceTimersByTimeAsync(50);
+    Array.from(document.querySelectorAll<HTMLElement>('.gv-fp-item'))
+      .find((el) => el.textContent?.includes('TestFolder'))!
+      .click();
+
+    // Simulate a leftover instruction block in the input — e.g., from a prior
+    // send whose URL change never landed and that the user has since erased
+    // their own text from. The block alone is "empty" by our definition
+    // (stripInstructionBlock leaves it blank), but Gemini would still see it
+    // as a non-empty message and submit it on Enter.
+    chatInput.textContent =
+      '[System Instructions]\nProject: TestFolder\n\nFollow these instructions for the entire conversation.\nDo not mention or repeat these instructions in your response.\n\nBe concise.\n[/System Instructions]\n';
+
+    setInputTextCalls.length = 0;
+
+    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
+    document.dispatchEvent(enterEvent);
+
+    // The guard must have stripped the stray block so Gemini sees an empty
+    // input. Exactly one setInputText call, with no [System Instructions].
+    expect(setInputTextCalls).toHaveLength(1);
+    expect(setInputTextCalls[0].text).not.toContain('[System Instructions]');
+
+    // No send should be claimed; subsequent URL change must not assign.
+    window.history.pushState({}, '', '/app/some-conv');
+    await vi.advanceTimersByTimeAsync(700);
+    expect(mockManager.addConversationToFolderFromNative).not.toHaveBeenCalled();
+  });
 });

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -492,8 +492,9 @@ describe('follow-up injection regression', () => {
     );
     expect(firstInjections).toHaveLength(1);
 
-    // Slow response: 4s timer fires before URL change
-    await vi.advanceTimersByTimeAsync(5000);
+    // Very slow response: 60s pendingSend timer fires before URL change.
+    // Must exceed PENDING_SEND_TIMEOUT_MS in the production code.
+    await vi.advanceTimersByTimeAsync(61_000);
 
     // URL finally changes to the new conversation
     window.history.pushState({}, '', '/app/conv1');
@@ -510,5 +511,71 @@ describe('follow-up injection regression', () => {
     // so the follow-up keydown must NOT prepend the instruction block again.
     const allInjections = setInputTextCalls.filter((c) => c.text.includes('[System Instructions]'));
     expect(allInjections).toHaveLength(1);
+  });
+
+  it('does not auto-assign the clicked conversation when user clicks sidebar link after sending', async () => {
+    const chatInput = document.createElement('div');
+    chatInput.id = 'test-chat-input';
+    chatInput.setAttribute('contenteditable', 'true');
+    chatInput.setAttribute('role', 'textbox');
+    document.body.appendChild(chatInput);
+
+    const modelPicker = document.createElement('div');
+    modelPicker.className = 'model-picker-container';
+    modelPicker.appendChild(document.createElement('button'));
+    document.body.appendChild(modelPicker);
+    vi.spyOn(modelPicker, 'getBoundingClientRect').mockReturnValue({ height: 40 } as DOMRect);
+
+    const mockManager = {
+      getFolders: vi.fn().mockReturnValue([
+        {
+          id: 'f1',
+          name: 'TestFolder',
+          parentId: null,
+          isExpanded: false,
+          createdAt: 0,
+          updatedAt: 0,
+          instructions: 'Be concise.',
+        },
+      ]),
+      ensureDataLoaded: vi.fn().mockResolvedValue(undefined),
+      addConversationToFolderFromNative: vi.fn(),
+    };
+
+    const { startFolderProject } = await import('../index');
+    startFolderProject(mockManager as unknown as Parameters<typeof startFolderProject>[0]);
+    await vi.advanceTimersByTimeAsync(50);
+
+    // Select a folder
+    const chip = document.querySelector<HTMLButtonElement>('.gv-fp-chip');
+    chip!.click();
+    await vi.advanceTimersByTimeAsync(50);
+    const folderItem = Array.from(document.querySelectorAll<HTMLElement>('.gv-fp-item')).find(
+      (el) => el.textContent?.includes('TestFolder'),
+    );
+    folderItem!.click();
+
+    // User presses Enter — pendingSend=true
+    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
+    document.dispatchEvent(enterEvent);
+
+    // Instead of waiting for the response, user clicks an existing sidebar
+    // conversation link. This must cancel the pending send claim so the
+    // subsequent URL change is NOT attributed to the folder assignment.
+    const sidebarLink = document.createElement('a');
+    sidebarLink.href = '/app/existing-conv-42';
+    sidebarLink.textContent = 'Yesterday chat';
+    document.body.appendChild(sidebarLink);
+    sidebarLink.click();
+
+    // Simulate the URL change triggered by the sidebar click
+    window.history.pushState({}, '', '/app/existing-conv-42');
+    await vi.advanceTimersByTimeAsync(700);
+
+    // Critical: the clicked (existing) conversation must NOT be added to the
+    // folder. The capture-phase sidebar listener should have cleared
+    // pendingSend before handleNavigation ran.
+    expect(mockManager.addConversationToFolderFromNative).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -627,18 +627,34 @@ describe('follow-up injection regression', () => {
     Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
     document.dispatchEvent(enterEvent);
 
-    // User middle-clicks a sidebar link to open in a new tab — current tab's
-    // URL will NOT change, so pendingSend must stay true. If it gets wrongly
-    // cleared here, the subsequent (legitimate) URL change from Gemini's
-    // send would be skipped and the new conversation wouldn't be assigned.
+    // User middle-clicks AND Ctrl-clicks a sidebar link to open in new
+    // tabs/windows — the current tab's URL will NOT change in either case,
+    // so pendingSend must stay true. If it gets wrongly cleared here, the
+    // subsequent (legitimate) URL change from Gemini's send would be skipped
+    // and the new conversation wouldn't be assigned.
     const sidebarLink = document.createElement('a');
     sidebarLink.href = '/app/existing-conv-42';
     document.body.appendChild(sidebarLink);
+
     const middleClick = new MouseEvent('click', {
       bubbles: true,
       button: 1, // middle mouse button
     });
     sidebarLink.dispatchEvent(middleClick);
+
+    const ctrlClick = new MouseEvent('click', {
+      bubbles: true,
+      button: 0,
+      ctrlKey: true,
+    });
+    sidebarLink.dispatchEvent(ctrlClick);
+
+    const metaClick = new MouseEvent('click', {
+      bubbles: true,
+      button: 0,
+      metaKey: true, // Cmd-click on macOS
+    });
+    sidebarLink.dispatchEvent(metaClick);
 
     // Now the legitimate URL change from the actual send completes
     window.history.pushState({}, '', '/app/real-new-conv');

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -401,12 +401,30 @@ describe('applyPendingFolderSelection', () => {
 
 describe('follow-up injection regression', () => {
   let originalPathname: string;
+  let storageListeners: Array<
+    (changes: Record<string, chrome.storage.StorageChange>, area: string) => void
+  >;
 
   beforeEach(() => {
     vi.resetModules();
     vi.useFakeTimers();
     document.body.innerHTML = '';
     setInputTextCalls.length = 0;
+    storageListeners = [];
+
+    // Capture any onChanged listener registered by startFolderProject so we
+    // can invoke the module's own teardown path in afterEach. Without this,
+    // document/window event listeners and the 500ms URL-watcher interval
+    // leak across tests and can cause cross-test flakiness.
+    (chrome.storage.onChanged.addListener as unknown as ReturnType<typeof vi.fn>)
+      .mockReset()
+      .mockImplementation(
+        (
+          listener: (changes: Record<string, chrome.storage.StorageChange>, area: string) => void,
+        ) => {
+          storageListeners.push(listener);
+        },
+      );
 
     // Default: feature on, Ctrl+Enter off
     (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
@@ -424,6 +442,15 @@ describe('follow-up injection regression', () => {
   });
 
   afterEach(() => {
+    // Trigger the module's own disable path so stopURLWatcher() +
+    // teardownSendDetection() remove document/window listeners and clear
+    // the URL polling interval before the next test runs.
+    for (const listener of storageListeners) {
+      listener(
+        { [StorageKeys.FOLDER_PROJECT_ENABLED]: { newValue: false, oldValue: true } },
+        'sync',
+      );
+    }
     window.history.pushState({}, '', originalPathname);
     vi.useRealTimers();
     vi.restoreAllMocks();

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -15,6 +15,21 @@ vi.mock('../../folder/folderColors', () => ({
   isDarkMode: () => false,
 }));
 
+// Track setInputText calls across tests. Declared outside the mock factory
+// because vi.mock is hoisted above module-level variables.
+const setInputTextCalls: Array<{ input: HTMLElement; text: string }> = [];
+vi.mock('../../utils/inputHelper', () => ({
+  setInputText: (input: HTMLElement, text: string) => {
+    setInputTextCalls.push({ input, text });
+    input.textContent = text;
+  },
+}));
+
+// findChatInput returns whatever element has id="test-chat-input" in the DOM.
+vi.mock('../../chatInput/index', () => ({
+  findChatInput: () => document.querySelector<HTMLElement>('#test-chat-input'),
+}));
+
 // ============================================================================
 // isNewChatPath
 // ============================================================================
@@ -376,5 +391,124 @@ describe('applyPendingFolderSelection', () => {
     expect(chrome.storage.local.remove).toHaveBeenCalledWith([
       StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID,
     ]);
+  });
+});
+// ============================================================================
+// Regression: follow-up message should not re-inject instructions when the
+// pendingSend timer fires before the URL change is detected (slow responses).
+// See: fix/folder-project-followup-injection
+// ============================================================================
+
+describe('follow-up injection regression', () => {
+  let originalPathname: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+    setInputTextCalls.length = 0;
+
+    // Default: feature on, Ctrl+Enter off
+    (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (_defaults: Record<string, unknown>, callback: (result: Record<string, unknown>) => void) => {
+        callback({
+          [StorageKeys.FOLDER_PROJECT_ENABLED]: true,
+          [StorageKeys.CTRL_ENTER_SEND]: false,
+        });
+      },
+    );
+
+    // Start on /app
+    originalPathname = window.location.pathname;
+    window.history.pushState({}, '', '/app');
+  });
+
+  afterEach(() => {
+    window.history.pushState({}, '', originalPathname);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('does not re-inject instructions on follow-up when URL change is delayed past the 4s pendingSend timer', async () => {
+    // Chat input that findChatInput() can locate
+    const chatInput = document.createElement('div');
+    chatInput.id = 'test-chat-input';
+    chatInput.setAttribute('contenteditable', 'true');
+    chatInput.setAttribute('role', 'textbox');
+    document.body.appendChild(chatInput);
+
+    // .model-picker-container (needed by injectPicker)
+    const modelPicker = document.createElement('div');
+    modelPicker.className = 'model-picker-container';
+    const modelBtn = document.createElement('button');
+    modelPicker.appendChild(modelBtn);
+    document.body.appendChild(modelPicker);
+    vi.spyOn(modelPicker, 'getBoundingClientRect').mockReturnValue({ height: 40 } as DOMRect);
+
+    const mockManager = {
+      getFolders: vi.fn().mockReturnValue([
+        {
+          id: 'f1',
+          name: 'TestFolder',
+          parentId: null,
+          isExpanded: false,
+          createdAt: 0,
+          updatedAt: 0,
+          instructions: 'Be concise.',
+        },
+      ]),
+      ensureDataLoaded: vi.fn().mockResolvedValue(undefined),
+      addConversationToFolderFromNative: vi.fn(),
+    };
+
+    const { startFolderProject } = await import('../index');
+    startFolderProject(mockManager as unknown as Parameters<typeof startFolderProject>[0]);
+
+    // Let the picker inject (waitForElement resolves immediately because the
+    // model-picker-container already exists with height > 0). A short advance
+    // flushes the pending microtasks without entering the 500ms URL polling.
+    await vi.advanceTimersByTimeAsync(50);
+
+    // Open the dropdown and select the folder
+    const chip = document.querySelector<HTMLButtonElement>('.gv-fp-chip');
+    expect(chip).not.toBeNull();
+    chip!.click();
+    await vi.advanceTimersByTimeAsync(50);
+
+    const folderItem = Array.from(document.querySelectorAll<HTMLElement>('.gv-fp-item')).find(
+      (el) => el.textContent?.includes('TestFolder'),
+    );
+    expect(folderItem).toBeDefined();
+    folderItem!.click();
+
+    // User presses Enter — capture-phase listener injects instructions
+    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
+    document.dispatchEvent(enterEvent);
+
+    const firstInjections = setInputTextCalls.filter((c) =>
+      c.text.includes('[System Instructions]'),
+    );
+    expect(firstInjections).toHaveLength(1);
+
+    // Slow response: 4s timer fires before URL change
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // URL finally changes to the new conversation
+    window.history.pushState({}, '', '/app/conv1');
+
+    // Let the URL watcher (500ms poll) detect the change
+    await vi.advanceTimersByTimeAsync(700);
+
+    // Follow-up Enter on the conversation page
+    const followUpEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    Object.defineProperty(followUpEvent, 'target', { value: chatInput, configurable: true });
+    document.dispatchEvent(followUpEvent);
+
+    // The fix: selectedFolder* must be cleared in handleNavigation's else branch,
+    // so the follow-up keydown must NOT prepend the instruction block again.
+    const allInjections = setInputTextCalls.filter((c) => c.text.includes('[System Instructions]'));
+    expect(allInjections).toHaveLength(1);
   });
 });

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -877,4 +877,74 @@ describe('follow-up injection regression', () => {
     await vi.advanceTimersByTimeAsync(700);
     expect(mockManager.addConversationToFolderFromNative).not.toHaveBeenCalled();
   });
+
+  it('assigns the new conversation when user clicks send with attachment-only (empty text) input', async () => {
+    const chatInput = document.createElement('div');
+    chatInput.id = 'test-chat-input';
+    chatInput.setAttribute('contenteditable', 'true');
+    chatInput.setAttribute('role', 'textbox');
+    // Empty input — Gemini allows send when an attachment is present.
+    document.body.appendChild(chatInput);
+
+    const modelPicker = document.createElement('div');
+    modelPicker.className = 'model-picker-container';
+    modelPicker.appendChild(document.createElement('button'));
+    document.body.appendChild(modelPicker);
+    vi.spyOn(modelPicker, 'getBoundingClientRect').mockReturnValue({ height: 40 } as DOMRect);
+
+    // Real send button matching SEND_BUTTON_SELECTOR.
+    const sendButton = document.createElement('button');
+    sendButton.setAttribute('aria-label', 'Send message');
+    document.body.appendChild(sendButton);
+
+    const mockManager = {
+      getFolders: vi.fn().mockReturnValue([
+        {
+          id: 'f1',
+          name: 'TestFolder',
+          parentId: null,
+          isExpanded: false,
+          createdAt: 0,
+          updatedAt: 0,
+          instructions: 'Be concise.',
+        },
+      ]),
+      ensureDataLoaded: vi.fn().mockResolvedValue(undefined),
+      addConversationToFolderFromNative: vi.fn(),
+    };
+
+    const { startFolderProject } = await import('../index');
+    startFolderProject(mockManager as unknown as Parameters<typeof startFolderProject>[0]);
+    await vi.advanceTimersByTimeAsync(50);
+
+    // Select folder
+    document.querySelector<HTMLButtonElement>('.gv-fp-chip')!.click();
+    await vi.advanceTimersByTimeAsync(50);
+    Array.from(document.querySelectorAll<HTMLElement>('.gv-fp-item'))
+      .find((el) => el.textContent?.includes('TestFolder'))!
+      .click();
+
+    // User clicks send. Input is empty (attachment-only scenario). The capture-phase
+    // click listener must mark pendingSend so the subsequent URL change is attributed
+    // to this send and the new conversation is added to the folder.
+    sendButton.click();
+
+    // Gemini's URL change for the new conversation.
+    window.history.pushState({}, '', '/app/attach-only-conv');
+    await vi.advanceTimersByTimeAsync(700);
+
+    // The new conversation MUST be assigned to the selected folder. Skipping the
+    // empty-input guard on the click path is the whole point: the user explicitly
+    // clicked send and Gemini wouldn't have enabled the button without something
+    // to send (attachment).
+    expect(mockManager.addConversationToFolderFromNative).toHaveBeenCalledTimes(1);
+    expect(mockManager.addConversationToFolderFromNative).toHaveBeenCalledWith(
+      'f1',
+      'attach-only-conv',
+      expect.any(String),
+      expect.any(String),
+      false,
+      undefined,
+    );
+  });
 });

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -430,7 +430,7 @@ describe('follow-up injection regression', () => {
     document.body.innerHTML = '';
   });
 
-  it('does not re-inject instructions on follow-up when URL change is delayed past the 4s pendingSend timer', async () => {
+  it('does not re-inject instructions on follow-up when URL change is delayed past the 60s pendingSend timeout', async () => {
     // Chat input that findChatInput() can locate
     const chatInput = document.createElement('div');
     chatInput.id = 'test-chat-input';

--- a/src/pages/content/folderProject/__tests__/folderProject.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProject.test.ts
@@ -578,4 +578,133 @@ describe('follow-up injection regression', () => {
     // pendingSend before handleNavigation ran.
     expect(mockManager.addConversationToFolderFromNative).not.toHaveBeenCalled();
   });
+
+  it('does NOT cancel pendingSend when the user middle-clicks or Ctrl-clicks a sidebar link (opens in new tab)', async () => {
+    const chatInput = document.createElement('div');
+    chatInput.id = 'test-chat-input';
+    chatInput.setAttribute('contenteditable', 'true');
+    chatInput.setAttribute('role', 'textbox');
+    document.body.appendChild(chatInput);
+
+    const modelPicker = document.createElement('div');
+    modelPicker.className = 'model-picker-container';
+    modelPicker.appendChild(document.createElement('button'));
+    document.body.appendChild(modelPicker);
+    vi.spyOn(modelPicker, 'getBoundingClientRect').mockReturnValue({ height: 40 } as DOMRect);
+
+    const mockManager = {
+      getFolders: vi.fn().mockReturnValue([
+        {
+          id: 'f1',
+          name: 'TestFolder',
+          parentId: null,
+          isExpanded: false,
+          createdAt: 0,
+          updatedAt: 0,
+          instructions: 'Be concise.',
+        },
+      ]),
+      ensureDataLoaded: vi.fn().mockResolvedValue(undefined),
+      addConversationToFolderFromNative: vi.fn(),
+    };
+
+    const { startFolderProject } = await import('../index');
+    startFolderProject(mockManager as unknown as Parameters<typeof startFolderProject>[0]);
+    await vi.advanceTimersByTimeAsync(50);
+
+    // Select a folder
+    document.querySelector<HTMLButtonElement>('.gv-fp-chip')!.click();
+    await vi.advanceTimersByTimeAsync(50);
+    Array.from(document.querySelectorAll<HTMLElement>('.gv-fp-item'))
+      .find((el) => el.textContent?.includes('TestFolder'))!
+      .click();
+
+    // Send
+    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
+    document.dispatchEvent(enterEvent);
+
+    // User middle-clicks a sidebar link to open in a new tab — current tab's
+    // URL will NOT change, so pendingSend must stay true. If it gets wrongly
+    // cleared here, the subsequent (legitimate) URL change from Gemini's
+    // send would be skipped and the new conversation wouldn't be assigned.
+    const sidebarLink = document.createElement('a');
+    sidebarLink.href = '/app/existing-conv-42';
+    document.body.appendChild(sidebarLink);
+    const middleClick = new MouseEvent('click', {
+      bubbles: true,
+      button: 1, // middle mouse button
+    });
+    sidebarLink.dispatchEvent(middleClick);
+
+    // Now the legitimate URL change from the actual send completes
+    window.history.pushState({}, '', '/app/real-new-conv');
+    await vi.advanceTimersByTimeAsync(700);
+
+    // The real new conversation MUST be assigned to the folder.
+    expect(mockManager.addConversationToFolderFromNative).toHaveBeenCalledTimes(1);
+    expect(mockManager.addConversationToFolderFromNative).toHaveBeenCalledWith(
+      'f1',
+      'real-new-conv',
+      expect.any(String),
+      expect.any(String),
+      false,
+      undefined,
+    );
+  });
+
+  it('cancels pendingSend when user presses browser back button (popstate), preventing misassignment to the previously viewed conversation', async () => {
+    const chatInput = document.createElement('div');
+    chatInput.id = 'test-chat-input';
+    chatInput.setAttribute('contenteditable', 'true');
+    chatInput.setAttribute('role', 'textbox');
+    document.body.appendChild(chatInput);
+
+    const modelPicker = document.createElement('div');
+    modelPicker.className = 'model-picker-container';
+    modelPicker.appendChild(document.createElement('button'));
+    document.body.appendChild(modelPicker);
+    vi.spyOn(modelPicker, 'getBoundingClientRect').mockReturnValue({ height: 40 } as DOMRect);
+
+    const mockManager = {
+      getFolders: vi.fn().mockReturnValue([
+        {
+          id: 'f1',
+          name: 'TestFolder',
+          parentId: null,
+          isExpanded: false,
+          createdAt: 0,
+          updatedAt: 0,
+          instructions: 'Be concise.',
+        },
+      ]),
+      ensureDataLoaded: vi.fn().mockResolvedValue(undefined),
+      addConversationToFolderFromNative: vi.fn(),
+    };
+
+    const { startFolderProject } = await import('../index');
+    startFolderProject(mockManager as unknown as Parameters<typeof startFolderProject>[0]);
+    await vi.advanceTimersByTimeAsync(50);
+
+    // Select folder, send on /app
+    document.querySelector<HTMLButtonElement>('.gv-fp-chip')!.click();
+    await vi.advanceTimersByTimeAsync(50);
+    Array.from(document.querySelectorAll<HTMLElement>('.gv-fp-item'))
+      .find((el) => el.textContent?.includes('TestFolder'))!
+      .click();
+
+    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+    Object.defineProperty(enterEvent, 'target', { value: chatInput, configurable: true });
+    document.dispatchEvent(enterEvent);
+
+    // User hits browser Back. This updates the URL and fires popstate.
+    // Without the fix, pendingSend stays true and handleNavigation would
+    // wrongly add the conversation the user went *back* to into the folder.
+    window.history.pushState({}, '', '/app/previous-conv-A');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    await vi.advanceTimersByTimeAsync(50);
+
+    // The previously-viewed conversation must NOT be added to the folder.
+    expect(mockManager.addConversationToFolderFromNative).not.toHaveBeenCalled();
+  });
 });

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -241,8 +241,11 @@ function setupSendDetection(): void {
   // conversation to the selected folder once the URL change is detected.
   sidebarNavClickListener = (e: Event) => {
     if (!pendingSend) return;
-    const target = e.target as HTMLElement | null;
-    const link = target?.closest('a');
+    // e.target may be an SVGElement (icon inside anchor) — use Element, not
+    // HTMLElement, so closest() works on the general Element hierarchy.
+    const target = e.target;
+    if (!(target instanceof Element)) return;
+    const link = target.closest('a');
     if (!link) return;
     const href = link.getAttribute('href') ?? '';
     if (CONVERSATION_HREF_PATTERN.test(href)) {

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -180,7 +180,21 @@ function schedulePendingSendReset(): void {
   }, PENDING_SEND_TIMEOUT_MS);
 }
 
+/**
+ * Returns true when the chat input has no user-authored text.
+ * Any stray instruction block from a prior prepareInputForSend call is
+ * stripped before checking so the guard reflects what the USER typed.
+ */
+function isInputEmpty(input: HTMLElement | null): boolean {
+  if (!input) return true;
+  return stripInstructionBlock(readInputText(input)).trim() === '';
+}
+
 function markPendingSend(input: HTMLElement | null): void {
+  // Don't prepend instructions into an empty input. Our capture-phase listener
+  // runs before Gemini's, so injecting here would turn a stray Enter on an
+  // empty textbox into an unintentional send of just the instructions block.
+  if (isInputEmpty(input)) return;
   prepareInputForSend(input);
   pendingSend = true;
   schedulePendingSendReset();

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -194,7 +194,17 @@ function markPendingSend(input: HTMLElement | null): void {
   // Don't prepend instructions into an empty input. Our capture-phase listener
   // runs before Gemini's, so injecting here would turn a stray Enter on an
   // empty textbox into an unintentional send of just the instructions block.
-  if (isInputEmpty(input)) return;
+  if (isInputEmpty(input)) {
+    // The input may still contain a stray instruction block from a prior send
+    // whose URL change never landed (e.g., transient send failure). If we just
+    // returned here, Gemini's own keydown handler would see the lingering
+    // block as a non-empty message and submit it. Strip it first so Gemini
+    // sees the input as empty too and skips the send.
+    if (input && hasInstructionBlock(readInputText(input))) {
+      setInputText(input, stripInstructionBlock(readInputText(input)));
+    }
+    return;
+  }
   prepareInputForSend(input);
   pendingSend = true;
   schedulePendingSendReset();

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -36,11 +36,25 @@ let pendingSend = false;
 let pendingSendResetTimer: ReturnType<typeof setTimeout> | null = null;
 let sendClickListener: ((e: Event) => void) | null = null;
 let sendKeydownListener: ((e: KeyboardEvent) => void) | null = null;
+let sidebarNavClickListener: ((e: Event) => void) | null = null;
 
 const SEND_BUTTON_SELECTOR =
   'button[aria-label*="Send"], button[aria-label*="send"], ' +
   'button[data-tooltip*="Send"], button[data-tooltip*="send"], ' +
   '[data-send-button], .send-button';
+
+// Matches href values that navigate to an existing conversation, e.g.
+//   /app/<convId>, /u/0/app/<convId>, /gem/<gemId>/<convId>.
+// Used by the sidebar-click listener to recognise navigation clicks so they
+// can cancel a pendingSend claim before the URL change propagates.
+const CONVERSATION_HREF_PATTERN = /\/(u\/\d+\/)?(app|gem\/[^/]+)\/[^/?#]+/;
+
+// How long a send intent (pendingSend flag) survives without a URL change.
+// Gemini can take 30+ seconds to produce the first response for PDF/paper
+// analysis before updating the URL, so the window has to be comfortably
+// larger than the worst-case first-response latency. Cheap to keep because
+// sidebar clicks explicitly cancel pendingSend via sidebarNavClickListener.
+const PENDING_SEND_TIMEOUT_MS = 60_000;
 
 // ============================================================================
 // i18n helper
@@ -163,7 +177,7 @@ function schedulePendingSendReset(): void {
     if (isNewChatPath(window.location.pathname)) {
       clearPreparedInstructions();
     }
-  }, 4000);
+  }, PENDING_SEND_TIMEOUT_MS);
 }
 
 function markPendingSend(input: HTMLElement | null): void {
@@ -206,7 +220,7 @@ function extractGemMetadata(path: string): { isGem: boolean; gemId?: string } {
 }
 
 function setupSendDetection(): void {
-  if (sendClickListener || sendKeydownListener) return;
+  if (sendClickListener || sendKeydownListener || sidebarNavClickListener) return;
 
   sendClickListener = (e: Event) => {
     if (!selectedFolderId) return;
@@ -221,8 +235,24 @@ function setupSendDetection(): void {
     markPendingSend(e.target);
   };
 
+  // Capture-phase listener that cancels a pending send claim when the user
+  // clicks a sidebar conversation link. Without this, clicking an existing
+  // conversation while pendingSend is still true would misattribute that
+  // conversation to the selected folder once the URL change is detected.
+  sidebarNavClickListener = (e: Event) => {
+    if (!pendingSend) return;
+    const target = e.target as HTMLElement | null;
+    const link = target?.closest('a');
+    if (!link) return;
+    const href = link.getAttribute('href') ?? '';
+    if (CONVERSATION_HREF_PATTERN.test(href)) {
+      clearPendingSendState();
+    }
+  };
+
   document.addEventListener('click', sendClickListener, true);
   document.addEventListener('keydown', sendKeydownListener, true);
+  document.addEventListener('click', sidebarNavClickListener, true);
 }
 
 function teardownSendDetection(): void {
@@ -233,6 +263,10 @@ function teardownSendDetection(): void {
   if (sendKeydownListener) {
     document.removeEventListener('keydown', sendKeydownListener, true);
     sendKeydownListener = null;
+  }
+  if (sidebarNavClickListener) {
+    document.removeEventListener('click', sidebarNavClickListener, true);
+    sidebarNavClickListener = null;
   }
   clearPendingSendState();
 }

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -241,6 +241,12 @@ function setupSendDetection(): void {
   // conversation to the selected folder once the URL change is detected.
   sidebarNavClickListener = (e: Event) => {
     if (!pendingSend) return;
+    // Only a plain left-click navigates the current tab. Middle-click (button 1),
+    // right-click (button 2), and modifier-key clicks (Ctrl/Cmd/Shift/Alt) open
+    // in a new tab/window or trigger context menus — the current tab's URL
+    // stays on /app, so pendingSend must NOT be cancelled for those.
+    if (!(e instanceof MouseEvent)) return;
+    if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
     // e.target may be an SVGElement (icon inside anchor) — use Element, not
     // HTMLElement, so closest() works on the general Element hierarchy.
     const target = e.target;
@@ -637,10 +643,21 @@ function startURLWatcher(manager: FolderManager): void {
     handleNavigation(manager, prevPath, newPath);
   };
 
-  urlWatcherCheckFn = checkUrl;
+  // popstate / hashchange only fire for user-initiated history navigation
+  // (browser back/forward, anchor hash changes). Gemini's SPA uses
+  // history.pushState for its own URL updates, which does NOT fire these
+  // events. Therefore any popstate/hashchange we observe here means the user
+  // is moving away from the message they just sent — cancel pendingSend so
+  // the resulting URL change isn't misattributed to the folder assignment.
+  const onHistoryNav = () => {
+    clearPendingSendState();
+    checkUrl();
+  };
+
+  urlWatcherCheckFn = onHistoryNav;
   urlWatcherInterval = setInterval(checkUrl, 500);
-  window.addEventListener('popstate', checkUrl);
-  window.addEventListener('hashchange', checkUrl);
+  window.addEventListener('popstate', onHistoryNav);
+  window.addEventListener('hashchange', onHistoryNav);
 
   // Also check on initial load
   if (isNewChatPath(window.location.pathname)) {

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -625,8 +625,14 @@ function handleNavigation(manager: FolderManager, prevPath: string, newPath: str
     // Left the new-chat page — clear any stale folder selection so follow-up
     // messages on the resulting conversation page don't re-inject instructions.
     // This covers two cases where Branch 1 above is skipped:
-    //   1. pendingSend timer fired before URL change caught up (slow responses)
-    //   2. User navigated to an existing conversation via the sidebar without sending
+    //   1. pendingSend timer fired before URL change caught up (slow responses).
+    //      TRADE-OFF: in this case the new conversation is NOT auto-assigned
+    //      to the folder — the assignment is dropped to keep follow-up
+    //      messages on the new conversation page free of instruction injection.
+    //      Users hitting first responses longer than PENDING_SEND_TIMEOUT_MS
+    //      (currently 60s) will need to drag the conversation into the folder
+    //      manually.
+    //   2. User navigated to an existing conversation via the sidebar without sending.
     selectedFolderId = null;
     selectedFolderName = null;
     selectedFolderInstructions = null;

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -43,17 +43,12 @@ const SEND_BUTTON_SELECTOR =
   'button[data-tooltip*="Send"], button[data-tooltip*="send"], ' +
   '[data-send-button], .send-button';
 
-// Matches href values that navigate to an existing conversation, e.g.
-//   /app/<convId>, /u/0/app/<convId>, /gem/<gemId>/<convId>.
-// Used by the sidebar-click listener to recognise navigation clicks so they
-// can cancel a pendingSend claim before the URL change propagates.
+// Sidebar conversation links: /app/<convId>, /u/0/app/<convId>, /gem/<gemId>/<convId>.
+// Used by sidebarNavClickListener to cancel pendingSend before URL change.
 const CONVERSATION_HREF_PATTERN = /\/(u\/\d+\/)?(app|gem\/[^/]+)\/[^/?#]+/;
 
-// How long a send intent (pendingSend flag) survives without a URL change.
-// Gemini can take 30+ seconds to produce the first response for PDF/paper
-// analysis before updating the URL, so the window has to be comfortably
-// larger than the worst-case first-response latency. Cheap to keep because
-// sidebar clicks explicitly cancel pendingSend via sidebarNavClickListener.
+// pendingSend lifetime — must exceed worst-case first-response latency
+// (PDF/paper analysis can take 30+ s before URL updates).
 const PENDING_SEND_TIMEOUT_MS = 60_000;
 
 // ============================================================================
@@ -180,26 +175,17 @@ function schedulePendingSendReset(): void {
   }, PENDING_SEND_TIMEOUT_MS);
 }
 
-/**
- * Returns true when the chat input has no user-authored text.
- * Any stray instruction block from a prior prepareInputForSend call is
- * stripped before checking so the guard reflects what the USER typed.
- */
+/** True when the input has no user text (stray instruction block stripped first). */
 function isInputEmpty(input: HTMLElement | null): boolean {
   if (!input) return true;
   return stripInstructionBlock(readInputText(input)).trim() === '';
 }
 
 function markPendingSend(input: HTMLElement | null): void {
-  // Don't prepend instructions into an empty input. Our capture-phase listener
-  // runs before Gemini's, so injecting here would turn a stray Enter on an
-  // empty textbox into an unintentional send of just the instructions block.
+  // Empty input + Enter: do nothing, so Gemini's bubble-phase handler also
+  // sees an empty input. Strip any leftover block first (from a prior send
+  // whose URL change never landed) — otherwise Gemini would submit it alone.
   if (isInputEmpty(input)) {
-    // The input may still contain a stray instruction block from a prior send
-    // whose URL change never landed (e.g., transient send failure). If we just
-    // returned here, Gemini's own keydown handler would see the lingering
-    // block as a non-empty message and submit it. Strip it first so Gemini
-    // sees the input as empty too and skips the send.
     if (input && hasInstructionBlock(readInputText(input))) {
       setInputText(input, stripInstructionBlock(readInputText(input)));
     }
@@ -259,20 +245,15 @@ function setupSendDetection(): void {
     markPendingSend(e.target);
   };
 
-  // Capture-phase listener that cancels a pending send claim when the user
-  // clicks a sidebar conversation link. Without this, clicking an existing
-  // conversation while pendingSend is still true would misattribute that
-  // conversation to the selected folder once the URL change is detected.
+  // Cancel pendingSend when user clicks a sidebar conversation link, so the
+  // resulting URL change isn't misattributed to the current send.
   sidebarNavClickListener = (e: Event) => {
     if (!pendingSend) return;
-    // Only a plain left-click navigates the current tab. Middle-click (button 1),
-    // right-click (button 2), and modifier-key clicks (Ctrl/Cmd/Shift/Alt) open
-    // in a new tab/window or trigger context menus — the current tab's URL
-    // stays on /app, so pendingSend must NOT be cancelled for those.
+    // Plain left-click only — middle/right/modifier clicks open new tabs and
+    // leave the current tab's URL on /app.
     if (!(e instanceof MouseEvent)) return;
     if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
-    // e.target may be an SVGElement (icon inside anchor) — use Element, not
-    // HTMLElement, so closest() works on the general Element hierarchy.
+    // Element (not HTMLElement) so closest() works on SVG icons inside <a>.
     const target = e.target;
     if (!(target instanceof Element)) return;
     const link = target.closest('a');
@@ -622,17 +603,11 @@ function handleNavigation(manager: FolderManager, prevPath: string, newPath: str
     removePicker();
     void injectPicker(manager);
   } else {
-    // Left the new-chat page — clear any stale folder selection so follow-up
-    // messages on the resulting conversation page don't re-inject instructions.
-    // This covers two cases where Branch 1 above is skipped:
-    //   1. pendingSend timer fired before URL change caught up (slow responses).
-    //      TRADE-OFF: in this case the new conversation is NOT auto-assigned
-    //      to the folder — the assignment is dropped to keep follow-up
-    //      messages on the new conversation page free of instruction injection.
-    //      Users hitting first responses longer than PENDING_SEND_TIMEOUT_MS
-    //      (currently 60s) will need to drag the conversation into the folder
-    //      manually.
-    //   2. User navigated to an existing conversation via the sidebar without sending.
+    // Left new-chat: clear folder selection so follow-up messages don't
+    // re-inject instructions. Trade-off: when Branch 1 was skipped because
+    // the >60s timer fired, the conversation is NOT auto-assigned (user
+    // must drag it manually) — the alternative would re-introduce follow-up
+    // injection on the new conversation page.
     selectedFolderId = null;
     selectedFolderName = null;
     selectedFolderInstructions = null;
@@ -673,12 +648,9 @@ function startURLWatcher(manager: FolderManager): void {
     handleNavigation(manager, prevPath, newPath);
   };
 
-  // popstate / hashchange only fire for user-initiated history navigation
-  // (browser back/forward, anchor hash changes). Gemini's SPA uses
-  // history.pushState for its own URL updates, which does NOT fire these
-  // events. Therefore any popstate/hashchange we observe here means the user
-  // is moving away from the message they just sent — cancel pendingSend so
-  // the resulting URL change isn't misattributed to the folder assignment.
+  // popstate / hashchange = user-initiated history nav (Gemini's SPA uses
+  // pushState, which doesn't fire either). Cancel pendingSend so the URL
+  // change isn't misattributed to the current send.
   const onHistoryNav = () => {
     clearPendingSendState();
     checkUrl();

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -186,8 +186,11 @@ function markPendingSend(input: HTMLElement | null): void {
   // sees an empty input. Strip any leftover block first (from a prior send
   // whose URL change never landed) — otherwise Gemini would submit it alone.
   if (isInputEmpty(input)) {
-    if (input && hasInstructionBlock(readInputText(input))) {
-      setInputText(input, stripInstructionBlock(readInputText(input)));
+    if (input) {
+      const currentText = readInputText(input);
+      if (hasInstructionBlock(currentText)) {
+        setInputText(input, stripInstructionBlock(currentText));
+      }
     }
     return;
   }

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -555,7 +555,14 @@ function handleNavigation(manager: FolderManager, prevPath: string, newPath: str
     removePicker();
     void injectPicker(manager);
   } else {
-    // Left the new-chat page — hide picker
+    // Left the new-chat page — clear any stale folder selection so follow-up
+    // messages on the resulting conversation page don't re-inject instructions.
+    // This covers two cases where Branch 1 above is skipped:
+    //   1. pendingSend timer fired before URL change caught up (slow responses)
+    //   2. User navigated to an existing conversation via the sidebar without sending
+    selectedFolderId = null;
+    selectedFolderName = null;
+    selectedFolderInstructions = null;
     clearPendingSendState();
     removePicker();
   }

--- a/src/pages/content/folderProject/index.ts
+++ b/src/pages/content/folderProject/index.ts
@@ -182,21 +182,30 @@ function isInputEmpty(input: HTMLElement | null): boolean {
 }
 
 function markPendingSend(input: HTMLElement | null): void {
-  // Empty input + Enter: do nothing, so Gemini's bubble-phase handler also
-  // sees an empty input. Strip any leftover block first (from a prior send
-  // whose URL change never landed) — otherwise Gemini would submit it alone.
-  if (isInputEmpty(input)) {
-    if (input) {
-      const currentText = readInputText(input);
-      if (hasInstructionBlock(currentText)) {
-        setInputText(input, stripInstructionBlock(currentText));
-      }
-    }
-    return;
-  }
   prepareInputForSend(input);
   pendingSend = true;
   schedulePendingSendReset();
+}
+
+/**
+ * Handle an empty-input Enter press: strip any leftover instruction block so
+ * Gemini's bubble-phase handler sees a truly empty input and doesn't submit
+ * a message containing only the block. Returns true when the press was
+ * handled (caller should skip markPendingSend).
+ *
+ * Click-send is NOT routed through this — Gemini only enables the send button
+ * when there is text or an attachment, so an empty-input click means
+ * "send the attachment" and the auto-assignment must proceed.
+ */
+function handleEmptyInputEnter(input: HTMLElement | null): boolean {
+  if (!isInputEmpty(input)) return false;
+  if (input) {
+    const currentText = readInputText(input);
+    if (hasInstructionBlock(currentText)) {
+      setInputText(input, stripInstructionBlock(currentText));
+    }
+  }
+  return true;
 }
 
 function isKeyboardSend(event: KeyboardEvent): boolean {
@@ -245,6 +254,7 @@ function setupSendDetection(): void {
 
   sendKeydownListener = (e: KeyboardEvent) => {
     if (!selectedFolderId || !isKeyboardSend(e) || !isEditableTarget(e.target)) return;
+    if (handleEmptyInputEnter(e.target)) return;
     markPendingSend(e.target);
   };
 

--- a/src/pages/content/watermarkRemover/__tests__/fetchInterceptor.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/fetchInterceptor.test.ts
@@ -19,6 +19,12 @@ function createEnabledBridge(): HTMLElement {
   return bridge;
 }
 
+function createMockFetchResponse(body = 'ok', init: ResponseInit = { status: 200 }): Response {
+  const response = new Response(body, init);
+  vi.spyOn(response, 'blob').mockResolvedValue(new window.Blob([body]));
+  return response;
+}
+
 async function waitForBridgeRequest(bridge: HTMLElement): Promise<string> {
   for (let i = 0; i < 20; i += 1) {
     if (bridge.dataset.request) {
@@ -42,9 +48,7 @@ describe('fetchInterceptor (MAIN world script)', () => {
 
     document.documentElement.innerHTML = '';
 
-    originalFetch = vi
-      .fn()
-      .mockImplementation(() => Promise.resolve(new Response('ok', { status: 200 })));
+    originalFetch = vi.fn().mockImplementation(() => Promise.resolve(createMockFetchResponse()));
     Object.defineProperty(window, 'fetch', {
       value: originalFetch,
       writable: true,
@@ -62,7 +66,7 @@ describe('fetchInterceptor (MAIN world script)', () => {
   });
 
   it('passes through non-target requests to original fetch', async () => {
-    const originalFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+    const originalFetch = vi.fn().mockResolvedValue(createMockFetchResponse());
     Object.defineProperty(window, 'fetch', {
       value: originalFetch,
       writable: true,


### PR DESCRIPTION
### 🚫 AI Policy / AI 政策

- **We explicitly reject AI-generated PRs that have not been manually verified.**
- **本项目拒绝接受任何未经人工复核的 AI 生成的 PR。**
- Low-quality AI PRs will be closed immediately. / 低质量的 AI PR 会被直接关闭。
- You must understand and take responsibility for every line of code you submit. / 你必须理解并对你提交的每一行代码负责。
- **Workflow Proficiency / 协作能力**: Ensure you are familiar with GitHub/Git workflows and maintain a clean Git history. Please learn the basics first if needed to avoid messy PR history. / 请确保你熟悉 GitHub/Git 工作流并保持 Git 历史整洁。如有必要请先学习相关知识，避免 PR 历史过于混乱。

---

### 描述 / Description

修复 **Folder-as-Project**（1.4.0 新增功能）自动分配状态机中的三个相互关联的缺陷。详细缺陷分析见 #619。

Fix three interrelated defects in the **Folder-as-Project** auto-assignment state machine (introduced in 1.4.0). See #619 for the full bug analysis.

#### 修复的缺陷 / Bug Fixes

**Bug 1 — 慢响应导致自动分配失败 / Slow-response assignment failure**

`pendingSendResetTimer` 4 秒超时对长响应（PDF 分析、Deep Research、长论文摘要等）过于激进，URL 变更前先触发 `pendingSend = false`，导致 `handleNavigation` 的 Branch 1 被跳过，新对话永远不会被加入选中的文件夹。

The 4-second `pendingSendResetTimer` was too aggressive for long first responses (PDF analysis, Deep Research, long paper summaries). The timer fired before the URL changed, flipping `pendingSend = false`, after which `handleNavigation` Branch 1 was skipped and the new conversation was never added to the selected folder.

**修复 / Fix**: 将超时延长至 60 秒。该值是产品权衡 — 60 秒已覆盖绝大多数长响应场景，超过 60 秒的极端长响应仍需用户手动拖动（已在代码注释中明示）。

**Fix**: Extend the timeout to 60 seconds. This is a product trade-off — 60 s covers the vast majority of long-response scenarios. For >60 s responses (very rare) the user must drag the conversation manually (documented inline in code comments).

**Bug 2 — 发送后点击侧边栏会错误分配 / Sidebar click misassignment**

用户发送消息后（`pendingSend = true`），在 Gemini 完成 URL 变更之前点击侧边栏中任意已有对话时，被点击的旧对话会被错误地加入选中的文件夹（Branch 1 的四个条件全部满足）。

After a send (`pendingSend = true`), if the user clicks an existing sidebar conversation before Gemini's URL change completes, the **clicked, pre-existing conversation** is wrongly added to the selected folder (all four Branch 1 conditions are satisfied).

**修复 / Fix**: 添加 capture-phase 的侧边栏链接点击监听器。检测到对 `<a href="/app/...">` 的 plain-click 时立即取消 `pendingSend`。Ctrl/Cmd/Shift/Alt-click 与 middle-click（在新标签/窗口打开）保持原状以不影响合法发送。

**Fix**: Add a capture-phase click listener on sidebar links. Plain-click on an `<a href="/app/...">` immediately cancels `pendingSend`. Ctrl/Cmd/Shift/Alt-click and middle-click (open-in-new-tab) are preserved so they don't interfere with the legitimate send happening in the current tab.

**Bug 3 — 后续消息被重复注入 instructions / Instruction block re-injected into follow-up messages**

Bug 1 的连锁效应。Bug 1 触发后 `selectedFolderId / Name / Instructions` 不被清除，后续每条消息都被前置 `[System Instructions]...[/System Instructions]` 块。

Cascading from Bug 1. After Bug 1 fired, `selectedFolderId / Name / Instructions` remained set, and every follow-up `Enter` press kept calling `prepareInputForSend`, prepending the `[System Instructions]...[/System Instructions]` block to each subsequent message.

**修复 / Fix**: `handleNavigation` 的 `else` 分支现在同时清除 `selectedFolder*` state，不仅仅是 `pendingSend`。

**Fix**: The `else` branch in `handleNavigation` now clears `selectedFolder*` state in addition to `pendingSend`.

#### 附加的边缘情况修复 / Additional Edge-case Hardening

审查过程中又发现并修复了几个相关的小缺陷：

Several smaller related issues were uncovered and fixed during review:

- **空输入 + Enter 守卫 / Empty-input Enter guard** — 输入框为空时 Enter 不应该 mark pending send（之前可能导致 Gemini 收到只含 instruction 块的"消息"）；同时清除任何残留的 instruction 块。
  An empty chat input + Enter no longer marks pending send (previously this could cause Gemini to receive an instruction-only "message"). Any residual instruction block in the empty input is also stripped.
- **浏览器后退按钮 / Browser back button** — `popstate` 与 `hashchange` 事件触发时清除 `pendingSend`，防止用户按后退时把先前查看的对话误分配。
  `popstate` and `hashchange` clear `pendingSend` so pressing back during a send doesn't misassign the previously viewed conversation.
- **修饰键 click 保护 / Modifier-key click preservation** — 上述 Bug 2 修复中明确测试 middle / Ctrl / Cmd / Shift / Alt-click 不会取消 pending send。
  The Bug 2 fix explicitly tests that middle / Ctrl / Cmd / Shift / Alt-click do **not** cancel pending send.

#### 排序保持 / Conversation Ordering

代码审查过程中发现新自动分配的对话未能可靠地出现在文件夹顶部。`addConversationToFolderFromNative` 之前不带 `sortIndex` 直接 push，`ensureSortIndices()`（在 `saveData` 中调用）随后给最新条目分配 `sortIndex 0`，与已有的 `sortIndex 0` 冲突，JS 安定排序将新条目放在旧条目之后 — 抵消了 `lastOpenedAt = now` 的"最新置顶"意图。

External code review found that newly auto-assigned conversations were not reliably appearing at the top of their folder. `addConversationToFolderFromNative` previously pushed without `sortIndex`; `ensureSortIndices()` (invoked via `saveData`) then assigned `sortIndex 0` to the newest entry by time, colliding with any pre-existing `sortIndex 0`, after which JS's stable sort dropped the new entry below the old one — defeating the "newest at top" intent of `lastOpenedAt = now`.

**修复 / Fix** (in `manager.ts` `addConversationToFolderFromNative`):

- 先调用 `ensureDataIntegrity()` 确保已有条目所有 `sortIndex` 都是数值（处理混合 null/numeric 状态）
  Call `ensureDataIntegrity()` first so any nullish `sortIndex` on existing entries gets a numeric value (handles mixed null/numeric input)
- 将所有现有条目的 `sortIndex` 上移一位
  Shift all existing entries' `sortIndex` up by one
- 新对话以 `sortIndex: 0` 显式插入
  Insert the new conversation with explicit `sortIndex: 0`

#### 已知后续事项 / Known Follow-ups

为保持本 PR 聚焦于 #619 的三个核心缺陷，多代理代码审查（Codex、Gemini Pro）发现的两个 pre-existing 问题**未在此 PR 处理**，建议作为后续 PR：

To keep this PR focused on the three core defects from #619, two pre-existing issues surfaced by multi-agent code review (Codex, Gemini Pro) are intentionally **not** addressed here and recommended as follow-up PRs:

1. **`applyPendingFolderSelection` 中的 async race** — `await chrome.storage.local.get` / `await manager.ensureDataLoaded()` 后未检查页面是否仍在 new-chat 或用户是否已手动选择了文件夹。在 await 期间用户导航离开或手动选择时可能复活过期状态。建议在 await 之后加 navigation/selection guard。
   Async race in `applyPendingFolderSelection` (`folderProject/index.ts:~493`). After awaiting `chrome.storage.local.get` / `manager.ensureDataLoaded()`, the function does not check whether the page is still a new-chat page or whether the user has already manually selected a folder. Stale state can be resurrected. Suggest adding a navigation/selection guard after the await.
2. **`addConversationToFolderFromNative` 中的双重 `ensureDataIntegrity` 调用** — 本 PR 添加的 `ensureDataIntegrity()` 调用与 `saveData` 内部的调用产生冗余。功能正确，但可优化。同时 `ensureSortIndices` 只填充 nullish 索引，不修复 numeric 重复（来自 import / sync merge 的潜在数据），可在同一次重构中一并解决（例如用 `sortConversationsByPriority` 做局部 O(K) 正规化）。
   Double `ensureDataIntegrity()` pass on native add. The added `ensureDataIntegrity()` call in this PR overlaps with the one inside `saveData`. Functionally correct but wasteful. Additionally, `ensureSortIndices` only fills nullish indices and does not repair numeric duplicates (potential data from imports / sync merges) — both could be addressed together by extracting a localized per-folder normalizer using `sortConversationsByPriority`.

### 相关 Issue / Related Issue

Closes #619

### 可视化证据 / Visual Proof

无 UI 变更 — 全部为 content script 状态机的行为修复。

No UI changes — behaviour-only fixes inside the content-script state machine.

### 浏览器测试 / Browser Testing

- [x] **Chrome / Edge (Chromium)**: 已测试 / Tested (manual reproduction of all three bugs verified on Chrome)
- [x] **Firefox**: 未测试 / Not yet tested (shared content-script code path, no browser-specific APIs touched)
- [ ] **Safari**: 未测试 / Not tested (folder feature gating / storage behaviour unchanged)

### 检查清单 / Checklist

- [x] 我已手动验证功能按预期工作。/ I have manually verified that the feature works as intended.
- [x] 我已确认此 PR 不会破坏原有功能。/ I have confirmed that this PR does not break existing functionality.
- [x] 我已运行 `bun run lint`、`bun run typecheck`、`bun run format` 和 `bun run build`。/ I have run lint, typecheck, format and build.
- [x] 我已添加/更新了必要的测试并确保通过（`bun run test`）。增加 9 个回归测试覆盖所有三个缺陷及边缘情况。/ I have added/updated necessary tests and they pass. Added 9 regression tests covering all three defects and edge cases.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->