### PR TITLE
fix(plugins): restore detached DOM state before pruning

### DIFF
--- a/src/features/plugins/runtime/declarativeEngine.test.ts
+++ b/src/features/plugins/runtime/declarativeEngine.test.ts
@@ -332,23 +332,41 @@ describe('DeclarativeEngine', () => {
     disconnect.mockRestore();
   });
 
-  it('prunes ledger entries for elements that left the document', () => {
-    document.body.innerHTML = '<div class="target"></div>';
-    const el = document.querySelector('.target')!;
+  it('restores a detached element before pruning and remains reversible after reattachment', () => {
+    document.body.innerHTML = '<div class="target" data-orig="yes" style="color: blue;"></div>';
     const engine = new DeclarativeEngine({ doc: document });
     engine.mount(
       makeManifest({
-        domOps: [{ op: 'addClass', target: cssRef('.target'), className: 'gv-plugin-on' }],
+        domOps: [
+          { op: 'addClass', target: cssRef('.target'), className: 'gv-plugin-added' },
+          { op: 'setAttribute', target: cssRef('.target'), name: 'data-orig', value: 'no' },
+          { op: 'setStyle', target: cssRef('.target'), styles: { color: 'red' } },
+        ],
       }),
     );
-    expect(el.classList.contains('gv-plugin-on')).toBe(true);
 
-    // SPA re-render replaced the node: the engine must forget it instead of
-    // pinning the detached subtree in its ledgers until unmount.
+    const el = document.querySelector<HTMLElement>('.target')!;
+    expect(el.classList.contains('gv-plugin-added')).toBe(true);
+    expect(el.getAttribute('data-orig')).toBe('no');
+    expect(el.style.color).toBe('red');
+
     el.remove();
     engine.reapplyNow();
 
+    expect(el.classList.contains('gv-plugin-added')).toBe(false);
+    expect(el.getAttribute('data-orig')).toBe('yes');
+    expect(el.style.color).toBe('blue');
+
+    document.body.appendChild(el);
+    engine.reapplyNow();
+
+    expect(el.classList.contains('gv-plugin-added')).toBe(true);
+    expect(el.getAttribute('data-orig')).toBe('no');
+    expect(el.style.color).toBe('red');
+
     engine.unmount('test.plugin');
-    expect(el.classList.contains('gv-plugin-on')).toBe(true);
+    expect(el.classList.contains('gv-plugin-added')).toBe(false);
+    expect(el.getAttribute('data-orig')).toBe('yes');
+    expect(el.style.color).toBe('blue');
   });
 });

--- a/src/features/plugins/runtime/declarativeEngine.ts
+++ b/src/features/plugins/runtime/declarativeEngine.ts
@@ -143,23 +143,36 @@ export class DeclarativeEngine {
   /** Re-apply all active plugins' dom ops immediately (exposed for tests + the
    *  rAF scheduler). Idempotent. */
   reapplyNow(): void {
-    this.pruneDetachedLedgerEntries();
+    this.restoreDetachedLedgerEntries();
     for (const entry of this.active.values()) this.applyDomOps(entry);
   }
 
-  /** Drop ledger entries whose element left the document. An SPA re-render
-   *  replaces nodes rather than reattaching them, so there is no original to
-   *  restore — and without pruning, the ledgers pin every replaced subtree in
-   *  memory for as long as the plugin stays mounted. */
-  private pruneDetachedLedgerEntries(): void {
-    for (const el of this.classOwners.keys()) {
-      if (!el.isConnected) this.classOwners.delete(el);
+  /** Restore detached elements before dropping their ledger entries. This
+   *  prevents the ledgers from pinning replaced SPA subtrees while preserving
+   *  reversibility if a framework later reattaches the same element. */
+  private restoreDetachedLedgerEntries(): void {
+    for (const [el, perEl] of this.classOwners) {
+      if (this.doc.contains(el)) continue;
+      for (const className of perEl.keys()) el.classList.remove(className);
+      this.classOwners.delete(el);
     }
-    for (const el of this.attrLayers.keys()) {
-      if (!el.isConnected) this.attrLayers.delete(el);
+
+    for (const [el, perEl] of this.attrLayers) {
+      if (this.doc.contains(el)) continue;
+      for (const [name, layer] of perEl) {
+        if (layer.original === null) el.removeAttribute(name);
+        else el.setAttribute(name, layer.original);
+      }
+      this.attrLayers.delete(el);
     }
-    for (const el of this.styleLayers.keys()) {
-      if (!el.isConnected) this.styleLayers.delete(el);
+
+    for (const [el, perEl] of this.styleLayers) {
+      if (this.doc.contains(el)) continue;
+      for (const [prop, layer] of perEl) {
+        if (!layer.original) el.style.removeProperty(prop);
+        else el.style.setProperty(prop, layer.original);
+      }
+      this.styleLayers.delete(el);
     }
   }
 


### PR DESCRIPTION
## Summary

- restore plugin-owned classes, attributes, and inline styles before pruning detached ledger entries
- preserve the current `main` branch's DOM observer optimization
- cover detach → prune → reattach → unmount reversibility with a regression test

## Validation

- `bun run test -- src/features/plugins/runtime/declarativeEngine.test.ts` — 16/16 passed
- `bun run test` — 243 files, 2101 tests passed
- `bun run typecheck` — passed
- focused ESLint — passed
- `bun run build:chrome` — passed