### PR TITLE
fix: resolve multi-account usage traffic fetch

### DIFF
--- a/public/usage-observer.js
+++ b/public/usage-observer.js
@@ -192,8 +192,12 @@
       var freq = JSON.stringify([[[rpcid, args, null, 'generic']]]);
       var reqBody = 'f.req=' + encodeURIComponent(freq) + '&at=' + encodeURIComponent(at) + '&';
       var reqid = 100000 + (Math.floor(performance.now()) % 800000);
+      
+            var match = sourcePath.match(/^\/u\/\d+/);
+      var accountPrefix = match ? match[0] : '';
       var url =
         location.origin +
+        accountPrefix +
         '/_/BardChatUi/data/batchexecute?rpcids=' +
         encodeURIComponent(rpcid) +
         '&source-path=' +

--- a/public/usage-observer.js
+++ b/public/usage-observer.js
@@ -192,7 +192,7 @@
       var freq = JSON.stringify([[[rpcid, args, null, 'generic']]]);
       var reqBody = 'f.req=' + encodeURIComponent(freq) + '&at=' + encodeURIComponent(at) + '&';
       var reqid = 100000 + (Math.floor(performance.now()) % 800000);
-      
+
       var match = sourcePath.match(/^\/u\/\d+/);
       var accountPrefix = match ? match[0] : '';
       var url =

--- a/public/usage-observer.js
+++ b/public/usage-observer.js
@@ -193,7 +193,7 @@
       var reqBody = 'f.req=' + encodeURIComponent(freq) + '&at=' + encodeURIComponent(at) + '&';
       var reqid = 100000 + (Math.floor(performance.now()) % 800000);
       
-            var match = sourcePath.match(/^\/u\/\d+/);
+      var match = sourcePath.match(/^\/u\/\d+/);
       var accountPrefix = match ? match[0] : '';
       var url =
         location.origin +

--- a/src/pages/content/usageStatus/__tests__/usageObserver.test.ts
+++ b/src/pages/content/usageStatus/__tests__/usageObserver.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const observerScript = readFileSync(resolve(process.cwd(), 'public/usage-observer.js'), 'utf-8');
+
+type UsageWindow = Window &
+  typeof globalThis & {
+    __gvUsageObserverInstalled?: boolean;
+    WIZ_global_data?: Record<string, string>;
+  };
+
+function installObserver(): void {
+  (0, eval)(observerScript);
+}
+
+function dispatchReplay(sourcePath: string): void {
+  const event = new MessageEvent('message', {
+    data: {
+      source: 'gv-usage-observer-cmd',
+      type: 'replay',
+      payload: {
+        id: 1,
+        rpcid: 'jSf9Qc',
+        args: '[]',
+        sourcePath,
+      },
+    },
+  });
+  Object.defineProperty(event, 'source', { value: window });
+  window.dispatchEvent(event);
+}
+
+describe('usage-observer replay', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    const usageWindow = window as UsageWindow;
+    delete usageWindow.__gvUsageObserverInstalled;
+    usageWindow.WIZ_global_data = {
+      SNlM0e: 'at-token',
+      cfb2h: 'bl-token',
+      FdrFJe: 'fsid-token',
+    };
+
+    fetchMock = vi.fn().mockResolvedValue({
+      text: vi.fn().mockResolvedValue('[]'),
+    });
+    Object.defineProperty(window, 'fetch', {
+      value: fetchMock,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('replays multi-account usage requests on the same account route', async () => {
+    installObserver();
+
+    dispatchReplay('/u/2/app');
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const requestUrl = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(requestUrl.pathname).toBe('/u/2/_/BardChatUi/data/batchexecute');
+    expect(requestUrl.searchParams.get('source-path')).toBe('/u/2/app');
+  });
+});


### PR DESCRIPTION
### 🚫 AI Policy / AI 政策

- **We explicitly reject AI-generated PRs that have not been manually verified.**
- **本项目拒绝接受任何未经人工复核的 AI 生成的 PR。**
- Low-quality AI PRs will be closed immediately. / 低质量的 AI PR 会被直接关闭。
- You must understand and take responsibility for every line of code you submit. / 你必须理解并对你提交的每一行代码负责。
- **Workflow Proficiency / 协作能力**: Ensure you are familiar with GitHub/Git workflows and maintain a clean Git history. Please learn the basics first if needed to avoid messy PR history. / 请确保你熟悉 GitHub/Git 工作流并保持 Git 历史整洁。如有必要请先学习相关知识，避免 PR 历史过于混乱。

---

### Description / 描述


修复了在多账号（例如 `/u/1/` 或 `/u/2/`）页面下，用量悬浮窗点击刷新或后台自动刷新时，由于脚本写死了 `/_/BardChatUi/data/batchexecute` 接口路径，导致总是拉取默认账号（`/u/0/`）流量数据的 Bug。
现在的逻辑会从 `sourcePath` 中动态提取账号路径前缀（如 `/u/1`）并拼接到请求 URL 中。

### Related Issue / 相关 Issue

Closes #766

<!-- Link the issue this PR resolves (e.g., Closes #123). FOR NEW FEATURES: You MUST open an Issue for discussion first. PRs submitted without prior discussion will be closed. -->
<!-- 链接此 PR 解决的 issue（例如：Closes #123）。对于新功能：请务必先开启一个 Issue 进行讨论，未经讨论直接提交的 PR 会被关闭。 -->

### Visual Proof / 可视化证据

<!-- REQUIRED for UI changes: Please provide screenshots or screen recordings. -->
<!-- UI 修改必填：请提供截图或屏幕录制。 -->

### Browser Testing / 浏览器测试

- [ x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x ] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [ x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x ] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [ ] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [ ] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。
