### PR TITLE
fix(prevent-auto-scroll): keep sidebar history scrollable

### DIFF
--- a/public/prevent-auto-scroll.js
+++ b/public/prevent-auto-scroll.js
@@ -6,6 +6,24 @@
   console.log('[Gemini Voyager] Prevent auto scroll script loaded');
 
   const BRIDGE_ID = 'gv-prevent-auto-scroll-bridge';
+  const CHAT_SCROLL_SELECTOR = [
+    '#chat-history',
+    'infinite-scroller.chat-history',
+    '.chat-history-scroll-container',
+    'chat-window',
+    'chat-window-content',
+    '.conversation-container',
+  ].join(', ');
+  const SIDEBAR_SELECTOR = [
+    'bard-sidenav',
+    'side-navigation-content',
+    '[data-test-id="overflow-container"]',
+    '[data-test-id="all-conversations"]',
+    'expandable-section[data-test-id="chats-expandable-section"]',
+    '[data-test-id="conversation"]',
+    '.gv-folder-container',
+    '.gv-gems-inline-list',
+  ].join(', ');
   const INITIAL_NATIVE_SCROLL_ALLOW_MS = 8000;
   const ROUTE_NATIVE_SCROLL_ALLOW_MS = 4000;
   const SUBMIT_SCROLL_BLOCK_MS = 120000;
