### PR TITLE
fix(defaultModel): unify selector set to prevent dropdown flash on new chat

### DIFF
--- a/src/pages/content/defaultModel/__tests__/modelLocker.test.ts
+++ b/src/pages/content/defaultModel/__tests__/modelLocker.test.ts
@@ -1061,6 +1061,35 @@ describe('DefaultModelManager (default model locker)', () => {
     expect(selectorBtn.click).toHaveBeenCalledTimes(0);
   });
 
+  it('fast-path: button found via .input-area-switch-label still skips menu click (#756)', async () => {
+    (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (_key: unknown, callback: (items: Record<string, unknown>) => void) => {
+        callback({
+          gvDefaultModel: { id: 'e6fa609c3fa255c0', name: '3.1 Pro' },
+        });
+      },
+    );
+
+    history.replaceState({}, '', '/app');
+
+    // Use .input-area-switch-label instead of data-test-id="bard-mode-menu-button"
+    // to verify the shared findSelectorButton() helper covers all selectors.
+    const selectorBtn = document.createElement('div');
+    selectorBtn.className = 'input-area-switch-label';
+    selectorBtn.textContent = 'Pro';
+    selectorBtn.click = vi.fn();
+    document.body.appendChild(selectorBtn);
+
+    const { default: DefaultModelManager } = await import('../modelLocker');
+    await DefaultModelManager.getInstance().init();
+    destroyManager = () => DefaultModelManager.getInstance().destroy();
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    // Must NOT have re-clicked the trigger — fast-path should recognise "Pro" === "3.1 Pro".
+    expect(selectorBtn.click).toHaveBeenCalledTimes(0);
+  });
+
   it('auto-locks Thinking level by opening submenu and clicking the target item', async () => {
     (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       (_key: unknown, callback: (items: Record<string, unknown>) => void) => {

--- a/src/pages/content/defaultModel/modelLocker.ts
+++ b/src/pages/content/defaultModel/modelLocker.ts
@@ -1145,16 +1145,9 @@ class DefaultModelManager {
     const targetName = normalize(targetModel.name);
     const targetAsWholeWord = new RegExp(`(^|\\b)${escapeRegExp(targetName)}(\\b|$)`, 'i');
 
-    // 1. Find selector button. The 2026 redesign exposes the real button via
-    // [data-test-id="bard-mode-menu-button"]; older builds only had the inner
-    // .input-area-switch-label div (click bubbles to its parent button).
-    const selectorBtn =
-      document.querySelector('[data-test-id="bard-mode-menu-button"]') ||
-      document.querySelector('button.input-area-switch') ||
-      document.querySelector('.input-area-switch-label') ||
-      document.querySelector('[data-test-id="model-selector"]') ||
-      document.querySelector('button[aria-haspopup="menu"].mat-mdc-menu-trigger'); // Legacy fallback
-
+    // 1. Find selector button (shared helper keeps selectors in sync with the
+    //    fast-path check in readTriggerPillLines — #756).
+    const selectorBtn = this.findSelectorButton();
     if (!selectorBtn) return;
 
     // 2. Check current model text - early return if already correct
@@ -1295,9 +1288,7 @@ class DefaultModelManager {
     this.isLocked = true;
 
     try {
-      const trigger =
-        document.querySelector<HTMLElement>('[data-test-id="bard-mode-menu-button"]') ??
-        document.querySelector<HTMLElement>('button.input-area-switch');
+      const trigger = this.findSelectorButton();
       if (!trigger) return;
 
       // Open the model menu first.
@@ -1454,14 +1445,29 @@ class DefaultModelManager {
   }
 
   /**
+   * Find the model selector trigger button using all known selectors.
+   * Shared by `readTriggerPillLines`, `tryLockToModel`, and `tryLockToThinkingLevel`
+   * so the fast-path check and the actual menu-opening code always agree on
+   * whether the button exists (prevents unnecessary menu clicks when the button
+   * is only discoverable via a selector that the fast-path didn't check — #756).
+   */
+  private findSelectorButton(): HTMLElement | null {
+    return (
+      document.querySelector<HTMLElement>('[data-test-id="bard-mode-menu-button"]') ??
+      document.querySelector<HTMLElement>('button.input-area-switch') ??
+      document.querySelector<HTMLElement>('.input-area-switch-label') ??
+      document.querySelector<HTMLElement>('[data-test-id="model-selector"]') ??
+      document.querySelector<HTMLElement>('button[aria-haspopup="menu"].mat-mdc-menu-trigger')
+    );
+  }
+
+  /**
    * Read the trigger pill's visible text. The 2026 redesign renders the model name and
    * the optional thinking level on two separate lines (innerText newline-separated).
-   * Returns lower-cased lines so callers can match against stored labels.
+   * Returns the raw lines so callers can match against stored labels.
    */
   private readTriggerPillLines(): string[] {
-    const btn =
-      document.querySelector<HTMLElement>('[data-test-id="bard-mode-menu-button"]') ??
-      document.querySelector<HTMLElement>('button.input-area-switch');
+    const btn = this.findSelectorButton();
     const text = btn?.innerText ?? btn?.textContent ?? '';
     return text
       .split(/\n+/)

--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -7983,10 +7983,7 @@ export class FolderManager {
    */
   private hasLegacyActionsContainer(): boolean {
     const now = performance.now();
-    if (
-      this.legacyActionsProbe &&
-      now - this.legacyActionsProbe.at < LEGACY_ACTIONS_PROBE_TTL_MS
-    ) {
+    if (this.legacyActionsProbe && now - this.legacyActionsProbe.at < LEGACY_ACTIONS_PROBE_TTL_MS) {
       return this.legacyActionsProbe.present;
     }
     const present =


### PR DESCRIPTION
## What

Unify the model selector trigger button lookup across three methods in `DefaultModelManager` to eliminate a selector mismatch that caused the dropdown to flash open every second for ~10 seconds on new conversations.

## Why

`readTriggerPillLines()` (the fast-path check) used **2 selectors** to find the trigger button, while `tryLockToModel()` used **5 selectors** and `tryLockToThinkingLevel()` used **2 selectors**.

When the button existed under one of the 3 selectors missing from the fast-path (`.input-area-switch-label`, `[data-test-id="model-selector"]`, or `button[aria-haspopup="menu"]`):

1. `readTriggerPillLines()` returned `[]`
2. `modelMatchesLines()` always returned `false`
3. `tryLockToModel()` was called every 1 second
4. Each call programmatically clicked the trigger button to open the dropdown
5. Result: ~10 seconds of dropdown flashing (up to 20 attempts)

## How

Extracted a shared `findSelectorButton()` private method with all 5 selectors and replaced the inline queries in:

- `readTriggerPillLines()` — fast-path check
- `tryLockToModel()` — model switch
- `tryLockToThinkingLevel()` — thinking level switch

Now the fast-path check and the menu-opening code always agree on whether the button exists.

## User impact

Users who set a default model will no longer see the model selector dropdown flash open repeatedly when starting a new conversation. The auto-switch still works correctly — it just skips the unnecessary menu clicks when the model is already right.

## Testing

- Added a new test case that uses `.input-area-switch-label` (instead of `data-test-id="bard-mode-menu-button"`) to verify the fast-path correctly skips menu clicks with the expanded selector set.
- All 1334 existing tests continue to pass.

## Checklist

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — 1334/1334 pass
- [x] `bun run build:chrome` — builds successfully
- [x] `bun run format` — applied
- [x] Unit test covers the fix

Closes #756