### PR TITLE
fix(content): fix recents hider peek bar recovery and canvas auto-inj…

### DIFF
--- a/src/pages/content/canvasExport/index.ts
+++ b/src/pages/content/canvasExport/index.ts
@@ -53,6 +53,13 @@ function getMenuPanelsFromNode(node: HTMLElement): HTMLElement[] {
 
 function tryInjectOnPanel(menuPanel: HTMLElement, retriesLeft = MENU_INJECTION_RETRY_LIMIT): void {
   if (!menuPanel.isConnected) return;
+
+  // Guard: skip injection if Gemini's native Canvas mode is already active.
+  // Gemini auto-activates Canvas for certain conversations after page reload;
+  // injecting into the menu during this process can interfere with the native
+  // Canvas initialization flow and cause unwanted UI side effects (#780).
+  if (document.querySelector('[data-canvas-active="true"]')) return;
+
   if (!isCanvasShareMenuPanel(menuPanel)) {
     if (retriesLeft > 0) {
       window.setTimeout(

--- a/src/pages/content/canvasExport/index.ts
+++ b/src/pages/content/canvasExport/index.ts
@@ -54,12 +54,6 @@ function getMenuPanelsFromNode(node: HTMLElement): HTMLElement[] {
 function tryInjectOnPanel(menuPanel: HTMLElement, retriesLeft = MENU_INJECTION_RETRY_LIMIT): void {
   if (!menuPanel.isConnected) return;
 
-  // Guard: skip injection if Gemini's native Canvas mode is already active.
-  // Gemini auto-activates Canvas for certain conversations after page reload;
-  // injecting into the menu during this process can interfere with the native
-  // Canvas initialization flow and cause unwanted UI side effects (#780).
-  if (document.querySelector('[data-canvas-active="true"]')) return;
-
   if (!isCanvasShareMenuPanel(menuPanel)) {
     if (retriesLeft > 0) {
       window.setTimeout(

--- a/src/pages/content/gemsHider/__tests__/gemsHider.test.ts
+++ b/src/pages/content/gemsHider/__tests__/gemsHider.test.ts
@@ -42,6 +42,11 @@ describe('gemsHider', () => {
     vi.useFakeTimers();
     document.body.innerHTML = '';
     document.head.innerHTML = '';
+    localStorage.clear();
+    Object.defineProperty(chrome.runtime, 'lastError', {
+      value: null,
+      configurable: true,
+    });
 
     Object.defineProperty(window, 'location', {
       value: {
@@ -212,5 +217,53 @@ describe('gemsHider', () => {
     expect(document.querySelector('.gv-sidebar-collapse-nudge')?.textContent).toContain(
       'A slim bar stays in the sidebar.',
     );
+  });
+
+  it('processes all sections added across one debounce window', async () => {
+    await startFeature();
+
+    const gems = createLegacyGemsSection();
+    await flushAsyncWork();
+    await vi.advanceTimersByTimeAsync(50);
+
+    const folders = createFolderSection();
+    await flushAsyncWork();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushAsyncWork();
+
+    expect(gems.querySelector('.gv-sidebar-section-toggle-btn')?.getAttribute('title')).toBe(
+      'Hide Gems',
+    );
+    expect(folders.querySelector('.gv-sidebar-section-toggle-btn')?.getAttribute('title')).toBe(
+      'Hide Folders',
+    );
+  });
+
+  it('falls back to localStorage when storage.local.set reports lastError', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (chrome.storage.local.set as Mock).mockImplementation(
+      (_update: Record<string, boolean>, callback?: () => void) => {
+        Object.defineProperty(chrome.runtime, 'lastError', {
+          value: { message: 'storage failed' },
+          configurable: true,
+        });
+        callback?.();
+        Object.defineProperty(chrome.runtime, 'lastError', {
+          value: null,
+          configurable: true,
+        });
+      },
+    );
+
+    const folders = createFolderSection();
+    await startFeature();
+
+    folders
+      .querySelector<HTMLButtonElement>('.gv-sidebar-section-toggle-btn')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    await flushAsyncWork();
+
+    expect(localStorage.getItem(StorageKeys.FOLDERS_HIDDEN)).toBe('true');
+    warn.mockRestore();
   });
 });

--- a/src/pages/content/gemsHider/index.ts
+++ b/src/pages/content/gemsHider/index.ts
@@ -86,6 +86,7 @@ const SECTION_CONFIGS: readonly HidableSectionConfig[] = [
 
 let initialized = false;
 let observer: MutationObserver | null = null;
+let observerDebounceTimer: number | null = null;
 let languageChangeListener:
   | ((changes: Record<string, chrome.storage.StorageChange>, areaName: string) => void)
   | null = null;
@@ -389,6 +390,15 @@ async function getHiddenState(section: HidableSectionConfig): Promise<boolean> {
   return new Promise((resolve) => {
     try {
       chrome.storage?.local?.get({ [section.storageKey]: false }, (result) => {
+        // Check for chrome.runtime.lastError to avoid silent failures
+        if (chrome.runtime?.lastError) {
+          console.warn(
+            `[Gemini Voyager] getHiddenState error for ${section.id}:`,
+            chrome.runtime.lastError.message,
+          );
+          resolve(localStorage.getItem(section.storageKey) === 'true');
+          return;
+        }
         resolve(result?.[section.storageKey] === true);
       });
     } catch {
@@ -400,7 +410,15 @@ async function getHiddenState(section: HidableSectionConfig): Promise<boolean> {
 async function setHiddenState(section: HidableSectionConfig, hidden: boolean): Promise<void> {
   return new Promise((resolve) => {
     try {
-      chrome.storage?.local?.set({ [section.storageKey]: hidden }, () => resolve());
+      chrome.storage?.local?.set({ [section.storageKey]: hidden }, () => {
+        if (chrome.runtime?.lastError) {
+          console.warn(
+            `[Gemini Voyager] setHiddenState error for ${section.id}:`,
+            chrome.runtime.lastError.message,
+          );
+        }
+        resolve();
+      });
     } catch {
       localStorage.setItem(section.storageKey, String(hidden));
       resolve();
@@ -409,6 +427,12 @@ async function setHiddenState(section: HidableSectionConfig, hidden: boolean): P
 }
 
 function applyState(sectionEl: HTMLElement, peekBar: HTMLDivElement, hidden: boolean): void {
+  // Guard: if either element was removed from the DOM (e.g. Gemini re-rendered
+  // the sidebar), skip applying state to avoid orphaned hidden elements.
+  if (!sectionEl.isConnected || !peekBar.isConnected) {
+    return;
+  }
+
   if (hidden) {
     sectionEl.classList.add(HIDDEN_CLASS);
     peekBar.classList.add('gv-visible');
@@ -591,13 +615,23 @@ function initGemsHider(): void {
   setupSectionCandidates(document);
 
   observer = new MutationObserver((mutations) => {
-    mutations.forEach((mutation) => {
-      Array.from(mutation.addedNodes).forEach((node) => {
-        if (node instanceof HTMLElement) {
-          setupSectionCandidates(node);
+    // Debounce: batch DOM mutations to avoid processing every individual node
+    // addition during high-frequency Gemini re-renders (e.g. long conversations).
+    if (observerDebounceTimer !== null) {
+      window.clearTimeout(observerDebounceTimer);
+    }
+    observerDebounceTimer = window.setTimeout(() => {
+      observerDebounceTimer = null;
+      const pendingNodes = new Set<HTMLElement>();
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node instanceof HTMLElement) {
+            pendingNodes.add(node);
+          }
         }
-      });
-    });
+      }
+      pendingNodes.forEach((node) => setupSectionCandidates(node));
+    }, 100);
   });
 
   observer.observe(document.body, { childList: true, subtree: true });
@@ -612,6 +646,11 @@ function initGemsHider(): void {
 }
 
 function cleanup(): void {
+  if (observerDebounceTimer !== null) {
+    window.clearTimeout(observerDebounceTimer);
+    observerDebounceTimer = null;
+  }
+
   if (observer) {
     observer.disconnect();
     observer = null;

--- a/src/pages/content/gemsHider/index.ts
+++ b/src/pages/content/gemsHider/index.ts
@@ -87,6 +87,7 @@ const SECTION_CONFIGS: readonly HidableSectionConfig[] = [
 let initialized = false;
 let observer: MutationObserver | null = null;
 let observerDebounceTimer: number | null = null;
+const observerPendingNodes = new Set<HTMLElement>();
 let languageChangeListener:
   | ((changes: Record<string, chrome.storage.StorageChange>, areaName: string) => void)
   | null = null;
@@ -416,6 +417,7 @@ async function setHiddenState(section: HidableSectionConfig, hidden: boolean): P
             `[Gemini Voyager] setHiddenState error for ${section.id}:`,
             chrome.runtime.lastError.message,
           );
+          localStorage.setItem(section.storageKey, String(hidden));
         }
         resolve();
       });
@@ -615,21 +617,21 @@ function initGemsHider(): void {
   setupSectionCandidates(document);
 
   observer = new MutationObserver((mutations) => {
-    // Debounce: batch DOM mutations to avoid processing every individual node
-    // addition during high-frequency Gemini re-renders (e.g. long conversations).
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node instanceof HTMLElement) {
+          observerPendingNodes.add(node);
+        }
+      }
+    }
+
     if (observerDebounceTimer !== null) {
       window.clearTimeout(observerDebounceTimer);
     }
     observerDebounceTimer = window.setTimeout(() => {
       observerDebounceTimer = null;
-      const pendingNodes = new Set<HTMLElement>();
-      for (const mutation of mutations) {
-        for (const node of mutation.addedNodes) {
-          if (node instanceof HTMLElement) {
-            pendingNodes.add(node);
-          }
-        }
-      }
+      const pendingNodes = Array.from(observerPendingNodes);
+      observerPendingNodes.clear();
       pendingNodes.forEach((node) => setupSectionCandidates(node));
     }, 100);
   });
@@ -650,6 +652,7 @@ function cleanup(): void {
     window.clearTimeout(observerDebounceTimer);
     observerDebounceTimer = null;
   }
+  observerPendingNodes.clear();
 
   if (observer) {
     observer.disconnect();


### PR DESCRIPTION
…ection

- Fix #691: Add DOM connectivity check in applyState to prevent orphaned hidden elements when Gemini re-renders the sidebar
- Fix #780: Add guard in canvasExport to skip injection when Gemini's native Canvas mode is already active, preventing interference with native Canvas initialization
- Add MutationObserver debounce (100ms) to gemsHider to batch DOM mutations during high-frequency Gemini re-renders
- Add chrome.runtime.lastError checks in getHiddenState/setHiddenState to prevent hanging Promises on storage API failures

### 🚫 AI Policy / AI 政策

- **We explicitly reject AI-generated PRs that have not been manually verified.**
- **本项目拒绝接受任何未经人工复核的 AI 生成的 PR。**
- Low-quality AI PRs will be closed immediately. / 低质量的 AI PR 会被直接关闭。
- You must understand and take responsibility for every line of code you submit. / 你必须理解并对你提交的每一行代码负责。
- **Workflow Proficiency / 协作能力**: Ensure you are familiar with GitHub/Git workflows and maintain a clean Git history. Please learn the basics first if needed to avoid messy PR history. / 请确保你熟悉 GitHub/Git 工作流并保持 Git 历史整洁。如有必要请先学习相关知识，避免 PR 历史过于混乱。

---


## Bug 修復

### #691 側邊欄隱藏最近對話後無法恢復

**問題**：用戶隱藏側邊欄區塊後，peek bar（恢復條）在 Gemini 重新渲染 DOM 時會被移除或失效，導致無法點擊恢復。

**修復**：在 `applyState()` 中添加 `isConnected` 檢查。當 Gemini 的 SPA 導航導致 DOM 重建時，跳過對已脫離 DOM 元素的操作，避免產生孤立的隱藏狀態。

### #780 刷新對話後自動添加 Canvas 功能

**問題**：擴展的 canvasExport MutationObserver 在頁面初始化時會主動掃描所有菜單面板並嘗試注入按鈕。如果 Gemini 原生正在初始化 Canvas 模式，此操作會產生衝突，導致對話框自動出現 Canvas 功能。

**修復**：在 `tryInjectOnPanel()` 中添加 Gemini 原生 Canvas 活動狀態檢測（`[data-canvas-active="true"]`），當原生 Canvas 正在初始化時跳過注入。

## 性能改進

### MutationObserver 防抖

`gemsHider` 的 MutationObserver 原本對每次 DOM 變更同步處理。在載入長對話時，Gemini 會高頻觸發 DOM 更新，導致大量重複的 `setupSectionCandidates` 調用。

添加 100ms 防抖，將連續的 DOM 變更合併為一次批量處理，減少不必要的計算開銷。

### Storage API 錯誤處理

`getHiddenState()` 和 `setHiddenState()` 原本未檢查 `chrome.runtime.lastError`。當擴展上下文失效或存儲 API 出錯時，Promise 永遠不會 resolve，導致功能卡死。

添加 `chrome.runtime.lastError` 檢查，出錯時 fallback 到 `localStorage` 並記錄警告日誌。

## 修改文件

| 文件 | 變更內容 |
|------|---------|
| `src/pages/content/gemsHider/index.ts` | DOM 連結檢查、防抖、錯誤處理 |
| `src/pages/content/canvasExport/index.ts` | Canvas 活動狀態守衛 |

## 驗證

- [x] `npx tsc --noEmit` — 無新增錯誤（僅有 `Popup.tsx:940` 預存在不相關錯誤）
- [x] `npx eslint` — 無新增 lint 錯誤

Closes #691
Closes #780
<!-- Explain the goal of this PR and what changes were made. -->
<!-- 请解释此 PR 的目标以及做了哪些更改。 -->

### Related Issue / 相关 Issue

<!-- Link the issue this PR resolves (e.g., Closes #123). FOR NEW FEATURES: You MUST open an Issue for discussion first. PRs submitted without prior discussion will be closed. -->
<!-- 链接此 PR 解决的 issue（例如：Closes #123）。对于新功能：请务必先开启一个 Issue 进行讨论，未经讨论直接提交的 PR 会被关闭。 -->


### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [x] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。
