### PR TITLE
fix(export): avoid hanging markdown image packaging

### DIFF
--- a/src/features/export/services/ConversationExportService.ts
+++ b/src/features/export/services/ConversationExportService.ts
@@ -29,6 +29,8 @@ export class ConversationExportService {
 
   private static readonly CHAT_JSON_FORMAT = 'gemini-voyager.chat.v1' as const;
 
+  private static readonly MARKDOWN_IMAGE_FETCH_TIMEOUT_MS = 15000;
+
   /**
    * Export conversation in specified format
    */
@@ -438,6 +440,11 @@ export class ConversationExportService {
       mapping.set(item.url, `assets/${fileName}`);
     }
 
+    if (mapping.size === 0) {
+      MarkdownFormatter.download(markdown, normalizedFilename);
+      return normalizedFilename;
+    }
+
     const packagedMarkdown = MarkdownFormatter.rewriteImageUrls(markdown, mapping);
     zip.file(markdownEntryName, packagedMarkdown);
 
@@ -544,6 +551,25 @@ export class ConversationExportService {
     }
   }
 
+  private static async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+  ): Promise<Response | null> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      this.MARKDOWN_IMAGE_FETCH_TIMEOUT_MS,
+    );
+
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
   private static async fetchImageForMarkdownPackaging(
     url: string,
   ): Promise<{ blob: Blob; contentType: string | null } | null> {
@@ -551,30 +577,28 @@ export class ConversationExportService {
       return this.decodeDataImageUrl(url);
     }
 
-    try {
-      const response = await fetch(url, { credentials: 'include', mode: 'cors' as RequestMode });
-      if (response.ok) {
-        return {
-          blob: await response.blob(),
-          contentType: response.headers.get('Content-Type'),
-        };
-      }
-    } catch {
-      /* ignore */
+    const directIncludeResponse = await this.fetchWithTimeout(url, {
+      credentials: 'include',
+      mode: 'cors' as RequestMode,
+    });
+    if (directIncludeResponse?.ok) {
+      return {
+        blob: await directIncludeResponse.blob(),
+        contentType: directIncludeResponse.headers.get('Content-Type'),
+      };
     }
 
     // Retry without credentials for servers with wildcard CORS
     // (Access-Control-Allow-Origin: * is incompatible with credentials: 'include')
-    try {
-      const response = await fetch(url, { credentials: 'omit', mode: 'cors' as RequestMode });
-      if (response.ok) {
-        return {
-          blob: await response.blob(),
-          contentType: response.headers.get('Content-Type'),
-        };
-      }
-    } catch {
-      /* ignore */
+    const directOmitResponse = await this.fetchWithTimeout(url, {
+      credentials: 'omit',
+      mode: 'cors' as RequestMode,
+    });
+    if (directOmitResponse?.ok) {
+      return {
+        blob: await directOmitResponse.blob(),
+        contentType: directOmitResponse.headers.get('Content-Type'),
+      };
     }
 
     type RuntimeFetchImageResponse =
@@ -612,12 +636,25 @@ export class ConversationExportService {
       const sendMessage = chrome.runtime?.sendMessage;
       if (typeof sendMessage !== 'function') return null;
       return await new Promise<RuntimeFetchImageResponse>((resolve) => {
+        let settled = false;
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        const finish = (response: RuntimeFetchImageResponse) => {
+          if (settled) return;
+          settled = true;
+          if (timeoutId) clearTimeout(timeoutId);
+          resolve(response);
+        };
+
+        timeoutId = setTimeout(() => {
+          finish(null);
+        }, this.MARKDOWN_IMAGE_FETCH_TIMEOUT_MS);
+
         try {
           (sendMessage as (...args: unknown[]) => void)({ type, url }, (rawResponse: unknown) => {
-            resolve((rawResponse as RuntimeFetchImageResponse) ?? null);
+            finish((rawResponse as RuntimeFetchImageResponse) ?? null);
           });
         } catch {
-          resolve(null);
+          finish(null);
         }
       });
     };

--- a/src/features/export/services/__tests__/ConversationExportService.test.ts
+++ b/src/features/export/services/__tests__/ConversationExportService.test.ts
@@ -530,6 +530,32 @@ describe('ConversationExportService', () => {
       expect(capturedAssetOptions).toMatchObject({ base64: true });
     });
 
+    it('downloads plain markdown when no image assets can be packaged', async () => {
+      const imageUrl = 'https://lh3.googleusercontent.com/gg/export-image=s0';
+      const markdown = `![uploaded image](${imageUrl})`;
+      vi.spyOn(MarkdownFormatter, 'extractImageUrls').mockReturnValue([imageUrl]);
+      const rewriteSpy = vi.spyOn(MarkdownFormatter, 'rewriteImageUrls');
+      const downloadSpy = vi.spyOn(MarkdownFormatter, 'download').mockImplementation(() => {});
+      const service = ConversationExportService as unknown as {
+        downloadMarkdownOrZip: (
+          markdown: string,
+          filename: string,
+          markdownEntryName: string,
+        ) => Promise<string>;
+        fetchImageForMarkdownPackaging: (url: string) => Promise<unknown>;
+      };
+      const fetchSpy = vi
+        .spyOn(service, 'fetchImageForMarkdownPackaging')
+        .mockResolvedValue(null);
+
+      const finalFilename = await service.downloadMarkdownOrZip(markdown, 'chat.md', 'chat.md');
+
+      expect(finalFilename).toBe('chat.md');
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(downloadSpy).toHaveBeenCalledWith(markdown, 'chat.md');
+      expect(rewriteSpy).not.toHaveBeenCalled();
+    });
+
     it('packages inline data images as zip assets instead of leaving base64 in markdown', async () => {
       const dataUrl = 'data:image/png;base64,aGVsbG8=';
 
@@ -608,6 +634,43 @@ describe('ConversationExportService', () => {
         { type: 'gv.fetchImageViaPage', url: imageUrl },
         expect.any(Function),
       );
+    });
+
+    it('resolves image fetch when runtime fetch callbacks do not answer', async () => {
+      vi.useFakeTimers();
+      const originalSendMessage = chrome.runtime.sendMessage;
+
+      try {
+        const imageUrl = 'https://lh3.googleusercontent.com/export-image.png';
+        vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network blocked'));
+
+        const sendMessageMock = vi.fn(
+          (_message: { type?: string; url?: string }, _callback?: (response: unknown) => void) => {
+            // Simulate an extension message channel that never answers.
+          },
+        );
+        chrome.runtime.sendMessage = sendMessageMock as unknown as typeof chrome.runtime.sendMessage;
+
+        const service = ConversationExportService as unknown as {
+          fetchImageForMarkdownPackaging: (url: string) => Promise<unknown>;
+        };
+        const fetchPromise = service.fetchImageForMarkdownPackaging(imageUrl);
+
+        await vi.runAllTimersAsync();
+
+        await expect(fetchPromise).resolves.toBeNull();
+        expect(sendMessageMock).toHaveBeenCalledWith(
+          { type: 'gv.fetchImage', url: imageUrl },
+          expect.any(Function),
+        );
+        expect(sendMessageMock).toHaveBeenCalledWith(
+          { type: 'gv.fetchImageViaPage', url: imageUrl },
+          expect.any(Function),
+        );
+      } finally {
+        chrome.runtime.sendMessage = originalSendMessage;
+        vi.useRealTimers();
+      }
     });
 
     it('should skip gv.fetchImageViaPage for blob urls', async () => {


### PR DESCRIPTION
## Summary
- Bound Markdown image fetch attempts and runtime message waits with a per-attempt timeout.
- Fall back to downloading the original `.md` when no image assets can be packaged.
- Add regression tests for empty image packaging and silent runtime image fetch callbacks.

## Root cause
Markdown export waits for image packaging work before clearing the export overlay. Gemini uploaded image previews can fail to be fetched from page context because of CORS, and an extension runtime fetch callback may also fail to answer. In those cases the export can remain stuck on `Export...Loading...` instead of downloading a Markdown file.

## Validation
- `bun run test src/features/export/services/__tests__/ConversationExportService.test.ts`
- `bun run typecheck`
- `bun run lint` (passes with existing warnings)
- `bun run test`
- `bun run build:chrome`

Fixes #795