### PR TITLE
fix(export): export rendered Mermaid diagrams

### DIFF
--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -458,12 +458,11 @@ export class DOMContentExtractor {
       }
 
       // Code block (check for nested code-block first)
-      const codeBlock = child.querySelector('code-block');
-      if (
-        tagName === 'code-block' ||
-        child.classList.contains('code-block') ||
-        (tagName !== 'ul' && tagName !== 'ol' && codeBlock)
-      ) {
+      const codeBlock = Array.from(child.querySelectorAll('code-block')).find((candidate) => {
+        const containingList = candidate.closest('ul, ol');
+        return !containingList || !child.contains(containingList);
+      });
+      if (tagName === 'code-block' || child.classList.contains('code-block') || codeBlock) {
         if (this.DEBUG) console.log('[DOMContentExtractor] Found code block!');
         const elementToExtract = (codeBlock || child) as HTMLElement;
         const codeContent = this.extractCodeBlock(elementToExtract);
@@ -1055,11 +1054,26 @@ export class DOMContentExtractor {
         }
       });
 
+      // Keep regular block code in list items as fenced Markdown instead of
+      // letting inline processing flatten it to a single backtick span.
+      const codeTexts: string[] = [];
+      tempContainer.querySelectorAll('code-block, .code-block').forEach((codeBlock) => {
+        if (codeBlock.closest('.gv-mermaid-wrapper')) return;
+        if (codeBlock.parentElement?.closest('code-block, .code-block')) return;
+
+        const codeContent = this.extractCodeBlock(codeBlock as HTMLElement);
+        if (codeContent.text) {
+          hasCode = true;
+          codeTexts.push(codeContent.text);
+        }
+        codeBlock.remove();
+      });
+
       // Process inline content (handles formulas, emphasis, etc.)
       const processed = this.processInlineContent(tempContainer);
       if (processed.hasFormulas) hasFormulas = true;
       const plainItemText = processed.text || this.normalizeText(tempContainer.textContent || '');
-      const itemText = [plainItemText, ...mermaidTexts].filter(Boolean).join('\n');
+      const itemText = [plainItemText, ...codeTexts, ...mermaidTexts].filter(Boolean).join('\n');
 
       const prefix = isOrdered ? `${index + 1}. ` : '- ';
       textLines.push(indent + prefix + itemText);