@@ -41,6 +59,17 @@
   function shouldBlockAutoScroll() {
     const now = Date.now();
     return isEnabled() && now >= nativeScrollAllowedUntil && now < blockScrollUntil;
+  }
+
+  function isSidebarElement(el) {
+    return el instanceof Element && Boolean(el.closest(SIDEBAR_SELECTOR));
+  }
+
+  function isChatScrollElement(el) {
+    if (el === window) return true;
+    if (!(el instanceof Element)) return false;
+    if (isSidebarElement(el)) return false;
+    return Boolean(el.matches(CHAT_SCROLL_SELECTOR) || el.closest(CHAT_SCROLL_SELECTOR));
   }
 
   function handlePossibleRouteChange() {
@@ -170,6 +199,7 @@
 
   function shouldBlockScrollTo(el, args) {
     if (!shouldBlockAutoScroll()) return false;
+    if (!isChatScrollElement(el)) return false;
     if (isScrolledUp(el) && isScrollingDownTo(el, args)) {
       return true;
     }
@@ -178,6 +208,7 @@
 
   function shouldBlockScrollBy(el, args) {
     if (!shouldBlockAutoScroll()) return false;
+    if (!isChatScrollElement(el)) return false;
     if (isScrolledUp(el) && isScrollingDownBy(args)) {
       return true;
     }
@@ -210,11 +241,13 @@
 
   const originalScrollIntoView = Element.prototype.scrollIntoView;
   Element.prototype.scrollIntoView = function (...args) {
-    if (shouldBlockAutoScroll()) {
+    if (shouldBlockAutoScroll() && isChatScrollElement(this)) {
       let ancestor = this.parentElement;
       let blocked = false;
       while (ancestor) {
+        if (isSidebarElement(ancestor)) break;
         if (ancestor.scrollHeight > ancestor.clientHeight) {
+          if (!isChatScrollElement(ancestor)) break;
           if (isScrolledUp(ancestor)) {
             const rect = this.getBoundingClientRect();
             if (rect.top > (window.innerHeight || document.documentElement.clientHeight)) {
@@ -247,7 +280,7 @@
     Object.defineProperty(Element.prototype, 'scrollTop', {
       get: originalScrollTopDescriptor.get,
       set: function (value) {
-        if (shouldBlockAutoScroll() && isScrolledUp(this)) {
+        if (shouldBlockAutoScroll() && isChatScrollElement(this) && isScrolledUp(this)) {
           const currentVal = originalScrollTopDescriptor.get.call(this);
           if (value > currentVal) {
             return;

--- a/src/pages/content/preventAutoScroll/__tests__/preventAutoScrollScript.test.ts
+++ b/src/pages/content/preventAutoScroll/__tests__/preventAutoScrollScript.test.ts
@@ -74,8 +74,12 @@ function installScript(enabled = true): void {
   new Function(preventAutoScrollScript)();
 }
 
-function createScrollableElement(): { el: HTMLElement; getScrollTop: () => number } {
+function createScrollableElement(className = 'chat-history-scroll-container'): {
+  el: HTMLElement;
+  getScrollTop: () => number;
+} {
   const el = document.createElement('div');
+  el.className = className;
   let scrollTop = 0;
 
   Object.defineProperties(el, {
@@ -164,6 +168,25 @@ describe('prevent-auto-scroll page script', () => {
 
     expect(elementScrollToSpy).not.toHaveBeenCalled();
     expect(getScrollTop()).toBe(0);
+  });
+
+  it('allows the sidebar history list to scroll after a submit', () => {
+    installScript();
+    submitFromComposer();
+
+    const sidebar = document.createElement('bard-sidenav');
+    const overflow = document.createElement('div');
+    overflow.setAttribute('data-test-id', 'overflow-container');
+    sidebar.appendChild(overflow);
+    document.body.appendChild(sidebar);
+
+    const { el, getScrollTop } = createScrollableElement('');
+    overflow.appendChild(el);
+
+    el.scrollTo({ top: 1800 });
+
+    expect(elementScrollToSpy).toHaveBeenCalledTimes(1);
+    expect(getScrollTop()).toBe(1800);
   });
 
   it('re-allows native scrolls after route changes that are not part of a fresh submit', () => {


### PR DESCRIPTION
### 🚫 AI Policy / AI 政策

- **We explicitly reject AI-generated PRs that have not been manually verified.**
- **本项目拒绝接受任何未经人工复核的 AI 生成的 PR。**
- Low-quality AI PRs will be closed immediately. / 低质量的 AI PR 会被直接关闭。
- You must understand and take responsibility for every line of code you submit. / 你必须理解并对你提交的每一行代码负责。
- **Workflow Proficiency / 协作能力**: Ensure you are familiar with GitHub/Git workflows and maintain a clean Git history. Please learn the basics first if needed to avoid messy PR history. / 请确保你熟悉 GitHub/Git 工作流并保持 Git 历史整洁。如有必要请先学习相关知识，避免 PR 历史过于混乱。

---

### Description / 描述

<!-- Explain the goal of this PR and what changes were made. -->
<!-- 请解释此 PR 的目标以及做了哪些更改。 -->
修复 Gemini 左侧历史对话列表无法滚动的问题，根因是“防止自动滚动”页面脚本的拦截范围过大。

之前开启 `gvPreventAutoScrollEnabled` 后，脚本会全局 patch 滚动相关 API，导致 Gemini 左侧历史列表里的滚动操作也可能被拦截。因此用滚轮滚动或拖动滚动条时，历史列表会被拉回顶部。

本 PR 将自动滚动拦截范围收窄到 Gemini 聊天正文/对话滚动容器，并明确排除侧边栏历史容器，例如 `bard-sidenav` 和 `[data-test-id="overflow-container"]`。

已验证：
- 提交消息后，聊天正文需要阻止自动下滚时仍会被正确拦截
- 提交消息后，左侧历史列表仍然可以正常滚动

### Related Issue / 相关 Issue

<!-- Link the issue this PR resolves (e.g., Closes #123). FOR NEW FEATURES: You MUST open an Issue for discussion first. PRs submitted without prior discussion will be closed. -->
<!-- 链接此 PR 解决的 issue（例如：Closes #123）。对于新功能：请务必先开启一个 Issue 进行讨论，未经讨论直接提交的 PR 会被关闭。 -->

### Visual Proof / 可视化证据

<!-- REQUIRED for UI changes: Please provide screenshots or screen recordings. -->
<!-- UI 修改必填：请提供截图或屏幕录制。 -->

### Browser Testing / 浏览器测试

- [X] **Chrome / Edge (Chromium)**: Tested / 已测试
- [X] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [X] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [X] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [X] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [X] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。
