### PR TITLE
fix(folder): align AI Studio folder actions with Gemini inline UX

### DIFF
--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -5746,10 +5746,39 @@ body.dark-theme .gv-folders-anchor-toggle:hover,
   min-height: 28px;
 }
 
+.gv-aistudio .gv-folder-item-header.gv-folder-editing {
+  gap: 4px;
+  padding-right: 6px;
+  cursor: default;
+  background: var(--mat-sys-surface-container, rgba(255, 255, 255, 0.62));
+}
+
+.gv-aistudio .gv-folder-item-header.gv-folder-editing .gv-folder-pin-btn,
+.gv-aistudio .gv-folder-item-header.gv-folder-editing .gv-folder-actions-btn {
+  display: none !important;
+}
+
+.gv-aistudio .gv-folder-item-header.gv-folder-editing .gv-folder-expand-btn,
+.gv-aistudio .gv-folder-item-header.gv-folder-editing .gv-folder-icon {
+  flex: 0 0 auto;
+}
+
+.gv-aistudio .gv-folder-item-header.gv-folder-editing .gv-folder-rename-inline {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.gv-aistudio .gv-folder-item-header.gv-folder-editing .gv-folder-rename-input {
+  flex: 1 1 auto;
+  width: 100%;
+}
+
 .gv-aistudio .gv-folder-name {
   font-size: 12px;
   /* Allow a bit more width visually */
-  letter-spacing: 0.1px;
+  letter-spacing: 0;
   /* Ensure folder name has minimum width to display at least a few characters */
   min-width: 40px;
   flex: 1;
@@ -5776,6 +5805,115 @@ body.dark-theme .gv-folders-anchor-toggle:hover,
 .gv-aistudio .gv-folder-list {
   padding-left: 0;
   padding-right: 0;
+}
+
+.gv-aistudio-folder-menu {
+  min-width: 176px;
+  padding: 6px;
+  border-radius: 12px;
+  background: var(--mat-sys-surface-container-high, oklch(0.98 0.002 250));
+  border: 1px solid var(--mat-sys-outline-variant, oklch(0.88 0.004 250 / 0.8));
+  box-shadow:
+    0 12px 32px rgba(0, 0, 0, 0.16),
+    0 3px 10px rgba(0, 0, 0, 0.08);
+  color: var(--mat-sys-on-surface, oklch(0.18 0.004 285));
+}
+
+.gv-aistudio-folder-menu .gv-folder-menu-item {
+  min-height: 34px;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  color: var(--mat-sys-on-surface, oklch(0.18 0.004 285));
+}
+
+.gv-aistudio-folder-menu .gv-folder-menu-item:hover {
+  background: var(--mat-sys-surface-container-highest, rgba(0, 0, 0, 0.06));
+}
+
+.gv-aistudio-folder-menu .gv-folder-menu-item .google-symbols {
+  width: 18px;
+  height: 18px;
+  margin-right: 0;
+  font-size: 18px;
+  line-height: 18px;
+  color: var(--mat-sys-on-surface-variant, #5f6368);
+  flex-shrink: 0;
+}
+
+.gv-aistudio-folder-menu .gv-folder-menu-item-danger,
+.gv-aistudio-folder-menu .gv-folder-menu-item-danger .google-symbols {
+  color: var(--mat-sys-error, #ba1a1a);
+}
+
+.gv-aistudio-folder-menu .gv-folder-menu-item-danger:hover {
+  background: color-mix(in srgb, var(--mat-sys-error, #ba1a1a) 10%, transparent);
+}
+
+.gv-aistudio .gv-folder-inline-input {
+  gap: 4px;
+  margin: 4px 6px;
+  padding: 4px;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(95, 99, 104, 0.18));
+  border-radius: 10px;
+  background: var(--mat-sys-surface-container, rgba(255, 255, 255, 0.72));
+}
+
+.gv-aistudio .gv-folder-rename-inline {
+  min-width: 0;
+  gap: 3px;
+}
+
+.gv-aistudio .gv-folder-name-input,
+.gv-aistudio .gv-folder-rename-input {
+  min-width: 0;
+  height: 30px;
+  padding: 0 8px;
+  border-radius: 8px;
+  border-color: transparent;
+  background: var(--mat-sys-surface-container-low, rgba(255, 255, 255, 0.9));
+  color: var(--mat-sys-on-surface, #202124);
+  font-size: 12px;
+}
+
+.gv-aistudio .gv-folder-name-input:focus,
+.gv-aistudio .gv-folder-rename-input:focus {
+  border-color: var(--mat-sys-primary, #1a73e8);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--mat-sys-primary, #1a73e8) 18%, transparent);
+}
+
+.gv-aistudio .gv-folder-inline-btn {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  color: var(--mat-sys-on-surface-variant, #5f6368);
+}
+
+.gv-aistudio .gv-folder-inline-btn:hover {
+  background: var(--mat-sys-surface-container-highest, rgba(0, 0, 0, 0.06));
+}
+
+.gv-aistudio .gv-folder-inline-save:hover {
+  color: #188038;
+  background: rgba(24, 128, 56, 0.1);
+}
+
+.gv-aistudio .gv-folder-inline-cancel:hover {
+  color: var(--mat-sys-error, #ba1a1a);
+  background: color-mix(in srgb, var(--mat-sys-error, #ba1a1a) 10%, transparent);
+}
+
+.gv-aistudio .gv-folder-inline-btn .google-symbols {
+  width: 18px;
+  height: 18px;
+  overflow: visible;
+  font-size: 18px;
+  line-height: 18px;
+}
+
+.gv-aistudio .gv-folder-inline-btn .google-symbols::before {
+  content: none;
+  display: none;
 }
 
 /* Make action buttons absolute so they don’t steal inline space */

--- a/src/pages/content/folder/__tests__/aistudio.test.ts
+++ b/src/pages/content/folder/__tests__/aistudio.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AIStudioFolderManager, mutationAddsPromptLinks, parseDragDataPayload } from '../aistudio';
+import type { Folder } from '../types';
 
 type DragDataTransferMock = {
   effectAllowed: string;
@@ -95,15 +96,10 @@ function createLibraryPromptRow(
 }
 
 type AIStudioManagerInternals = {
+  container: HTMLElement | null;
+  activeFolderInput: HTMLElement | null;
   data: {
-    folders: Array<{
-      id: string;
-      name: string;
-      parentId: string | null;
-      isExpanded: boolean;
-      createdAt: number;
-      updatedAt: number;
-    }>;
+    folders: Folder[];
     folderContents: Record<
       string,
       Array<{
@@ -120,13 +116,228 @@ type AIStudioManagerInternals = {
   observeLibraryTable: () => void;
   bindDraggablesInLibraryTable: () => void;
   syncConversationTitlesFromPromptList: () => Promise<void>;
+  createFolder: (parentId?: string | null) => void;
+  renameFolder: (folderId: string) => void;
+  deleteFolder: (folderId: string) => void;
   save: () => Promise<void>;
   render: () => void;
 };
 
+function createFolderFixture(overrides: Partial<Folder> = {}): Folder {
+  return {
+    id: 'folder-a',
+    name: 'Alpha',
+    parentId: null,
+    isExpanded: true,
+    createdAt: 100,
+    updatedAt: 100,
+    ...overrides,
+  };
+}
+
+function mountAIStudioFolderList(internals: AIStudioManagerInternals): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'gv-folder-container gv-aistudio';
+  const list = document.createElement('div');
+  list.className = 'gv-folder-list';
+  container.appendChild(list);
+  document.body.appendChild(container);
+  internals.container = container;
+  return list;
+}
+
 afterEach(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
   document.body.innerHTML = '';
+});
+
+describe('AIStudio inline folder editing', () => {
+  it('reuses the active create input instead of opening duplicates', () => {
+    const manager = new AIStudioFolderManager();
+    const internals = manager as unknown as AIStudioManagerInternals;
+    mountAIStudioFolderList(internals);
+
+    internals.createFolder();
+
+    const input = document.querySelector('.gv-folder-name-input') as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+    expect(document.querySelectorAll('.gv-folder-inline-input')).toHaveLength(1);
+    expect(internals.activeFolderInput).not.toBeNull();
+
+    const focusTrap = document.createElement('button');
+    document.body.appendChild(focusTrap);
+    focusTrap.focus();
+    expect(document.activeElement).toBe(focusTrap);
+
+    internals.createFolder();
+
+    expect(document.querySelectorAll('.gv-folder-inline-input')).toHaveLength(1);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('saves a trimmed root folder from the inline input', async () => {
+    const manager = new AIStudioFolderManager();
+    const internals = manager as unknown as AIStudioManagerInternals;
+    mountAIStudioFolderList(internals);
+    const saveSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    internals.save = saveSpy;
+    const renderSpy = vi.spyOn(internals, 'render');
+
+    internals.createFolder();
+    const input = document.querySelector('.gv-folder-name-input') as HTMLInputElement;
+    input.value = '  Project Alpha  ';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await Promise.resolve();
+
+    expect(internals.data.folders).toHaveLength(1);
+    expect(internals.data.folders[0]?.name).toBe('Project Alpha');
+    expect(internals.data.folders[0]?.parentId).toBeNull();
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.gv-folder-inline-input')).toBeNull();
+  });
+
+  it('cancels inline root creation without saving data', () => {
+    const manager = new AIStudioFolderManager();
+    const internals = manager as unknown as AIStudioManagerInternals;
+    mountAIStudioFolderList(internals);
+    const saveSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    internals.save = saveSpy;
+
+    internals.createFolder();
+    const input = document.querySelector('.gv-folder-name-input') as HTMLInputElement;
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(internals.data.folders).toHaveLength(0);
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(document.querySelector('.gv-folder-inline-input')).toBeNull();
+    expect(internals.activeFolderInput).toBeNull();
+  });
+
+  it('creates subfolders inline under the selected parent', async () => {
+    const manager = new AIStudioFolderManager();
+    const internals = manager as unknown as AIStudioManagerInternals;
+    mountAIStudioFolderList(internals);
+    internals.data = {
+      folders: [createFolderFixture({ id: 'parent', name: 'Parent' })],
+      folderContents: { parent: [] },
+    };
+    const saveSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    internals.save = saveSpy;
+    internals.render();
+
+    internals.createFolder('parent');
+
+    const parentContent = document.querySelector('[data-folder-id="parent"] .gv-folder-content');
+    expect(parentContent?.querySelector('.gv-folder-inline-input')).not.toBeNull();
+
+    const input = document.querySelector('.gv-folder-name-input') as HTMLInputElement;
+    input.value = 'Child';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await Promise.resolve();
+
+    const child = internals.data.folders.find((folder) => folder.name === 'Child');
+    expect(child?.parentId).toBe('parent');
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('renames folders inline from double-click and restores on empty names', async () => {
+    const manager = new AIStudioFolderManager();
+    const internals = manager as unknown as AIStudioManagerInternals;
+    mountAIStudioFolderList(internals);
+    internals.data = {
+      folders: [createFolderFixture()],
+      folderContents: { 'folder-a': [] },
+    };
+    const saveSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    internals.save = saveSpy;
+    internals.render();
+
+    const name = document.querySelector('.gv-folder-name') as HTMLElement;
+    name.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+
+    const emptyInput = document.querySelector('.gv-folder-rename-input') as HTMLInputElement;
+    expect(emptyInput.value).toBe('Alpha');
+    emptyInput.value = '   ';
+    emptyInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(document.querySelector('.gv-folder-rename-input')).toBeNull();
+    expect(name.classList.contains('gv-hidden')).toBe(false);
+
+    name.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    const input = document.querySelector('.gv-folder-rename-input') as HTMLInputElement;
+    input.value = 'Beta';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await Promise.resolve();
+
+    expect(internals.data.folders[0]?.name).toBe('Beta');
+    expect(internals.data.folders[0]?.updatedAt).toBeGreaterThan(100);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens inline rename from the folder context menu', () => {
+    const manager = new AIStudioFolderManager();
+    const internals = manager as unknown as AIStudioManagerInternals;
+    mountAIStudioFolderList(internals);
+    internals.data = {
+      folders: [createFolderFixture()],
+      folderContents: { 'folder-a': [] },
+    };
+    internals.render();
+
+    const moreBtn = document.querySelector('.gv-folder-actions-btn') as HTMLButtonElement;
+    moreBtn.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 20, clientY: 20 }));
+    const renameItem = Array.from(document.querySelectorAll('.gv-context-menu button')).find(
+      (button) => button.textContent === 'folder_rename',
+    ) as HTMLButtonElement | undefined;
+
+    expect(renameItem).not.toBeUndefined();
+    renameItem?.click();
+
+    const input = document.querySelector('.gv-folder-rename-input') as HTMLInputElement | null;
+    expect(input?.value).toBe('Alpha');
+  });
+
+  it('uses an in-page delete confirmation instead of window.confirm', async () => {
+    const manager = new AIStudioFolderManager();
+    const internals = manager as unknown as AIStudioManagerInternals;
+    mountAIStudioFolderList(internals);
+    internals.data = {
+      folders: [
+        createFolderFixture({ id: 'folder-a', name: 'Alpha' }),
+        createFolderFixture({ id: 'child-a', name: 'Child', parentId: 'folder-a' }),
+        createFolderFixture({ id: 'folder-b', name: 'Beta' }),
+      ],
+      folderContents: {
+        'folder-a': [],
+        'child-a': [],
+        'folder-b': [],
+      },
+    };
+    const saveSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    internals.save = saveSpy;
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    internals.render();
+
+    internals.deleteFolder('folder-a');
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    const dialog = document.querySelector('.gv-folder-confirm-dialog.gv-aistudio-confirm');
+    expect(dialog).not.toBeNull();
+
+    const confirmBtn = dialog?.querySelector('.gv-confirm-delete') as HTMLButtonElement;
+    confirmBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(internals.data.folders.map((folder) => folder.id)).toEqual(['folder-b']);
+    expect(internals.data.folderContents['folder-a']).toBeUndefined();
+    expect(internals.data.folderContents['child-a']).toBeUndefined();
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.gv-folder-confirm-dialog.gv-aistudio-confirm')).toBeNull();
+  });
 });
 
 describe('AIStudio prompt binding performance guards', () => {

--- a/src/pages/content/folder/__tests__/aistudio.test.ts
+++ b/src/pages/content/folder/__tests__/aistudio.test.ts
@@ -3,7 +3,6 @@ import { resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AIStudioFolderManager, mutationAddsPromptLinks, parseDragDataPayload } from '../aistudio';
-import type { Folder } from '../types';
 
 type DragDataTransferMock = {
   effectAllowed: string;
@@ -96,10 +95,15 @@ function createLibraryPromptRow(
 }
 
 type AIStudioManagerInternals = {
-  container: HTMLElement | null;
-  activeFolderInput: HTMLElement | null;
   data: {
-    folders: Folder[];
+    folders: Array<{
+      id: string;
+      name: string;
+      parentId: string | null;
+      isExpanded: boolean;
+      createdAt: number;
+      updatedAt: number;
+    }>;
     folderContents: Record<
       string,
       Array<{
@@ -116,228 +120,13 @@ type AIStudioManagerInternals = {
   observeLibraryTable: () => void;
   bindDraggablesInLibraryTable: () => void;
   syncConversationTitlesFromPromptList: () => Promise<void>;
-  createFolder: (parentId?: string | null) => void;
-  renameFolder: (folderId: string) => void;
-  deleteFolder: (folderId: string) => void;
   save: () => Promise<void>;
   render: () => void;
 };
 
-function createFolderFixture(overrides: Partial<Folder> = {}): Folder {
-  return {
-    id: 'folder-a',
-    name: 'Alpha',
-    parentId: null,
-    isExpanded: true,
-    createdAt: 100,
-    updatedAt: 100,
-    ...overrides,
-  };
-}
-
-function mountAIStudioFolderList(internals: AIStudioManagerInternals): HTMLElement {
-  const container = document.createElement('div');
-  container.className = 'gv-folder-container gv-aistudio';
-  const list = document.createElement('div');
-  list.className = 'gv-folder-list';
-  container.appendChild(list);
-  document.body.appendChild(container);
-  internals.container = container;
-  return list;
-}
-
 afterEach(() => {
   vi.useRealTimers();
-  vi.restoreAllMocks();
   document.body.innerHTML = '';
-});
-
-describe('AIStudio inline folder editing', () => {
-  it('reuses the active create input instead of opening duplicates', () => {
-    const manager = new AIStudioFolderManager();
-    const internals = manager as unknown as AIStudioManagerInternals;
-    mountAIStudioFolderList(internals);
-
-    internals.createFolder();
-
-    const input = document.querySelector('.gv-folder-name-input') as HTMLInputElement | null;
-    expect(input).not.toBeNull();
-    expect(document.querySelectorAll('.gv-folder-inline-input')).toHaveLength(1);
-    expect(internals.activeFolderInput).not.toBeNull();
-
-    const focusTrap = document.createElement('button');
-    document.body.appendChild(focusTrap);
-    focusTrap.focus();
-    expect(document.activeElement).toBe(focusTrap);
-
-    internals.createFolder();
-
-    expect(document.querySelectorAll('.gv-folder-inline-input')).toHaveLength(1);
-    expect(document.activeElement).toBe(input);
-  });
-
-  it('saves a trimmed root folder from the inline input', async () => {
-    const manager = new AIStudioFolderManager();
-    const internals = manager as unknown as AIStudioManagerInternals;
-    mountAIStudioFolderList(internals);
-    const saveSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
-    internals.save = saveSpy;
-    const renderSpy = vi.spyOn(internals, 'render');
-
-    internals.createFolder();
-    const input = document.querySelector('.gv-folder-name-input') as HTMLInputElement;
-    input.value = '  Project Alpha  ';
-    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-    await Promise.resolve();
-
-    expect(internals.data.folders).toHaveLength(1);
-    expect(internals.data.folders[0]?.name).toBe('Project Alpha');
-    expect(internals.data.folders[0]?.parentId).toBeNull();
-    expect(saveSpy).toHaveBeenCalledTimes(1);
-    expect(renderSpy).toHaveBeenCalledTimes(1);
-    expect(document.querySelector('.gv-folder-inline-input')).toBeNull();
-  });
-
-  it('cancels inline root creation without saving data', () => {
-    const manager = new AIStudioFolderManager();
-    const internals = manager as unknown as AIStudioManagerInternals;
-    mountAIStudioFolderList(internals);
-    const saveSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
-    internals.save = saveSpy;
-
-    internals.createFolder();
-    const input = document.querySelector('.gv-folder-name-input') as HTMLInputElement;
-    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-
-    expect(internals.data.folders).toHaveLength(0);
-    expect(saveSpy).not.toHaveBeenCalled();
-    expect(document.querySelector('.gv-folder-inline-input')).toBeNull();
-    expect(internals.activeFolderInput).toBeNull();
-  });
-
-  it('creates subfolders inline under the selected parent', async () => {
-    const manager = new AIStudioFolderManager();
-    const internals = manager as unknown as AIStudioManagerInternals;
-    mountAIStudioFolderList(internals);
-    internals.data = {
-      folders: [createFolderFixture({ id: 'parent', name: 'Parent' })],
-      folderContents: { parent: [] },
-    };
-    const saveSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
-    internals.save = saveSpy;
-    internals.render();
-
-    internals.createFolder('parent');
-
-    const parentContent = document.querySelector('[data-folder-id="parent"] .gv-folder-content');
-    expect(parentContent?.querySelector('.gv-folder-inline-input')).not.toBeNull();
-
-    const input = document.querySelector('.gv-folder-name-input') as HTMLInputElement;
-    input.value = 'Child';
-    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-    await Promise.resolve();
-
-    const child = internals.data.folders.find((folder) => folder.name === 'Child');
-    expect(child?.parentId).toBe('parent');
-    expect(saveSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('renames folders inline from double-click and restores on empty names', async () => {
-    const manager = new AIStudioFolderManager();
-    const internals = manager as unknown as AIStudioManagerInternals;
-    mountAIStudioFolderList(internals);
-    internals.data = {
-      folders: [createFolderFixture()],
-      folderContents: { 'folder-a': [] },
-    };
-    const saveSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
-    internals.save = saveSpy;
-    internals.render();
-
-    const name = document.querySelector('.gv-folder-name') as HTMLElement;
-    name.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
-
-    const emptyInput = document.querySelector('.gv-folder-rename-input') as HTMLInputElement;
-    expect(emptyInput.value).toBe('Alpha');
-    emptyInput.value = '   ';
-    emptyInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-
-    expect(saveSpy).not.toHaveBeenCalled();
-    expect(document.querySelector('.gv-folder-rename-input')).toBeNull();
-    expect(name.classList.contains('gv-hidden')).toBe(false);
-
-    name.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
-    const input = document.querySelector('.gv-folder-rename-input') as HTMLInputElement;
-    input.value = 'Beta';
-    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-    await Promise.resolve();
-
-    expect(internals.data.folders[0]?.name).toBe('Beta');
-    expect(internals.data.folders[0]?.updatedAt).toBeGreaterThan(100);
-    expect(saveSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('opens inline rename from the folder context menu', () => {
-    const manager = new AIStudioFolderManager();
-    const internals = manager as unknown as AIStudioManagerInternals;
-    mountAIStudioFolderList(internals);
-    internals.data = {
-      folders: [createFolderFixture()],
-      folderContents: { 'folder-a': [] },
-    };
-    internals.render();
-
-    const moreBtn = document.querySelector('.gv-folder-actions-btn') as HTMLButtonElement;
-    moreBtn.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 20, clientY: 20 }));
-    const renameItem = Array.from(document.querySelectorAll('.gv-context-menu button')).find(
-      (button) => button.textContent === 'folder_rename',
-    ) as HTMLButtonElement | undefined;
-
-    expect(renameItem).not.toBeUndefined();
-    renameItem?.click();
-
-    const input = document.querySelector('.gv-folder-rename-input') as HTMLInputElement | null;
-    expect(input?.value).toBe('Alpha');
-  });
-
-  it('uses an in-page delete confirmation instead of window.confirm', async () => {
-    const manager = new AIStudioFolderManager();
-    const internals = manager as unknown as AIStudioManagerInternals;
-    mountAIStudioFolderList(internals);
-    internals.data = {
-      folders: [
-        createFolderFixture({ id: 'folder-a', name: 'Alpha' }),
-        createFolderFixture({ id: 'child-a', name: 'Child', parentId: 'folder-a' }),
-        createFolderFixture({ id: 'folder-b', name: 'Beta' }),
-      ],
-      folderContents: {
-        'folder-a': [],
-        'child-a': [],
-        'folder-b': [],
-      },
-    };
-    const saveSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
-    internals.save = saveSpy;
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
-    internals.render();
-
-    internals.deleteFolder('folder-a');
-
-    expect(confirmSpy).not.toHaveBeenCalled();
-    const dialog = document.querySelector('.gv-folder-confirm-dialog.gv-aistudio-confirm');
-    expect(dialog).not.toBeNull();
-
-    const confirmBtn = dialog?.querySelector('.gv-confirm-delete') as HTMLButtonElement;
-    confirmBtn.click();
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(internals.data.folders.map((folder) => folder.id)).toEqual(['folder-b']);
-    expect(internals.data.folderContents['folder-a']).toBeUndefined();
-    expect(internals.data.folderContents['child-a']).toBeUndefined();
-    expect(saveSpy).toHaveBeenCalledTimes(1);
-    expect(document.querySelector('.gv-folder-confirm-dialog.gv-aistudio-confirm')).toBeNull();
-  });
 });
 
 describe('AIStudio prompt binding performance guards', () => {

--- a/src/pages/content/folder/aistudio.ts
+++ b/src/pages/content/folder/aistudio.ts
@@ -118,6 +118,13 @@ const PROMPT_DRAG_HOST_SELECTORS = [
 
 type LibraryPromptData = DragData & { conversationId: string };
 
+type InlineFolderEditor = {
+  wrapper: HTMLElement;
+  input: HTMLInputElement;
+  saveBtn: HTMLButtonElement;
+  cancelBtn: HTMLButtonElement;
+};
+
 function nodeContainsPromptLink(node: Node): boolean {
   if (!(node instanceof Element)) return false;
   if (node.matches(PROMPT_LINK_SELECTOR)) return true;
@@ -239,7 +246,6 @@ export class AIStudioFolderManager {
   private promptListBindTimer: number | null = null;
   private promptTitleSyncTimer: number | null = null;
   private promptTitleSyncInProgress: boolean = false;
-  private activeFolderInput: HTMLElement | null = null;
   private selectedLibraryPrompts: Set<string> = new Set();
   private isLibraryMultiSelectMode: boolean = false;
   private libraryOutsideClickHandler: ((e: MouseEvent) => void) | null = null;
@@ -282,6 +288,132 @@ export class AIStudioFolderManager {
     } catch {}
     span.textContent = name;
     return span;
+  }
+
+  private createInlineMaterialIcon(name: string): HTMLElement {
+    const icon = document.createElement('mat-icon');
+    icon.setAttribute('role', 'img');
+    icon.setAttribute('aria-hidden', 'true');
+    icon.className = 'mat-icon notranslate google-symbols mat-ligature-font mat-icon-no-color';
+    icon.textContent = name;
+    return icon;
+  }
+
+  private createMenuItem(
+    label: string,
+    iconName: string,
+    action: () => void,
+    options: { danger?: boolean } = {},
+  ): HTMLButtonElement {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = `gv-folder-menu-item${options.danger ? ' gv-folder-menu-item-danger' : ''}`;
+    item.appendChild(this.createInlineMaterialIcon(iconName));
+    item.append(document.createTextNode(label));
+    item.addEventListener('click', action);
+    return item;
+  }
+
+  private createInlineFolderEditor(
+    wrapperTag: 'div' | 'span',
+    wrapperClassName: string,
+    inputClassName: string,
+    inputOptions: { placeholder?: string; value?: string } = {},
+  ): InlineFolderEditor {
+    const wrapper = document.createElement(wrapperTag);
+    wrapper.className = wrapperClassName;
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = inputClassName;
+    input.maxLength = 50;
+    if (inputOptions.placeholder) input.placeholder = inputOptions.placeholder;
+    if (inputOptions.value) input.value = inputOptions.value;
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'gv-folder-inline-btn gv-folder-inline-save';
+    saveBtn.title = this.t('pm_save');
+    saveBtn.appendChild(this.createInlineMaterialIcon('check'));
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'gv-folder-inline-btn gv-folder-inline-cancel';
+    cancelBtn.title = this.t('pm_cancel');
+    cancelBtn.appendChild(this.createInlineMaterialIcon('close'));
+
+    wrapper.appendChild(input);
+    wrapper.appendChild(saveBtn);
+    wrapper.appendChild(cancelBtn);
+
+    return { wrapper, input, saveBtn, cancelBtn };
+  }
+
+  private showFolderConfirm(
+    anchor: HTMLElement | null | undefined,
+    message: string,
+    actionLabel: string,
+    onConfirm: () => void,
+    alignRight = false,
+  ): void {
+    document.querySelector('.gv-folder-confirm-dialog.gv-aistudio-confirm')?.remove();
+
+    const dialog = document.createElement('div');
+    dialog.className = 'gv-folder-confirm-dialog gv-aistudio-confirm';
+
+    if (anchor) {
+      const rect = anchor.getBoundingClientRect();
+      dialog.style.position = 'fixed';
+      dialog.style.top = `${rect.bottom + 4}px`;
+      dialog.style.left = `${Math.max(10, alignRight ? rect.right - 200 : rect.left + 24)}px`;
+      dialog.style.zIndex = '2147483647';
+    }
+
+    const msg = document.createElement('div');
+    msg.className = 'gv-confirm-message';
+    msg.textContent = message;
+    dialog.appendChild(msg);
+
+    const actions = document.createElement('div');
+    actions.className = 'gv-confirm-actions';
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.type = 'button';
+    confirmBtn.className = 'gv-confirm-btn gv-confirm-delete';
+    confirmBtn.textContent = actionLabel;
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'gv-confirm-btn gv-confirm-cancel';
+    cancelBtn.textContent = this.t('pm_cancel');
+
+    let closeOnOutside: ((e: MouseEvent) => void) | null = null;
+    const cleanup = () => {
+      if (closeOnOutside) {
+        document.removeEventListener('click', closeOnOutside);
+        closeOnOutside = null;
+      }
+      dialog.remove();
+    };
+
+    confirmBtn.addEventListener('click', () => {
+      onConfirm();
+      cleanup();
+    });
+    cancelBtn.addEventListener('click', cleanup);
+
+    actions.appendChild(confirmBtn);
+    actions.appendChild(cancelBtn);
+    dialog.appendChild(actions);
+    document.body.appendChild(dialog);
+
+    setTimeout(() => {
+      if (!dialog.isConnected) return;
+      closeOnOutside = (e: MouseEvent) => {
+        if (!dialog.contains(e.target as Node)) cleanup();
+      };
+      document.addEventListener('click', closeOnOutside);
+    }, 0);
   }
 
   async init(): Promise<void> {
@@ -427,10 +559,6 @@ export class AIStudioFolderManager {
       ]),
     );
     return { folders, folderContents };
-  }
-
-  private clearActiveFolderInput(): void {
-    this.activeFolderInput = null;
   }
 
   private async migrateLegacyFolderDataToScopedStorage(): Promise<FolderData | null> {
@@ -703,7 +831,6 @@ export class AIStudioFolderManager {
       if (nowTs - this.lastContainerReinjectAt < 250) return;
       this.lastContainerReinjectAt = nowTs;
 
-      this.clearActiveFolderInput();
       this.container = null;
       try {
         this.injectUI();
@@ -989,7 +1116,6 @@ export class AIStudioFolderManager {
     if (!this.container) return;
     const list = this.container.querySelector('.gv-folder-list') as HTMLElement | null;
     if (!list) return;
-    this.clearActiveFolderInput();
     list.innerHTML = '';
 
     // Render only root-level folders here; children are rendered recursively
@@ -1094,7 +1220,6 @@ export class AIStudioFolderManager {
   private ensureContainerMounted(): void {
     if (!this.folderEnabled) return;
     if (this.container && document.body.contains(this.container)) return;
-    this.clearActiveFolderInput();
     this.container = null;
     try {
       this.injectUI();
@@ -1313,105 +1438,74 @@ export class AIStudioFolderManager {
     if (!folder) return;
 
     const menu = document.createElement('div');
-    menu.className = 'gv-context-menu';
+    menu.className = 'gv-folder-menu gv-aistudio-folder-menu';
+    menu.style.position = 'fixed';
+    menu.style.left = `${ev.clientX}px`;
+    menu.style.top = `${ev.clientY}px`;
+
+    const closeMenu = () => {
+      menu.remove();
+      document.removeEventListener('click', onClickAway);
+    };
 
     // Only show "Create subfolder" for root-level folders (to maintain 2-level hierarchy)
     if (!folder.parentId) {
-      const createSub = document.createElement('button');
-      createSub.textContent = this.t('folder_create_subfolder') || 'Create Subfolder';
-      createSub.addEventListener('click', () => {
-        this.createFolder(folderId);
-        try {
-          document.body.removeChild(menu);
-        } catch {}
-      });
-      menu.appendChild(createSub);
+      menu.appendChild(
+        this.createMenuItem(this.t('folder_create_subfolder'), 'create_new_folder', () => {
+          this.createFolder(folderId);
+          closeMenu();
+        }),
+      );
     }
 
-    const rename = document.createElement('button');
-    rename.textContent = this.t('folder_rename');
-    rename.addEventListener('click', () => {
-      this.renameFolder(folderId);
-      try {
-        document.body.removeChild(menu);
-      } catch {}
-    });
-    menu.appendChild(rename);
-
-    const del = document.createElement('button');
-    del.textContent = this.t('folder_delete');
-    del.addEventListener('click', () => {
-      this.deleteFolder(folderId);
-      try {
-        document.body.removeChild(menu);
-      } catch {}
-    });
-    menu.appendChild(del);
-
-    // Apply styles with proper typing
-    const st = menu.style;
-    st.position = 'fixed';
-    st.top = `${ev.clientY}px`;
-    st.left = `${ev.clientX}px`;
-    st.zIndex = String(2147483647);
-    st.display = 'flex';
-    st.flexDirection = 'column';
-    document.body.appendChild(menu);
     const onClickAway = (e: MouseEvent) => {
       if (e.target instanceof Node && !menu.contains(e.target)) {
-        try {
-          document.body.removeChild(menu);
-        } catch {}
-        window.removeEventListener('click', onClickAway, true);
+        closeMenu();
       }
     };
-    window.addEventListener('click', onClickAway, true);
+
+    menu.appendChild(
+      this.createMenuItem(this.t('folder_rename'), 'edit', () => {
+        this.renameFolder(folderId);
+        closeMenu();
+      }),
+    );
+    menu.appendChild(
+      this.createMenuItem(
+        this.t('folder_delete'),
+        'delete',
+        () => {
+          this.deleteFolder(folderId);
+          closeMenu();
+        },
+        { danger: true },
+      ),
+    );
+
+    document.body.appendChild(menu);
+    setTimeout(() => document.addEventListener('click', onClickAway), 0);
   }
 
   private createFolder(parentId: string | null = null): void {
-    if (this.activeFolderInput && !this.activeFolderInput.isConnected) {
-      this.clearActiveFolderInput();
+    const existingInput = this.container?.querySelector<HTMLInputElement>(
+      '.gv-folder-inline-input input',
+    );
+    if (existingInput) {
+      existingInput.focus();
+      return;
     }
 
-    if (this.activeFolderInput) {
-      const existingInput = this.activeFolderInput.querySelector(
-        'input',
-      ) as HTMLInputElement | null;
-      if (existingInput) {
-        existingInput.focus();
-        return;
-      }
-      this.clearActiveFolderInput();
-    }
-
-    const inputContainer = document.createElement('div');
-    inputContainer.className = 'gv-folder-inline-input';
-
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.className = 'gv-folder-name-input';
-    input.placeholder = this.t('folder_name_prompt');
-    input.maxLength = 50;
-
-    const saveBtn = document.createElement('button');
-    saveBtn.type = 'button';
-    saveBtn.className = 'gv-folder-inline-btn gv-folder-inline-save';
-    saveBtn.title = this.t('pm_save');
-    saveBtn.appendChild(this.createIcon('check'));
-
-    const cancelBtn = document.createElement('button');
-    cancelBtn.type = 'button';
-    cancelBtn.className = 'gv-folder-inline-btn gv-folder-inline-cancel';
-    cancelBtn.title = this.t('pm_cancel');
-    cancelBtn.appendChild(this.createIcon('close'));
-
-    inputContainer.appendChild(input);
-    inputContainer.appendChild(saveBtn);
-    inputContainer.appendChild(cancelBtn);
+    const {
+      wrapper: inputContainer,
+      input,
+      saveBtn,
+      cancelBtn,
+    } = this.createInlineFolderEditor('div', 'gv-folder-inline-input', 'gv-folder-name-input', {
+      placeholder: this.t('folder_name_prompt'),
+    });
 
     const cancel = () => {
       inputContainer.remove();
-      this.clearActiveFolderInput();
     };
 
     const save = async () => {
@@ -1464,45 +1558,44 @@ export class AIStudioFolderManager {
     }
 
     input.focus();
-    this.activeFolderInput = inputContainer;
   }
 
   private renameFolder(folderId: string): void {
+    const activeRenameInput = this.container?.querySelector<HTMLInputElement>(
+      '.gv-folder-rename-inline input',
+    );
+    if (activeRenameInput) {
+      activeRenameInput.focus();
+      activeRenameInput.select();
+      return;
+    }
+
     const folder = this.data.folders.find((f) => f.id === folderId);
     if (!folder) return;
 
     const folderEl = this.container?.querySelector(`[data-folder-id="${folderId}"]`);
     if (!folderEl) return;
 
+    const headerEl = folderEl.querySelector<HTMLElement>('.gv-folder-item-header');
+    if (!headerEl) return;
+
     const folderNameEl = folderEl.querySelector('.gv-folder-name');
     if (!folderNameEl) return;
 
-    const inputContainer = document.createElement('span');
-    inputContainer.className = 'gv-folder-rename-inline';
-
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.className = 'gv-folder-rename-input';
-    input.value = folder.name;
-    input.maxLength = 50;
-
-    const saveBtn = document.createElement('button');
-    saveBtn.type = 'button';
-    saveBtn.className = 'gv-folder-inline-btn gv-folder-inline-save';
-    saveBtn.title = this.t('pm_save');
-    saveBtn.appendChild(this.createIcon('check'));
-
-    const cancelBtn = document.createElement('button');
-    cancelBtn.type = 'button';
-    cancelBtn.className = 'gv-folder-inline-btn gv-folder-inline-cancel';
-    cancelBtn.title = this.t('pm_cancel');
-    cancelBtn.appendChild(this.createIcon('close'));
-
-    inputContainer.appendChild(input);
-    inputContainer.appendChild(saveBtn);
-    inputContainer.appendChild(cancelBtn);
+    const {
+      wrapper: inputContainer,
+      input,
+      saveBtn,
+      cancelBtn,
+    } = this.createInlineFolderEditor(
+      'span',
+      'gv-folder-rename-inline',
+      'gv-folder-rename-input',
+      { value: folder.name },
+    );
 
     const restore = () => {
+      headerEl.classList.remove('gv-folder-editing');
       folderNameEl.classList.remove('gv-hidden');
       inputContainer.remove();
     };
@@ -1530,88 +1623,37 @@ export class AIStudioFolderManager {
     });
 
     folderNameEl.classList.add('gv-hidden');
-    folderNameEl.parentElement?.insertBefore(inputContainer, folderNameEl.nextSibling);
+    headerEl.classList.add('gv-folder-editing');
+    headerEl.insertBefore(inputContainer, folderNameEl.nextSibling);
     input.focus();
     input.select();
   }
 
   private deleteFolder(folderId: string): void {
-    const existingDialog = document.querySelector('.gv-folder-confirm-dialog.gv-aistudio-confirm');
-    existingDialog?.remove();
-
-    const dialog = document.createElement('div');
-    dialog.className = 'gv-folder-confirm-dialog gv-aistudio-confirm';
-
     const folderEl = this.container?.querySelector(`[data-folder-id="${folderId}"]`);
-    const headerEl = folderEl?.querySelector('.gv-folder-item-header');
-    if (headerEl) {
-      const rect = headerEl.getBoundingClientRect();
-      dialog.style.position = 'fixed';
-      dialog.style.top = `${rect.bottom + 4}px`;
-      dialog.style.left = `${Math.max(10, rect.left + 24)}px`;
-      dialog.style.zIndex = String(2147483647);
-    }
+    const headerEl = folderEl?.querySelector<HTMLElement>('.gv-folder-item-header');
 
-    const msg = document.createElement('div');
-    msg.className = 'gv-confirm-message';
-    msg.textContent = this.t('folder_delete_confirm');
-    dialog.appendChild(msg);
-
-    const actions = document.createElement('div');
-    actions.className = 'gv-confirm-actions';
-
-    const confirmBtn = document.createElement('button');
-    confirmBtn.type = 'button';
-    confirmBtn.className = 'gv-confirm-btn gv-confirm-delete';
-    confirmBtn.textContent = this.t('folder_remove_conversation_action') || 'Delete';
-
-    const cancelBtn = document.createElement('button');
-    cancelBtn.type = 'button';
-    cancelBtn.className = 'gv-confirm-btn gv-confirm-cancel';
-    cancelBtn.textContent = this.t('pm_cancel') || 'Cancel';
-
-    let closeOnOutside: ((e: MouseEvent) => void) | null = null;
-    const cleanup = () => {
-      if (closeOnOutside) {
-        document.removeEventListener('click', closeOnOutside);
-        closeOnOutside = null;
-      }
-      dialog.remove();
-    };
-
-    confirmBtn.addEventListener('click', () => {
-      // Collect all folder IDs to delete (including subfolders)
-      const folderIdsToDelete: string[] = [folderId];
-      const subfolders = this.data.folders.filter((f) => f.parentId === folderId);
-      for (const subfolder of subfolders) {
-        folderIdsToDelete.push(subfolder.id);
-      }
-
-      // Delete all collected folders and their contents
-      this.data.folders = this.data.folders.filter((f) => !folderIdsToDelete.includes(f.id));
-      for (const id of folderIdsToDelete) {
-        delete this.data.folderContents[id];
-      }
-
-      void this.save().then(() => this.render());
-      cleanup();
-    });
-    cancelBtn.addEventListener('click', cleanup);
-
-    actions.appendChild(confirmBtn);
-    actions.appendChild(cancelBtn);
-    dialog.appendChild(actions);
-    document.body.appendChild(dialog);
-
-    setTimeout(() => {
-      if (!dialog.isConnected) return;
-      closeOnOutside = (e: MouseEvent) => {
-        if (!dialog.contains(e.target as Node)) {
-          cleanup();
+    this.showFolderConfirm(
+      headerEl,
+      this.t('folder_delete_confirm'),
+      this.t('folder_remove_conversation_action'),
+      () => {
+        // Collect all folder IDs to delete (including subfolders)
+        const folderIdsToDelete: string[] = [folderId];
+        const subfolders = this.data.folders.filter((f) => f.parentId === folderId);
+        for (const subfolder of subfolders) {
+          folderIdsToDelete.push(subfolder.id);
         }
-      };
-      document.addEventListener('click', closeOnOutside);
-    }, 0);
+
+        // Delete all collected folders and their contents
+        this.data.folders = this.data.folders.filter((f) => !folderIdsToDelete.includes(f.id));
+        for (const id of folderIdsToDelete) {
+          delete this.data.folderContents[id];
+        }
+
+        void this.save().then(() => this.render());
+      },
+    );
   }
 
   private removeConversationFromFolder(folderId: string, conversationId: string): void {
@@ -1626,76 +1668,17 @@ export class AIStudioFolderManager {
     title: string,
     event: MouseEvent,
   ): void {
-    const dialog = document.createElement('div');
-    dialog.className = 'gv-folder-confirm-dialog gv-aistudio-confirm';
-
-    // Position near the button
     const target = event.currentTarget as HTMLElement;
-    const rect = target.getBoundingClientRect();
-
-    dialog.style.position = 'fixed';
-    dialog.style.zIndex = '2147483647';
-    // Position logic: prefer left side if space available
-    // AI Studio sidebar is on the left, so we might want to pop out to the right or below
-    // But usually context menus appear near the cursor.
-    // Let's position it below the button, aligned right
-    dialog.style.top = `${rect.bottom + 4}px`;
-    dialog.style.left = `${rect.right - 200}px`; // Align right edge roughly
-
-    // Ensure it's on screen
-    if (parseInt(dialog.style.left) < 10) dialog.style.left = '10px';
-
-    const msg = document.createElement('div');
-    msg.className = 'gv-confirm-message';
-    msg.textContent = this.t('folder_remove_conversation_confirm').replace(
-      '{title}',
-      title || this.t('conversation_untitled'),
+    this.showFolderConfirm(
+      target,
+      this.t('folder_remove_conversation_confirm').replace(
+        '{title}',
+        title || this.t('conversation_untitled'),
+      ),
+      this.t('folder_remove_conversation_action'),
+      () => this.removeConversationFromFolder(folderId, conversationId),
+      true,
     );
-    dialog.appendChild(msg);
-
-    const actions = document.createElement('div');
-    actions.className = 'gv-confirm-actions';
-
-    const confirmBtn = document.createElement('button');
-    confirmBtn.className = 'gv-confirm-btn gv-confirm-delete';
-    confirmBtn.textContent = this.t('folder_remove_conversation_action') || 'Remove';
-    confirmBtn.addEventListener('click', () => {
-      this.removeConversationFromFolder(folderId, conversationId);
-      dialog.remove();
-      document.removeEventListener('click', closeOnOutside);
-    });
-
-    const cancelBtn = document.createElement('button');
-    cancelBtn.className = 'gv-confirm-btn gv-confirm-cancel';
-    cancelBtn.textContent = this.t('pm_cancel') || 'Cancel';
-    cancelBtn.addEventListener('click', () => {
-      dialog.remove();
-      document.removeEventListener('click', closeOnOutside);
-    });
-
-    // Delete on left, Cancel on right
-    actions.appendChild(confirmBtn);
-    actions.appendChild(cancelBtn);
-    dialog.appendChild(actions);
-
-    document.body.appendChild(dialog);
-
-    // Close when clicking outside
-    const closeOnOutside = (e: MouseEvent) => {
-      if (
-        !dialog.contains(e.target as Node) &&
-        e.target !== target &&
-        !target.contains(e.target as Node)
-      ) {
-        dialog.remove();
-        document.removeEventListener('click', closeOnOutside);
-      }
-    };
-
-    // Delay adding the listener to avoid immediate closing
-    setTimeout(() => {
-      document.addEventListener('click', closeOnOutside);
-    }, 10);
   }
 
   private bindDropZone(el: HTMLElement, targetFolderId: string | null): void {

--- a/src/pages/content/folder/aistudio.ts
+++ b/src/pages/content/folder/aistudio.ts
@@ -1374,7 +1374,9 @@ export class AIStudioFolderManager {
     }
 
     if (this.activeFolderInput) {
-      const existingInput = this.activeFolderInput.querySelector('input') as HTMLInputElement | null;
+      const existingInput = this.activeFolderInput.querySelector(
+        'input',
+      ) as HTMLInputElement | null;
       if (existingInput) {
         existingInput.focus();
         return;
@@ -1534,9 +1536,7 @@ export class AIStudioFolderManager {
   }
 
   private deleteFolder(folderId: string): void {
-    const existingDialog = document.querySelector(
-      '.gv-folder-confirm-dialog.gv-aistudio-confirm',
-    );
+    const existingDialog = document.querySelector('.gv-folder-confirm-dialog.gv-aistudio-confirm');
     existingDialog?.remove();
 
     const dialog = document.createElement('div');

--- a/src/pages/content/folder/aistudio.ts
+++ b/src/pages/content/folder/aistudio.ts
@@ -1587,12 +1587,9 @@ export class AIStudioFolderManager {
       input,
       saveBtn,
       cancelBtn,
-    } = this.createInlineFolderEditor(
-      'span',
-      'gv-folder-rename-inline',
-      'gv-folder-rename-input',
-      { value: folder.name },
-    );
+    } = this.createInlineFolderEditor('span', 'gv-folder-rename-inline', 'gv-folder-rename-input', {
+      value: folder.name,
+    });
 
     const restore = () => {
       headerEl.classList.remove('gv-folder-editing');

--- a/src/pages/content/folder/aistudio.ts
+++ b/src/pages/content/folder/aistudio.ts
@@ -239,6 +239,7 @@ export class AIStudioFolderManager {
   private promptListBindTimer: number | null = null;
   private promptTitleSyncTimer: number | null = null;
   private promptTitleSyncInProgress: boolean = false;
+  private activeFolderInput: HTMLElement | null = null;
   private selectedLibraryPrompts: Set<string> = new Set();
   private isLibraryMultiSelectMode: boolean = false;
   private libraryOutsideClickHandler: ((e: MouseEvent) => void) | null = null;
@@ -426,6 +427,10 @@ export class AIStudioFolderManager {
       ]),
     );
     return { folders, folderContents };
+  }
+
+  private clearActiveFolderInput(): void {
+    this.activeFolderInput = null;
   }
 
   private async migrateLegacyFolderDataToScopedStorage(): Promise<FolderData | null> {
@@ -698,6 +703,7 @@ export class AIStudioFolderManager {
       if (nowTs - this.lastContainerReinjectAt < 250) return;
       this.lastContainerReinjectAt = nowTs;
 
+      this.clearActiveFolderInput();
       this.container = null;
       try {
         this.injectUI();
@@ -983,6 +989,7 @@ export class AIStudioFolderManager {
     if (!this.container) return;
     const list = this.container.querySelector('.gv-folder-list') as HTMLElement | null;
     if (!list) return;
+    this.clearActiveFolderInput();
     list.innerHTML = '';
 
     // Render only root-level folders here; children are rendered recursively
@@ -1087,6 +1094,7 @@ export class AIStudioFolderManager {
   private ensureContainerMounted(): void {
     if (!this.folderEnabled) return;
     if (this.container && document.body.contains(this.container)) return;
+    this.clearActiveFolderInput();
     this.container = null;
     try {
       this.injectUI();
@@ -1360,52 +1368,245 @@ export class AIStudioFolderManager {
     window.addEventListener('click', onClickAway, true);
   }
 
-  private async createFolder(parentId: string | null = null): Promise<void> {
-    const name = prompt(this.t('folder_name_prompt'));
-    if (!name) return;
-    const f: Folder = {
-      id: uid(),
-      name: name.trim(),
-      parentId: parentId || null,
-      isExpanded: true,
-      createdAt: now(),
-      updatedAt: now(),
+  private createFolder(parentId: string | null = null): void {
+    if (this.activeFolderInput && !this.activeFolderInput.isConnected) {
+      this.clearActiveFolderInput();
+    }
+
+    if (this.activeFolderInput) {
+      const existingInput = this.activeFolderInput.querySelector('input') as HTMLInputElement | null;
+      if (existingInput) {
+        existingInput.focus();
+        return;
+      }
+      this.clearActiveFolderInput();
+    }
+
+    const inputContainer = document.createElement('div');
+    inputContainer.className = 'gv-folder-inline-input';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'gv-folder-name-input';
+    input.placeholder = this.t('folder_name_prompt');
+    input.maxLength = 50;
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'gv-folder-inline-btn gv-folder-inline-save';
+    saveBtn.title = this.t('pm_save');
+    saveBtn.appendChild(this.createIcon('check'));
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'gv-folder-inline-btn gv-folder-inline-cancel';
+    cancelBtn.title = this.t('pm_cancel');
+    cancelBtn.appendChild(this.createIcon('close'));
+
+    inputContainer.appendChild(input);
+    inputContainer.appendChild(saveBtn);
+    inputContainer.appendChild(cancelBtn);
+
+    const cancel = () => {
+      inputContainer.remove();
+      this.clearActiveFolderInput();
     };
-    this.data.folders.push(f);
-    this.data.folderContents[f.id] = [];
-    await this.save();
-    this.render();
+
+    const save = async () => {
+      const name = input.value.trim();
+      if (!name) {
+        cancel();
+        return;
+      }
+
+      const f: Folder = {
+        id: uid(),
+        name,
+        parentId: parentId || null,
+        isExpanded: true,
+        createdAt: now(),
+        updatedAt: now(),
+      };
+      this.data.folders.push(f);
+      this.data.folderContents[f.id] = [];
+      await this.save();
+      this.render();
+    };
+
+    saveBtn.addEventListener('click', () => {
+      void save();
+    });
+    cancelBtn.addEventListener('click', cancel);
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') void save();
+      if (e.key === 'Escape') cancel();
+    });
+
+    const folderList = this.container?.querySelector('.gv-folder-list');
+    if (!folderList) return;
+
+    if (parentId) {
+      const parentFolder = folderList.querySelector(`[data-folder-id="${parentId}"]`);
+      if (parentFolder) {
+        const parentContent = parentFolder.querySelector('.gv-folder-content');
+        if (parentContent) {
+          parentContent.insertBefore(inputContainer, parentContent.firstChild);
+        } else {
+          parentFolder.insertAdjacentElement('afterend', inputContainer);
+        }
+      } else {
+        folderList.appendChild(inputContainer);
+      }
+    } else {
+      folderList.insertBefore(inputContainer, folderList.firstChild);
+    }
+
+    input.focus();
+    this.activeFolderInput = inputContainer;
   }
 
-  private async renameFolder(folderId: string): Promise<void> {
+  private renameFolder(folderId: string): void {
     const folder = this.data.folders.find((f) => f.id === folderId);
     if (!folder) return;
-    const name = prompt(this.t('folder_rename_prompt'), folder.name);
-    if (!name) return;
-    folder.name = name.trim();
-    folder.updatedAt = now();
-    await this.save();
-    this.render();
+
+    const folderEl = this.container?.querySelector(`[data-folder-id="${folderId}"]`);
+    if (!folderEl) return;
+
+    const folderNameEl = folderEl.querySelector('.gv-folder-name');
+    if (!folderNameEl) return;
+
+    const inputContainer = document.createElement('span');
+    inputContainer.className = 'gv-folder-rename-inline';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'gv-folder-rename-input';
+    input.value = folder.name;
+    input.maxLength = 50;
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'gv-folder-inline-btn gv-folder-inline-save';
+    saveBtn.title = this.t('pm_save');
+    saveBtn.appendChild(this.createIcon('check'));
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'gv-folder-inline-btn gv-folder-inline-cancel';
+    cancelBtn.title = this.t('pm_cancel');
+    cancelBtn.appendChild(this.createIcon('close'));
+
+    inputContainer.appendChild(input);
+    inputContainer.appendChild(saveBtn);
+    inputContainer.appendChild(cancelBtn);
+
+    const restore = () => {
+      folderNameEl.classList.remove('gv-hidden');
+      inputContainer.remove();
+    };
+
+    const save = async () => {
+      const name = input.value.trim();
+      if (!name) {
+        restore();
+        return;
+      }
+
+      folder.name = name;
+      folder.updatedAt = now();
+      await this.save();
+      this.render();
+    };
+
+    saveBtn.addEventListener('click', () => {
+      void save();
+    });
+    cancelBtn.addEventListener('click', restore);
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') void save();
+      if (e.key === 'Escape') restore();
+    });
+
+    folderNameEl.classList.add('gv-hidden');
+    folderNameEl.parentElement?.insertBefore(inputContainer, folderNameEl.nextSibling);
+    input.focus();
+    input.select();
   }
 
-  private async deleteFolder(folderId: string): Promise<void> {
-    if (!confirm(this.t('folder_delete_confirm'))) return;
+  private deleteFolder(folderId: string): void {
+    const existingDialog = document.querySelector(
+      '.gv-folder-confirm-dialog.gv-aistudio-confirm',
+    );
+    existingDialog?.remove();
 
-    // Collect all folder IDs to delete (including subfolders)
-    const folderIdsToDelete: string[] = [folderId];
-    const subfolders = this.data.folders.filter((f) => f.parentId === folderId);
-    for (const subfolder of subfolders) {
-      folderIdsToDelete.push(subfolder.id);
+    const dialog = document.createElement('div');
+    dialog.className = 'gv-folder-confirm-dialog gv-aistudio-confirm';
+
+    const folderEl = this.container?.querySelector(`[data-folder-id="${folderId}"]`);
+    const headerEl = folderEl?.querySelector('.gv-folder-item-header');
+    if (headerEl) {
+      const rect = headerEl.getBoundingClientRect();
+      dialog.style.position = 'fixed';
+      dialog.style.top = `${rect.bottom + 4}px`;
+      dialog.style.left = `${Math.max(10, rect.left + 24)}px`;
+      dialog.style.zIndex = String(2147483647);
     }
 
-    // Delete all collected folders and their contents
-    this.data.folders = this.data.folders.filter((f) => !folderIdsToDelete.includes(f.id));
-    for (const id of folderIdsToDelete) {
-      delete this.data.folderContents[id];
-    }
+    const msg = document.createElement('div');
+    msg.className = 'gv-confirm-message';
+    msg.textContent = this.t('folder_delete_confirm');
+    dialog.appendChild(msg);
 
-    await this.save();
-    this.render();
+    const actions = document.createElement('div');
+    actions.className = 'gv-confirm-actions';
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.type = 'button';
+    confirmBtn.className = 'gv-confirm-btn gv-confirm-delete';
+    confirmBtn.textContent = this.t('folder_remove_conversation_action') || 'Delete';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'gv-confirm-btn gv-confirm-cancel';
+    cancelBtn.textContent = this.t('pm_cancel') || 'Cancel';
+
+    const cleanup = () => {
+      dialog.remove();
+    };
+
+    confirmBtn.addEventListener('click', () => {
+      // Collect all folder IDs to delete (including subfolders)
+      const folderIdsToDelete: string[] = [folderId];
+      const subfolders = this.data.folders.filter((f) => f.parentId === folderId);
+      for (const subfolder of subfolders) {
+        folderIdsToDelete.push(subfolder.id);
+      }
+
+      // Delete all collected folders and their contents
+      this.data.folders = this.data.folders.filter((f) => !folderIdsToDelete.includes(f.id));
+      for (const id of folderIdsToDelete) {
+        delete this.data.folderContents[id];
+      }
+
+      void this.save().then(() => this.render());
+      cleanup();
+    });
+    cancelBtn.addEventListener('click', cleanup);
+
+    actions.appendChild(confirmBtn);
+    actions.appendChild(cancelBtn);
+    dialog.appendChild(actions);
+    document.body.appendChild(dialog);
+
+    setTimeout(() => {
+      const closeOnOutside = (e: MouseEvent) => {
+        if (!dialog.contains(e.target as Node)) {
+          cleanup();
+          document.removeEventListener('click', closeOnOutside);
+        }
+      };
+      document.addEventListener('click', closeOnOutside);
+    }, 0);
   }
 
   private removeConversationFromFolder(folderId: string, conversationId: string): void {

--- a/src/pages/content/folder/aistudio.ts
+++ b/src/pages/content/folder/aistudio.ts
@@ -1570,7 +1570,12 @@ export class AIStudioFolderManager {
     cancelBtn.className = 'gv-confirm-btn gv-confirm-cancel';
     cancelBtn.textContent = this.t('pm_cancel') || 'Cancel';
 
+    let closeOnOutside: ((e: MouseEvent) => void) | null = null;
     const cleanup = () => {
+      if (closeOnOutside) {
+        document.removeEventListener('click', closeOnOutside);
+        closeOnOutside = null;
+      }
       dialog.remove();
     };
 
@@ -1599,10 +1604,10 @@ export class AIStudioFolderManager {
     document.body.appendChild(dialog);
 
     setTimeout(() => {
-      const closeOnOutside = (e: MouseEvent) => {
+      if (!dialog.isConnected) return;
+      closeOnOutside = (e: MouseEvent) => {
         if (!dialog.contains(e.target as Node)) {
           cleanup();
-          document.removeEventListener('click', closeOnOutside);
         }
       };
       document.addEventListener('click', closeOnOutside);


### PR DESCRIPTION
### Description / 描述

优化AI Studio里文件夹的新建、重命名和删除体验

之前新建文件夹、重命名文件夹会弹浏览器原生 `aistudio.google.com says...` 输入框，体验和 Gemini 页面不一致。改动复用了gemini文件夹区已有的内联编辑方式：文件夹名称位置直接出现输入框，Enter 保存，Escape 取消。

主要改动：
- AI Studio 新建文件夹 / 新建子文件夹改为内联输入
- AI Studio 重命名文件夹改为内联输入
- AI Studio 删除文件夹改为页面内确认框，不再使用浏览器原生 confirm
- 复用现有 `gv-folder-*` 样式和已有翻译 key
- ~~补充了 create、cancel、subfolder create、rename、context menu rename、delete confirmation 的测试~~
之前定位为feature有些不太准确，考虑到 [CONTRIBUTING.md](https://github.com/Nagi-ovo/gemini-voyager/blob/main/.github/CONTRIBUTING.md)，把pr的定位改为了一个小fix，并移除了原先引入的test

### Visual Proof / 可视化证据

<img width="300" height="400" alt="image" src="https://github.com/user-attachments/assets/169d7f9e-1813-4b99-bcc4-261d705a9f14" />
<img width="300" height="400" alt="image" src="https://github.com/user-attachments/assets/813ac629-1657-4fbe-99d7-489e4d49bd3c" />

### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

本地验证：
- `bun run lint`：通过，有项目既有 warnings
- `bun run test`：通过，189 files / 1517 tests
- `bun run build:chrome`：通过，有项目既有 build warnings
- `bun run format`：执行成功
- `bun run typecheck`：失败；但是`main` 分支同样失败， `src/pages/popup/Popup.tsx:612` 有类型问题，和这次改动没关系