@@ -1086,6 +1100,19 @@ export class DOMContentExtractor {
       replacement.innerHTML = mermaidContent.html;
       const renderedDiagram = replacement.firstElementChild;
       if (renderedDiagram) wrapper.replaceWith(renderedDiagram);
+    });
+
+    cleanList.querySelectorAll('code-block, .code-block').forEach((codeBlock) => {
+      if (codeBlock.closest('.gv-mermaid-wrapper')) return;
+      if (codeBlock.parentElement?.closest('code-block, .code-block')) return;
+
+      const codeContent = this.extractCodeBlock(codeBlock as HTMLElement);
+      if (!codeContent.html) return;
+
+      const replacement = document.createElement('div');
+      replacement.innerHTML = codeContent.html;
+      const pre = replacement.firstElementChild;
+      if (pre) codeBlock.replaceWith(pre);
     });
 
     return {

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -398,7 +398,10 @@ export class DOMContentExtractor {
 
       // A response-element can wrap the Mermaid component. Recurse until the wrapper
       // is reached instead of letting the nested code-block shortcut export raw code.
-      if (child.querySelector('.gv-mermaid-wrapper .gv-mermaid-diagram svg')) {
+      if (
+        tagName === 'response-element' &&
+        child.querySelector('.gv-mermaid-wrapper .gv-mermaid-diagram svg')
+      ) {
         this.processNodes(child, htmlParts, textParts, flags);
         continue;
       }
@@ -456,7 +459,11 @@ export class DOMContentExtractor {
 
       // Code block (check for nested code-block first)
       const codeBlock = child.querySelector('code-block');
-      if (tagName === 'code-block' || child.classList.contains('code-block') || codeBlock) {
+      if (
+        tagName === 'code-block' ||
+        child.classList.contains('code-block') ||
+        (tagName !== 'ul' && tagName !== 'ol' && codeBlock)
+      ) {
         if (this.DEBUG) console.log('[DOMContentExtractor] Found code block!');
         const elementToExtract = (codeBlock || child) as HTMLElement;
         const codeContent = this.extractCodeBlock(elementToExtract);

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -385,6 +385,24 @@ export class DOMContentExtractor {
         continue;
       }
 
+      // Export the rendered Mermaid SVG while retaining the source for Markdown output.
+      if (child.classList.contains('gv-mermaid-wrapper')) {
+        const mermaidContent = this.extractRenderedMermaid(child as HTMLElement);
+        if (mermaidContent) {
+          flags.hasCode = true;
+          htmlParts.push(mermaidContent.html);
+          textParts.push(`\n${mermaidContent.text}\n`);
+          continue;
+        }
+      }
+
+      // A response-element can wrap the Mermaid component. Recurse until the wrapper
+      // is reached instead of letting the nested code-block shortcut export raw code.
+      if (child.querySelector('.gv-mermaid-wrapper .gv-mermaid-diagram svg')) {
+        this.processNodes(child, htmlParts, textParts, flags);
+        continue;
+      }
+
       // Canvas Export Section (Injected Canvas document content)
       if (child.classList.contains('gv-canvas-export-section')) {
         const headingEl = child.querySelector('h3');
@@ -847,6 +865,28 @@ export class DOMContentExtractor {
   } {
     const processed = this.processInlineContent(element);
     return { html: processed.html, text: processed.text };
+  }
+
+  /**
+   * Extract an already-rendered Mermaid diagram for rich exports.
+   * The original fenced source remains the text representation used by Markdown.
+   */
+  private static extractRenderedMermaid(
+    wrapper: HTMLElement,
+  ): { html: string; text: string } | null {
+    const svg = wrapper.querySelector('.gv-mermaid-diagram svg');
+    const codeBlock = wrapper.querySelector('code-block, .code-block') as HTMLElement | null;
+
+    if (!svg || !codeBlock) return null;
+
+    const codeContent = this.extractCodeBlock(codeBlock);
+    if (!codeContent.text) return null;
+
+    const clonedSvg = svg.cloneNode(true) as SVGElement;
+    return {
+      html: `<div class="gv-export-mermaid">${clonedSvg.outerHTML}</div>`,
+      text: codeContent.text,
+    };
   }
 
   /**

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -613,6 +613,7 @@ export class DOMContentExtractor {
       if (tagName === 'ul' || tagName === 'ol') {
         const listContent = this.extractList(child as HTMLElement);
         if (listContent.hasFormulas) flags.hasFormulas = true;
+        if (listContent.hasCode) flags.hasCode = true;
         htmlParts.push(listContent.html);
         textParts.push(`\n${listContent.text}\n`);
         continue;
@@ -1018,13 +1019,14 @@ export class DOMContentExtractor {
   private static extractList(
     element: HTMLElement,
     depth: number = 0,
-  ): { html: string; text: string; hasFormulas: boolean } {
+  ): { html: string; text: string; hasFormulas: boolean; hasCode: boolean } {
     const isOrdered = element.tagName === 'OL';
     const items = Array.from(element.querySelectorAll(':scope > li'));
     const indent = '  '.repeat(depth); // 2 spaces per level
 
     const textLines: string[] = [];
     let hasFormulas = false;
+    let hasCode = false;
     items.forEach((item, index) => {
       // Create a temporary container with only direct children (excluding nested lists)
       const tempContainer = document.createElement('div');
@@ -1042,10 +1044,22 @@ export class DOMContentExtractor {
         }
       });
 
+      // Mermaid needs separate rich HTML and fenced Markdown representations.
+      const mermaidTexts: string[] = [];
+      tempContainer.querySelectorAll('.gv-mermaid-wrapper').forEach((wrapper) => {
+        const mermaidContent = this.extractRenderedMermaid(wrapper as HTMLElement);
+        if (mermaidContent) {
+          hasCode = true;
+          mermaidTexts.push(mermaidContent.text);
+          wrapper.remove();
+        }
+      });
+
       // Process inline content (handles formulas, emphasis, etc.)
       const processed = this.processInlineContent(tempContainer);
       if (processed.hasFormulas) hasFormulas = true;
-      const itemText = processed.text || this.normalizeText(tempContainer.textContent || '');
+      const plainItemText = processed.text || this.normalizeText(tempContainer.textContent || '');
+      const itemText = [plainItemText, ...mermaidTexts].filter(Boolean).join('\n');
 
       const prefix = isOrdered ? `${index + 1}. ` : '- ';
       textLines.push(indent + prefix + itemText);
@@ -1055,6 +1069,7 @@ export class DOMContentExtractor {
       nestedLists.forEach((nestedList) => {
         const nestedResult = this.extractList(nestedList as HTMLElement, depth + 1);
         if (nestedResult.hasFormulas) hasFormulas = true;
+        if (nestedResult.hasCode) hasCode = true;
         if (nestedResult.text) {
           textLines.push(nestedResult.text);
         }
@@ -1063,9 +1078,19 @@ export class DOMContentExtractor {
 
     const cleanList = element.cloneNode(true) as HTMLElement;
     this.stripExportArtifacts(cleanList);
+    cleanList.querySelectorAll('.gv-mermaid-wrapper').forEach((wrapper) => {
+      const mermaidContent = this.extractRenderedMermaid(wrapper as HTMLElement);
+      if (!mermaidContent) return;
+
+      const replacement = document.createElement('div');
+      replacement.innerHTML = mermaidContent.html;
+      const renderedDiagram = replacement.firstElementChild;
+      if (renderedDiagram) wrapper.replaceWith(renderedDiagram);
+    });
 
     return {
       hasFormulas,
+      hasCode,
       html: cleanList.outerHTML,
       text: textLines.join('\n'),
     };

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -1080,7 +1080,9 @@ export class DOMContentExtractor {
       if (blockTexts.length === 0) {
         textLines.push(indent + prefix + plainItemText);
       } else {
-        const firstLine = plainItemText ? indent + prefix + plainItemText : indent + prefix.trimEnd();
+        const firstLine = plainItemText
+          ? indent + prefix + plainItemText
+          : indent + prefix.trimEnd();
         textLines.push(firstLine);
         for (const block of blockTexts) {
           const indentedBlock = block

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -1073,10 +1073,23 @@ export class DOMContentExtractor {
       const processed = this.processInlineContent(tempContainer);
       if (processed.hasFormulas) hasFormulas = true;
       const plainItemText = processed.text || this.normalizeText(tempContainer.textContent || '');
-      const itemText = [plainItemText, ...codeTexts, ...mermaidTexts].filter(Boolean).join('\n');
-
+      const blockTexts = [...codeTexts, ...mermaidTexts].filter(Boolean);
       const prefix = isOrdered ? `${index + 1}. ` : '- ';
-      textLines.push(indent + prefix + itemText);
+      // Indent fenced/code continuation lines so Markdown keeps them inside the list item.
+      const continuationIndent = indent + ' '.repeat(prefix.length);
+      if (blockTexts.length === 0) {
+        textLines.push(indent + prefix + plainItemText);
+      } else {
+        const firstLine = plainItemText ? indent + prefix + plainItemText : indent + prefix.trimEnd();
+        textLines.push(firstLine);
+        for (const block of blockTexts) {
+          const indentedBlock = block
+            .split('\n')
+            .map((line) => (line.length ? continuationIndent + line : continuationIndent.trimEnd()))
+            .join('\n');
+          textLines.push(indentedBlock);
+        }
+      }
 
       // Process nested lists
       const nestedLists = item.querySelectorAll(':scope > ul, :scope > ol');

--- a/src/features/export/services/PDFPrintService.ts
+++ b/src/features/export/services/PDFPrintService.ts
@@ -933,6 +933,21 @@ export class PDFPrintService {
           word-wrap: break-word;
         }
 
+        /* Rendered Mermaid diagrams */
+        .gv-print-turn-text .gv-export-mermaid {
+          max-width: 100%;
+          margin: 1em 0;
+          break-inside: avoid;
+          page-break-inside: avoid;
+        }
+
+        .gv-print-turn-text .gv-export-mermaid svg {
+          display: block;
+          max-width: 100%;
+          height: auto;
+          margin: 0 auto;
+        }
+
         /* Math formulas */
         .gv-print-turn-text .math-inline,
         .gv-print-turn-text .math-block,

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -428,5 +428,40 @@ describe('DOMContentExtractor', () => {
       expect(extracted.html).not.toContain('<button');
       expect(extracted.text).toContain('```mermaid\ngraph TD;\nA-->B;\n```');
     });
+
+    it('preserves list structure when a list item contains rendered Mermaid', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <response-element>
+              <ul>
+                <li>
+                  Diagram
+                  <div class="gv-mermaid-wrapper">
+                    <code-block style="display: none">
+                      <div class="code-block-decoration">mermaid</div>
+                      <code role="text">graph TD;\nA--&gt;B;</code>
+                    </code-block>
+                    <div class="gv-mermaid-toggle"><button>Code</button></div>
+                    <div class="gv-mermaid-diagram">
+                      <svg id="list-diagram" viewBox="0 0 100 50"></svg>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </response-element>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.html).toContain('<ul>');
+      expect(extracted.html).toContain('<li>');
+      expect(extracted.html).toContain('id="list-diagram"');
+      expect(extracted.html).not.toContain('<button');
+      expect(extracted.text).toMatch(/-\s+Diagram/);
+    });
   });
 });

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -457,11 +457,15 @@ describe('DOMContentExtractor', () => {
 
       const extracted = DOMContentExtractor.extractAssistantContent(assistant);
 
+      expect(extracted.hasCode).toBe(true);
       expect(extracted.html).toContain('<ul>');
       expect(extracted.html).toContain('<li>');
+      expect(extracted.html).toContain('<div class="gv-export-mermaid"><svg');
       expect(extracted.html).toContain('id="list-diagram"');
       expect(extracted.html).not.toContain('<button');
+      expect(extracted.html).not.toContain('<code-block');
       expect(extracted.text).toMatch(/-\s+Diagram/);
+      expect(extracted.text).toContain('```mermaid\ngraph TD;\nA-->B;\n```');
     });
   });
 });

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -465,7 +465,8 @@ describe('DOMContentExtractor', () => {
       expect(extracted.html).not.toContain('<button');
       expect(extracted.html).not.toContain('<code-block');
       expect(extracted.text).toMatch(/-\s+Diagram/);
-      expect(extracted.text).toContain('```mermaid\ngraph TD;\nA-->B;\n```');
+      // Fenced block lines after the list marker must be indented as list continuations.
+      expect(extracted.text).toMatch(/-\s+Diagram\n\s+```mermaid\n\s+graph TD;\n\s+A-->B;\n\s+```/);
     });
 
     it('preserves regular code blocks inside list items', () => {
@@ -498,7 +499,7 @@ describe('DOMContentExtractor', () => {
       );
       expect(extracted.html).not.toContain('<code-block');
       expect(extracted.text).toMatch(/-\s+Example/);
-      expect(extracted.text).toContain('```js\nconst answer = 42;\n```');
+      expect(extracted.text).toMatch(/-\s+Example\n\s+```js\n\s+const answer = 42;\n\s+```/);
     });
   });
 });

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -467,5 +467,38 @@ describe('DOMContentExtractor', () => {
       expect(extracted.text).toMatch(/-\s+Diagram/);
       expect(extracted.text).toContain('```mermaid\ngraph TD;\nA-->B;\n```');
     });
