### PR TITLE
fix(export): unify Google image URL processing for original resolution

### DIFF
--- a/src/features/export/services/ConversationExportService.ts
+++ b/src/features/export/services/ConversationExportService.ts
@@ -16,6 +16,7 @@ import type {
 } from '../types/export';
 import { DOMContentExtractor } from './DOMContentExtractor';
 import { DeepResearchPDFPrintService } from './DeepResearchPDFPrintService';
+import { getOriginalSizeGoogleImageUrl } from './googleImageUrl';
 import { ImageExportService } from './ImageExportService';
 import { MarkdownFormatter } from './MarkdownFormatter';
 import { PDFPrintService } from './PDFPrintService';
@@ -416,7 +417,7 @@ export class ConversationExportService {
     const fetchedByOrder = await Promise.all(
       imageUrls.map(async (url) => {
         // For Google images, request original size (=s0) instead of the display thumbnail
-        const fetchUrl = this.toOriginalSizeUrl(url);
+        const fetchUrl = getOriginalSizeGoogleImageUrl(url);
         const fetched = await this.fetchImageForMarkdownPackaging(fetchUrl);
         if (!fetched) return null;
         return {
@@ -459,20 +460,6 @@ export class ConversationExportService {
     }, 0);
 
     return zipFilename;
-  }
-
-  /**
-   * Replace Google image URL size parameter with =s0 for original resolution.
-   * Non-Google URLs are returned unchanged.
-   */
-  private static toOriginalSizeUrl(url: string): string {
-    const isGoogle = url.includes('googleusercontent.com') || url.includes('ggpht.com');
-    if (!isGoogle) return url;
-    const GOOGLE_SIZE_PATTERN = /=[swh]\d+[^?#]*/;
-    if (GOOGLE_SIZE_PATTERN.test(url)) {
-      return url.replace(GOOGLE_SIZE_PATTERN, '=s0');
-    }
-    return url.includes('=') ? url + '-s0' : url + '=s0';
   }
 
   private static pickImageExtension(contentType: string | null, url: string): string {

--- a/src/features/export/services/ImageExportService.ts
+++ b/src/features/export/services/ImageExportService.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_IMAGE_EXPORT_WIDTH,
 } from '../types/export';
 import { DOMContentExtractor } from './DOMContentExtractor';
+import { getOriginalSizeGoogleImageUrl } from './googleImageUrl';
 import { renderElementToImageBlob } from './ImageRenderService';
 
 export interface RenderableDocumentContent {
@@ -477,14 +478,7 @@ export class ImageExportService {
     await Promise.all(
       imgs.map(async (img) => {
         let src = img.getAttribute('src') || '';
-        // For Google images, request original size (=s0) instead of thumbnail
-        if (
-          /^https?:\/\//i.test(src) &&
-          (src.includes('googleusercontent.com') || src.includes('ggpht.com'))
-        ) {
-          const sizePattern = /=[swh]\d+[^?#]*/;
-          src = sizePattern.test(src) ? src.replace(sizePattern, '=s0') : src + '=s0';
-        }
+        src = getOriginalSizeGoogleImageUrl(src);
         const data = await toDataUrl(src);
         if (data) {
           try {

--- a/src/features/export/services/PDFPrintService.ts
+++ b/src/features/export/services/PDFPrintService.ts
@@ -7,6 +7,7 @@ import { isSafari } from '@/core/utils/browser';
 
 import type { ChatTurn, ConversationMetadata } from '../types/export';
 import { DOMContentExtractor } from './DOMContentExtractor';
+import { getOriginalSizeGoogleImageUrl } from './googleImageUrl';
 
 export interface PrintableDocumentContent {
   title: string;
@@ -260,16 +261,8 @@ export class PDFPrintService {
     await Promise.all(
       imgs.map(async (img) => {
         let src = img.getAttribute('src') || '';
-        // Handle both http(s) and blob: URLs (watermark-removed images use blob: URLs)
         if (!/^(https?:\/\/|blob:)/i.test(src)) return;
-        // For Google images, request original size (=s0) instead of thumbnail
-        if (
-          (src.includes('googleusercontent.com') || src.includes('ggpht.com')) &&
-          !src.startsWith('blob:')
-        ) {
-          const sizePattern = /=[swh]\d+[^?#]*/;
-          src = sizePattern.test(src) ? src.replace(sizePattern, '=s0') : src + '=s0';
-        }
+        src = getOriginalSizeGoogleImageUrl(src);
         const data = await toDataUrl(src);
         if (data) {
           try {

--- a/src/features/export/services/googleImageUrl.ts
+++ b/src/features/export/services/googleImageUrl.ts
@@ -1,0 +1,40 @@
+const SIZE_PATTERN = /=[swh]\d+[^?#]*/;
+
+/**
+ * Replace Google image size parameters (=s220, =w512-h286, etc.) with =s0
+ * to request original resolution. Also converts /rd-gg/ to /rd-gg-dl/ for
+ * higher-quality downloads. Non-Google URLs are returned unchanged.
+ */
+export function getOriginalSizeGoogleImageUrl(url: string): string {
+  const isGoogleImage = url.includes('googleusercontent.com') || url.includes('ggpht.com');
+  if (!isGoogleImage) return url;
+
+  if (url.includes('/rd-gg/') && !url.includes('/rd-gg-dl/')) {
+    url = url.replace('/rd-gg/', '/rd-gg-dl/');
+  }
+
+  // Already at original size — don't modify (must check before SIZE_PATTERN
+  // so =s0-d-I doesn't get stripped of its -d-I suffix)
+  if (url.includes('=s0')) return url;
+
+  if (SIZE_PATTERN.test(url)) {
+    return url.replace(SIZE_PATTERN, '=s0');
+  }
+
+  if (url.includes('?')) {
+    try {
+      const parsed = new URL(url);
+      parsed.searchParams.set('s', '0');
+      return parsed.toString();
+    } catch {
+      /* fall through */
+    }
+  }
+
+  const basePath = url.split(/[?#]/)[0];
+  const suffix = url.slice(basePath.length);
+  if (basePath.includes('=')) {
+    return basePath + '-s0' + suffix;
+  }
+  return basePath + '=s0' + suffix;
+}


### PR DESCRIPTION
### Description

Extract duplicated =s0 Google image size parameter replacement logic from three export services (Markdown ZIP / Image / PDF) into a shared getOriginalSizeGoogleImageUrl() function that requests original resolution during export. Also adds /rd-gg/ to /rd-gg-dl/ path conversion for higher-quality downloads.

### Changes

- Add src/features/export/services/googleImageUrl.ts — shared utility for Google image URL processing
- Deduplicate inline =s0 logic in ConversationExportService, ImageExportService, PDFPrintService
- Remove redundant toOriginalSizeUrl private method

### Verification

- [x] bun run test — all 1417 tests pass
- [x] bun run typecheck — no errors
- [x] bun run lint — no new errors
- [x] bun run build:chrome — builds successfully