### PR TITLE
fix(sidebarAutoHide): debounce global MutationObserver to fix sidebar open lag

### DIFF
--- a/src/pages/content/folder/manager.ts
+++ b/src/pages/content/folder/manager.ts
@@ -7983,10 +7983,7 @@ export class FolderManager {
    */
   private hasLegacyActionsContainer(): boolean {
     const now = performance.now();
-    if (
-      this.legacyActionsProbe &&
-      now - this.legacyActionsProbe.at < LEGACY_ACTIONS_PROBE_TTL_MS
-    ) {
+    if (this.legacyActionsProbe && now - this.legacyActionsProbe.at < LEGACY_ACTIONS_PROBE_TTL_MS) {
       return this.legacyActionsProbe.present;
     }
     const present =

--- a/src/pages/content/sidebarAutoHide/index.ts
+++ b/src/pages/content/sidebarAutoHide/index.ts
@@ -40,6 +40,10 @@ const SIDEBAR_TOGGLE_BUTTON_MATCH_SELECTOR = `${SIDEBAR_TOGGLE_BUTTON_SELECTOR},
 const TOGGLE_ICON_FONTICONS = ['side_nav', 'side_nav_expand'] as const;
 const SIDEBAR_STATE_SYNC_DELAYS_MS = [0, 300, 500] as const;
 
+// Debounce delay for the global body MutationObserver. During sidebar expansion
+// Gemini renders hundreds of conversation rows in rapid succession; without
+// debouncing, every mutation triggers a synchronous checkAndReattach() sweep.
+const OBSERVER_DEBOUNCE_MS = 100;
 // Debounce delay to avoid rapid toggling
 const LEAVE_DELAY_MS = 400;
 const ENTER_DELAY_MS = 150;
@@ -93,6 +97,7 @@ let predictiveMouseMoveHandler: ((e: MouseEvent) => void) | null = null;
 let observer: MutationObserver | null = null;
 let resizeHandler: (() => void) | null = null;
 let resizeDebounceTimer: number | null = null;
+let observerDebounceTimer: number | null = null;
 let sidenavCheckTimer: number | null = null;
 let menuClickHandler: ((e: Event) => void) | null = null;
 let sidebarStateSyncTimeoutIds: number[] = [];
@@ -683,7 +688,15 @@ function stopSidenavCheck(): void {
 function setupInfrastructure(): void {
   if (!observer) {
     observer = new MutationObserver(() => {
-      if (enabled || fullHideEnabled) checkAndReattach();
+      if (!enabled && !fullHideEnabled) return;
+      // Debounce: during sidebar expansion Gemini renders hundreds of
+      // conversation rows in rapid succession. Without debouncing every
+      // mutation triggers a synchronous DOM-query sweep (#753).
+      if (observerDebounceTimer !== null) window.clearTimeout(observerDebounceTimer);
+      observerDebounceTimer = window.setTimeout(() => {
+        observerDebounceTimer = null;
+        checkAndReattach();
+      }, OBSERVER_DEBOUNCE_MS);
     });
     observer.observe(document.body, { childList: true, subtree: true });
   }
@@ -705,6 +718,11 @@ function teardownInfrastructure(): void {
   if (resizeDebounceTimer !== null) {
     window.clearTimeout(resizeDebounceTimer);
     resizeDebounceTimer = null;
+  }
+
+  if (observerDebounceTimer !== null) {
+    window.clearTimeout(observerDebounceTimer);
+    observerDebounceTimer = null;
   }
 
   if (observer) {


### PR DESCRIPTION
## What

Debounce the body-level `MutationObserver` in the sidebar auto-hide module so that `checkAndReattach()` runs once after a DOM mutation burst settles, instead of on every single mutation.

## Why

The observer at `sidebarAutoHide/index.ts:685` watched `document.body` with `{ childList: true, subtree: true }` and called `checkAndReattach()` synchronously on **every** mutation callback. `checkAndReattach()` performs DOM queries (`document.querySelector("bard-sidenav")`, `getBoundingClientRect()`, etc.).

During sidebar expansion, Gemini renders hundreds of conversation rows in rapid succession. Each row insertion produces multiple mutation records (childList, characterData, attributes). This created a mutation storm — hundreds of synchronous DOM-query sweeps in a single expansion — the primary bottleneck reported in #753.

## How

- Add a 100ms debounce to the observer callback using `setTimeout` + a tracked timer ID.
- Clear the timer in `teardownInfrastructure()` to prevent leaks.
- The 100ms delay is well within the existing 150ms `mouseenter` debounce and 400ms `mouseleave` delay, so it does not affect perceived responsiveness.
- The 1-second `setInterval` fallback and the `resize` handler (200ms debounce) already cover edge cases where the observer alone might miss a sidebar removal.

## User impact

Users with long conversation histories will see significantly faster sidebar open/close. The extension no longer blocks the main thread during the mutation storm that occurs when Gemini renders the conversation list.

## Testing

- All 11 existing `SidebarAutoHide` tests pass without modification.
- Full test suite: 172 files, 1333 tests — all pass.

## Checklist

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — 1333/1333 pass
- [x] `bun run build:chrome` — builds successfully
- [x] `bun run format` — applied
- [x] Logic clearly explained

Closes #753