### PR TITLE
feat(export): add width selection for single response image export

### DIFF
--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -11125,3 +11125,41 @@ body.gv-hide-input-halo .nl-canvas {
 :root.gv-platform-themed .gv-pm-lock.active {
   box-shadow: 0 0 0 3px var(--gv-pm-brand-soft) !important;
 }
+
+/* Response action copy image menu */
+.gv-response-image-menu {
+  position: fixed;
+  background-color: var(--timeline-tooltip-bg);
+  border: 1px solid var(--timeline-tooltip-border);
+  border-radius: 8px;
+  box-shadow: var(--timeline-tooltip-shadow);
+  padding: 4px 0;
+  z-index: 2147483647;
+  min-width: 140px;
+  animation: gv-menu-in 0.12s ease-out;
+}
+
+@keyframes gv-menu-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.gv-response-image-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  color: var(--timeline-tooltip-text);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.1s ease;
+}
+
+.gv-response-image-menu-item:hover {
+  background-color: var(--timeline-dot-active-color);
+  color: #fff;
+}

--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -11140,8 +11140,14 @@ body.gv-hide-input-halo .nl-canvas {
 }
 
 @keyframes gv-menu-in {
-  from { opacity: 0; transform: scale(0.95); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .gv-response-image-menu-item {

--- a/src/pages/content/export/index.ts
+++ b/src/pages/content/export/index.ts
@@ -36,6 +36,7 @@ import {
 } from './conversationMenuInjection';
 import { mountPersistentExportToolbar } from './persistentExportToolbar';
 import { injectResponseActionCopyImageButtons } from './responseActionImageButton';
+import { showResponseActionCopyImageMenu } from './responseActionImageMenu';
 import { copyImageBlobToClipboard, downloadImageBlob } from './responseImageCopy';
 import { groupSelectedMessagesByTurn, resolveInitialSelectedMessageIds } from './selectionUtils';
 import { resolveSidebarConversationTarget } from './sidebarConversationTarget';
@@ -1858,6 +1859,9 @@ type ResponseCopyImageTexts = {
   failed: string;
   unsupported: string;
   targetMissing: string;
+  widthNarrow: string;
+  widthMedium: string;
+  widthWide: string;
 };
 
 function getResponseCopyImageTexts(lang: AppLanguage): ResponseCopyImageTexts {
@@ -1869,6 +1873,9 @@ function getResponseCopyImageTexts(lang: AppLanguage): ResponseCopyImageTexts {
       failed: '复制回复图片失败',
       unsupported: '当前浏览器不支持复制图片到剪贴板',
       targetMissing: '未找到可复制的回复内容',
+      widthNarrow: '窄（手机）',
+      widthMedium: '中（平板）',
+      widthWide: '宽（电脑）',
     };
   }
 
@@ -1880,6 +1887,9 @@ function getResponseCopyImageTexts(lang: AppLanguage): ResponseCopyImageTexts {
       failed: '複製回覆圖片失敗',
       unsupported: '目前瀏覽器不支援將圖片複製到剪貼簿',
       targetMissing: '找不到可複製的回覆內容',
+      widthNarrow: '窄（手機）',
+      widthMedium: '中（平板）',
+      widthWide: '寬（電腦）',
     };
   }
 
@@ -1890,6 +1900,9 @@ function getResponseCopyImageTexts(lang: AppLanguage): ResponseCopyImageTexts {
     failed: 'Failed to copy response image',
     unsupported: 'Clipboard image copy is not supported in this browser',
     targetMissing: 'Unable to locate response content',
+    widthNarrow: 'Narrow (Mobile)',
+    widthMedium: 'Medium (Tablet)',
+    widthWide: 'Wide (Desktop)',
   };
 }
 
@@ -1925,6 +1938,7 @@ function isUnsupportedClipboardError(error: unknown): boolean {
 async function handleResponseCopyImageClick(
   trigger: HTMLElement,
   getCurrentLanguage: () => AppLanguage,
+  imageWidth: number = DEFAULT_IMAGE_EXPORT_WIDTH,
 ): Promise<void> {
   if (trigger.dataset.gvCopyImageBusy === '1') {
     return;
@@ -1955,7 +1969,7 @@ async function handleResponseCopyImageClick(
     };
 
     const blob = await ImageExportService.renderConversationBlob(turnsForExport, metadata, {
-      imageWidth: DEFAULT_IMAGE_EXPORT_WIDTH,
+      imageWidth,
     });
     blobForFallback = blob;
     await copyImageBlobToClipboard(blob);
@@ -1983,7 +1997,17 @@ function applyResponseActionCopyImageButtons(getCurrentLanguage: () => AppLangua
     label: texts.label,
     tooltip: texts.label,
     onClick: (button) => {
-      void handleResponseCopyImageClick(button, getCurrentLanguage);
+      showResponseActionCopyImageMenu({
+        anchor: button,
+        translations: {
+          narrow: texts.widthNarrow,
+          medium: texts.widthMedium,
+          wide: texts.widthWide,
+        },
+        onSelect: (width) => {
+          void handleResponseCopyImageClick(button, getCurrentLanguage, width);
+        },
+      });
     },
   });
 }
@@ -2005,7 +2029,17 @@ function setupResponseActionCopyImageObserver({
           label: texts.label,
           tooltip: texts.label,
           onClick: (button) => {
-            void handleResponseCopyImageClick(button, getCurrentLanguage);
+            showResponseActionCopyImageMenu({
+              anchor: button,
+              translations: {
+                narrow: texts.widthNarrow,
+                medium: texts.widthMedium,
+                wide: texts.widthWide,
+              },
+              onSelect: (width) => {
+                void handleResponseCopyImageClick(button, getCurrentLanguage, width);
+              },
+            });
           },
         });
       });