+
+    it('preserves regular code blocks inside list items', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <response-element>
+              <ul>
+                <li>
+                  Example
+                  <code-block>
+                    <div class="code-block-decoration">js</div>
+                    <code role="text">const answer = 42;</code>
+                  </code-block>
+                </li>
+              </ul>
+            </response-element>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.hasCode).toBe(true);
+      expect(extracted.html).toContain('<ul>');
+      expect(extracted.html).toContain('<li>');
+      expect(extracted.html).toContain(
+        '<pre><code class="language-js">const answer = 42;</code></pre>',
+      );
+      expect(extracted.html).not.toContain('<code-block');
+      expect(extracted.text).toMatch(/-\s+Example/);
+      expect(extracted.text).toContain('```js\nconst answer = 42;\n```');
+    });
   });
 });

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -362,4 +362,71 @@ describe('DOMContentExtractor', () => {
       );
     });
   });
+
+  describe('Mermaid export', () => {
+    it('exports the rendered SVG as HTML and keeps fenced source as text', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <response-element>
+              <div class="gv-mermaid-wrapper">
+                <code-block style="display: none">
+                  <div class="code-block-decoration">mermaid</div>
+                  <code role="text">graph TD;\nA--&gt;B;</code>
+                </code-block>
+                <div class="gv-mermaid-toggle">
+                  <button>Diagram</button>
+                  <button>Code</button>
+                </div>
+                <div class="gv-mermaid-diagram">
+                  <svg id="diagram" viewBox="0 0 100 50">
+                    <path d="M0 0 L100 50"></path>
+                  </svg>
+                </div>
+              </div>
+            </response-element>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.hasCode).toBe(true);
+      expect(extracted.html).toContain('<div class="gv-export-mermaid"><svg');
+      expect(extracted.html).toContain('id="diagram"');
+      expect(extracted.html).not.toContain('gv-mermaid-toggle');
+      expect(extracted.html).not.toContain('<button');
+      expect(extracted.html).not.toContain('<pre>');
+      expect(extracted.text).toContain('```mermaid\ngraph TD;\nA-->B;\n```');
+    });
+
+    it('falls back to fenced source when no rendered SVG is available', () => {
+      const assistant = document.createElement('div');
+      assistant.innerHTML = `
+        <message-content>
+          <div class="markdown">
+            <response-element>
+              <div class="gv-mermaid-wrapper">
+                <code-block>
+                  <div class="code-block-decoration">mermaid</div>
+                  <code role="text">graph TD;\nA--&gt;B;</code>
+                </code-block>
+                <div class="gv-mermaid-toggle"><button>Code</button></div>
+                <div class="gv-mermaid-diagram"></div>
+              </div>
+            </response-element>
+          </div>
+        </message-content>
+      `;
+
+      const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+      expect(extracted.hasCode).toBe(true);
+      expect(extracted.html).toContain('<pre><code class="language-mermaid">');
+      expect(extracted.html).not.toContain('gv-export-mermaid');
+      expect(extracted.html).not.toContain('<button');
+      expect(extracted.text).toContain('```mermaid\ngraph TD;\nA-->B;\n```');
+    });
+  });
 });

