### PR TITLE
fix(folder-project): open folder picker upward

### DIFF
--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -8517,7 +8517,9 @@ body.gv-rtl .gv-timestamp {
 /* Dropdown list */
 .gv-fp-dropdown {
   position: absolute;
-  top: 100%;
+  top: auto;
+  bottom: 100%;
+  margin-bottom: 4px;
   left: 8px;
   min-width: 200px;
   max-width: 320px;

--- a/src/pages/content/folderProject/__tests__/folderProjectDropdown.test.ts
+++ b/src/pages/content/folderProject/__tests__/folderProjectDropdown.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('Folder-as-Project dropdown positioning', () => {
+  it('opens the folder picker upward from the Gemini input toolbar', () => {
+    const css = readFileSync(resolve(process.cwd(), 'public/contentStyle.css'), 'utf8');
+    const dropdownBlock = css.match(/\.gv-fp-dropdown\s*{([\s\S]*?)}/)?.[1] ?? '';
+
+    expect(dropdownBlock).toContain('top: auto;');
+    expect(dropdownBlock).toContain('bottom: 100%;');
+    expect(dropdownBlock).toContain('margin-bottom: 4px;');
+    expect(dropdownBlock).not.toContain('top: 100%;');
+  });
+});


### PR DESCRIPTION
## Summary
- Position the Folder-as-Project dropdown above the picker chip instead of below it.
- Add a small CSS regression test to keep the dropdown anchored upward.

## Why
When the picker is shown in Gemini's bottom input toolbar, the previous downward dropdown can extend below the visible viewport and become partially hidden. Opening it upward keeps the folder tree visible.

## Validation
- Ran a targeted Node-based CSS assertion locally because this environment does not have `bun` or `node_modules` installed.
- Full `bun run test` / `bun run build:chrome` not run locally for the same reason.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nagi-ovo/gemini-voyager/pull/739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->