--- a/src/pages/content/export/index.ts
+++ b/src/pages/content/export/index.ts
@@ -1864,7 +1864,11 @@ type ResponseCopyImageTexts = {
   widthWide: string;
 };
 
-function getResponseCopyImageTexts(lang: AppLanguage): ResponseCopyImageTexts {
+function getResponseCopyImageTexts(
+  lang: AppLanguage,
+  dict: Record<AppLanguage, Record<string, string>>,
+): ResponseCopyImageTexts {
+  const t = (key: TranslationKey) => dict[lang]?.[key] ?? dict.en?.[key] ?? key;
   if (lang === 'zh') {
     return {
       label: '复制回复为图片',
@@ -1873,9 +1877,9 @@ function getResponseCopyImageTexts(lang: AppLanguage): ResponseCopyImageTexts {
       failed: '复制回复图片失败',
       unsupported: '当前浏览器不支持复制图片到剪贴板',
       targetMissing: '未找到可复制的回复内容',
-      widthNarrow: '窄（手机）',
-      widthMedium: '中（平板）',
-      widthWide: '宽（电脑）',
+      widthNarrow: t('export_image_width_narrow'),
+      widthMedium: t('export_image_width_medium'),
+      widthWide: t('export_image_width_wide'),
     };
   }
 
@@ -1887,9 +1891,9 @@ function getResponseCopyImageTexts(lang: AppLanguage): ResponseCopyImageTexts {
       failed: '複製回覆圖片失敗',
       unsupported: '目前瀏覽器不支援將圖片複製到剪貼簿',
       targetMissing: '找不到可複製的回覆內容',
-      widthNarrow: '窄（手機）',
-      widthMedium: '中（平板）',
-      widthWide: '寬（電腦）',
+      widthNarrow: t('export_image_width_narrow'),
+      widthMedium: t('export_image_width_medium'),
+      widthWide: t('export_image_width_wide'),
     };
   }
 
@@ -1900,9 +1904,9 @@ function getResponseCopyImageTexts(lang: AppLanguage): ResponseCopyImageTexts {
     failed: 'Failed to copy response image',
     unsupported: 'Clipboard image copy is not supported in this browser',
     targetMissing: 'Unable to locate response content',
-    widthNarrow: 'Narrow (Mobile)',
-    widthMedium: 'Medium (Tablet)',
-    widthWide: 'Wide (Desktop)',
+    widthNarrow: t('export_image_width_narrow'),
+    widthMedium: t('export_image_width_medium'),
+    widthWide: t('export_image_width_wide'),
   };
 }
 
@@ -1938,6 +1942,7 @@ function isUnsupportedClipboardError(error: unknown): boolean {
 async function handleResponseCopyImageClick(
   trigger: HTMLElement,
   getCurrentLanguage: () => AppLanguage,
+  dict: Record<AppLanguage, Record<string, string>>,
   imageWidth: number = DEFAULT_IMAGE_EXPORT_WIDTH,
 ): Promise<void> {
   if (trigger.dataset.gvCopyImageBusy === '1') {
@@ -1945,7 +1950,7 @@ async function handleResponseCopyImageClick(
   }
   trigger.dataset.gvCopyImageBusy = '1';
 
-  const texts = getResponseCopyImageTexts(getCurrentLanguage());
+  const texts = getResponseCopyImageTexts(getCurrentLanguage(), dict);
   const messageId = resolveAssistantMessageIdFromMenuTrigger(trigger);
   let blobForFallback: Blob | null = null;
   try {
@@ -1991,8 +1996,11 @@ async function handleResponseCopyImageClick(
   }
 }
 
-function applyResponseActionCopyImageButtons(getCurrentLanguage: () => AppLanguage): void {
-  const texts = getResponseCopyImageTexts(getCurrentLanguage());
+function applyResponseActionCopyImageButtons(
+  getCurrentLanguage: () => AppLanguage,
+  dict: Record<AppLanguage, Record<string, string>>,
+): void {
+  const texts = getResponseCopyImageTexts(getCurrentLanguage(), dict);
   injectResponseActionCopyImageButtons(document, {
     label: texts.label,
     tooltip: texts.label,
@@ -2005,7 +2013,7 @@ function applyResponseActionCopyImageButtons(getCurrentLanguage: () => AppLangua
           wide: texts.widthWide,
         },
         onSelect: (width) => {
-          void handleResponseCopyImageClick(button, getCurrentLanguage, width);
+          void handleResponseCopyImageClick(button, getCurrentLanguage, dict, width);
         },
       });
     },
@@ -2014,17 +2022,19 @@ function applyResponseActionCopyImageButtons(getCurrentLanguage: () => AppLangua
 
 function setupResponseActionCopyImageObserver({
   getCurrentLanguage,
+  dict,
 }: {
   getCurrentLanguage: () => AppLanguage;
+  dict: Record<AppLanguage, Record<string, string>>;
 }): void {
-  applyResponseActionCopyImageButtons(getCurrentLanguage);
+  applyResponseActionCopyImageButtons(getCurrentLanguage, dict);
   if (responseActionObserver) return;
 
   const observer = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
       mutation.addedNodes.forEach((node) => {
         if (!(node instanceof HTMLElement)) return;
-        const texts = getResponseCopyImageTexts(getCurrentLanguage());
+        const texts = getResponseCopyImageTexts(getCurrentLanguage(), dict);
         injectResponseActionCopyImageButtons(node, {
           label: texts.label,
           tooltip: texts.label,
@@ -2037,7 +2047,7 @@ function setupResponseActionCopyImageObserver({
                 wide: texts.widthWide,
               },
               onSelect: (width) => {
-                void handleResponseCopyImageClick(button, getCurrentLanguage, width);
+                void handleResponseCopyImageClick(button, getCurrentLanguage, dict, width);
               },
             });
           },
@@ -2227,6 +2237,7 @@ export async function startExportButton(): Promise<void> {
   });
   setupResponseActionCopyImageObserver({
     getCurrentLanguage: () => lang,
+    dict,
   });
 
   const t0 = (key: TranslationKey) => dict[lang]?.[key] ?? dict.en?.[key] ?? key;
@@ -2285,7 +2296,7 @@ export async function startExportButton(): Promise<void> {
         const ttl =
           dict[next]?.['exportChatJson'] ?? dict.en?.['exportChatJson'] ?? 'Export chat history';
         toolbarHandle?.setText(lbl, ttl);
-        applyResponseActionCopyImageButtons(() => lang);
+        applyResponseActionCopyImageButtons(() => lang, dict);
       }
       const toolbarChange = changes[StorageKeys.PERSISTENT_EXPORT_TOOLBAR_ENABLED];
       if (toolbarChange && 'newValue' in toolbarChange) {
@@ -2356,7 +2367,7 @@ export async function startExportButton(): Promise<void> {
       const lbl = btn.querySelector('.gv-export-dropdown-label');
       if (lbl) lbl.textContent = dict[next]?.['pm_export'] ?? dict.en?.['pm_export'] ?? 'Export';
 
-      applyResponseActionCopyImageButtons(() => lang);
+      applyResponseActionCopyImageButtons(() => lang, dict);
     }
   };
 

--- a/src/pages/content/export/responseActionImageMenu.ts
+++ b/src/pages/content/export/responseActionImageMenu.ts
@@ -1,0 +1,91 @@
+import {
+  IMAGE_EXPORT_WIDTH_MEDIUM,
+  IMAGE_EXPORT_WIDTH_NARROW,
+  IMAGE_EXPORT_WIDTH_WIDE,
+} from '../../../features/export/types/export';
+
+export interface ResponseActionCopyImageMenuOptions {
+  anchor: HTMLElement;
+  translations: {
+    narrow: string;
+    medium: string;
+    wide: string;
+  };
+  onSelect: (width: number) => void;
+}
+
+let activeMenu: HTMLElement | null = null;
+let activeOutsideClickHandler: ((e: MouseEvent) => void) | null = null;
+
+export function showResponseActionCopyImageMenu(options: ResponseActionCopyImageMenuOptions): void {
+  hideResponseActionCopyImageMenu();
+
+  const menu = document.createElement('div');
+  menu.className = 'gv-response-image-menu';
+
+  const widths = [
+    { value: IMAGE_EXPORT_WIDTH_NARROW, label: options.translations.narrow },
+    { value: IMAGE_EXPORT_WIDTH_MEDIUM, label: options.translations.medium },
+    { value: IMAGE_EXPORT_WIDTH_WIDE, label: options.translations.wide },
+  ];
+
+  widths.forEach((w) => {
+    const item = document.createElement('button');
+    item.className = 'gv-response-image-menu-item';
+    item.textContent = w.label;
+
+    item.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      options.onSelect(w.value);
+      hideResponseActionCopyImageMenu();
+    });
+
+    menu.appendChild(item);
+  });
+
+  document.body.appendChild(menu);
+  activeMenu = menu;
+
+  const rect = options.anchor.getBoundingClientRect();
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const menuWidth = menu.offsetWidth;
+  const menuHeight = menu.offsetHeight;
+
+  let left = rect.left;
+  let top = rect.bottom + 4;
+
+  if (left + menuWidth > vw - 10) {
+    left = vw - menuWidth - 10;
+  }
+  if (top + menuHeight > vh - 10) {
+    top = rect.top - menuHeight - 4;
+  }
+
+  menu.style.left = `${left}px`;
+  menu.style.top = `${top}px`;
+
+  const handleOutsideClick = (e: MouseEvent) => {
+    if (
+      activeMenu &&
+      !activeMenu.contains(e.target as Node) &&
+      !options.anchor.contains(e.target as Node)
+    ) {
+      hideResponseActionCopyImageMenu();
+    }
+  };
+  activeOutsideClickHandler = handleOutsideClick;
+  document.addEventListener('mousedown', handleOutsideClick);
+}
+
+export function hideResponseActionCopyImageMenu(): void {
+  if (activeOutsideClickHandler) {
+    document.removeEventListener('mousedown', activeOutsideClickHandler);
+    activeOutsideClickHandler = null;
+  }
+  if (activeMenu) {
+    activeMenu.remove();
+    activeMenu = null;
+  }
+}


### PR DESCRIPTION
### Purpose
This PR adds a width selection menu to the "Copy response as image" feature. Previously, this action used a hardcoded width (620px), which might not look optimal on all devices. Users can now choose between Narrow (620px), Medium (960px), and Wide (1360px) when copying a single response.

### Implementation
- **Decoupled Logic**: Refactored `handleResponseCopyImageClick` to accept an optional `imageWidth`.
- **New UI Component**: Added `src/pages/content/export/responseActionImageMenu.ts` to render a Material-style popover menu near the trigger button.
- **Improved UX**: The click handler now triggers the selection menu first, allowing for a more flexible export experience.

### Verification
- Verified code structure and style.
- Ensured consistent behavior across languages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->