--- a/src/features/export/services/__tests__/PDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/PDFPrintService.test.ts
@@ -333,4 +333,48 @@ describe('PDFPrintService', () => {
     }).not.toThrow();
     expect(title).toBe('Escaped Selector Title');
   });
+
+  it('prints rendered Mermaid SVGs without controls and constrains page layout', async () => {
+    window.print = vi.fn();
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <response-element>
+            <div class="gv-mermaid-wrapper">
+              <code-block style="display: none">
+                <div class="code-block-decoration">mermaid</div>
+                <code role="text">graph TD;\nA--&gt;B;</code>
+              </code-block>
+              <div class="gv-mermaid-toggle"><button>Code</button></div>
+              <div class="gv-mermaid-diagram">
+                <svg id="pdf-mermaid" viewBox="0 0 100 50"></svg>
+              </div>
+            </div>
+          </response-element>
+        </div>
+      </message-content>
+    `;
+
+    await PDFPrintService.export(
+      [{ user: 'u', assistant: '', assistantElement: assistant, starred: false }],
+      {
+        url: 'https://gemini.google.com/app/x',
+        exportedAt: new Date().toISOString(),
+        count: 1,
+        title: 'Mermaid Export',
+      },
+    );
+
+    const container = document.getElementById('gv-pdf-print-container');
+    const styles = document.getElementById('gv-pdf-print-styles')?.textContent || '';
+
+    expect(container?.querySelector('.gv-export-mermaid svg#pdf-mermaid')).toBeTruthy();
+    expect(container?.querySelector('.gv-mermaid-toggle')).toBeNull();
+    expect(container?.querySelector('button')).toBeNull();
+    expect(styles).toContain('.gv-print-turn-text .gv-export-mermaid svg');
+    expect(styles).toContain('max-width: 100%');
+    expect(styles).toContain('height: auto');
+    expect(styles).toContain('break-inside: avoid');
+  });
 });


### PR DESCRIPTION
### AI-Assisted PR Policy / AI 辅助 PR 政策

I used an agent for implementation, then reviewed the scope, diff, tests, and export behavior. The change is limited to Mermaid handling in HTML/PDF export.

---

### Description / 描述

Mermaid blocks are currently rendered as diagrams in Voyager, but HTML/PDF export falls back to the hidden source code block. This change:

- exports the rendered Mermaid SVG for HTML/PDF output;
- keeps the fenced Mermaid source in Markdown/text output;
- removes Mermaid view controls from exported content;
- falls back to the fenced source when no rendered SVG is available;
- constrains exported SVGs to the printable page without splitting them across pages.

### Related Issue / 相关 Issue

Closes #840

### Visual Proof / 可视化证据

The screenshot below shows the built Chrome extension loaded on Gemini with a representative rendered Mermaid response used for the export check:

![Voyager Mermaid export runtime check](https://raw.githubusercontent.com/Solaris-star/voyager/pr-assets/voyager-840/voyager-840-runtime-source.png)

Manual Chromium check:

1. Built and loaded `dist_chrome` as an unpacked extension in Playwright Chromium 143.
2. Injected a representative Gemini Mermaid response DOM because anonymous Gemini did not return a generated response in this environment.
3. Used Voyager's actual PDF export UI, selected both messages, and exported.
4. Confirmed that the print container was created and the PDF path invoked `window.print()`.

The focused integration tests additionally verify that the exported print container contains the rendered SVG, omits Mermaid controls, and applies page-safe SVG styles.

### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [ ] **Firefox**: Tested (Mandatory) / 已测试（必填） — Firefox runtime was unavailable; `bun run build:firefox` passes.
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持 — Not tested.

### Checklist / 检查清单

- [x] If I used an agent, I discussed the requirement, affected scope, and verification plan clearly. / 如果使用了 Agent，我已讨论清楚需求、影响范围和验证方式。
- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] For UI/behavior changes, I have tried the real workflow for about 15 minutes when possible. / 对于 UI/行为改动，条件允许时我已用真实流程体验约 15 分钟。
- [x] For UI/behavior changes, I have included visual proof after verification. / 对于 UI/行为改动，我已在验证后提供可视化证据。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] This PR focuses on one issue or one coherent change. / 此 PR 只聚焦一个问题或一个清晰完整的改动。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [ ] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`）。

### Testing notes

Passed:

- `bun run format`
- `bun run lint` (0 errors; existing warnings remain)
- `bun run typecheck`
- `bun run build:chrome`
- `bun run build:firefox`
- Focused Vitest run for `DOMContentExtractor.test.ts` and `PDFPrintService.test.ts` (31 tests passed)
- `git diff --check`

The full `bun run test` currently has two failures outside the touched export files:

- `scripts/__tests__/verify-release-privacy.test.ts` fails on the Windows path separator used for `embedded.provisionprofile`.
- `src/pages/content/folder/__tests__/observerBatching.test.ts` failed intermittently in the full run, but its 19 tests pass when rerun independently.
