### PR TITLE
fix(export): render Mermaid diagrams in exports

### DIFF
--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -400,6 +400,7 @@ rendering.
 
 Regression test:
 `src/features/export/services/__tests__/DOMContentExtractor.test.ts`
+`src/features/export/services/__tests__/PDFPrintService.test.ts`
 `src/features/export/services/__tests__/ImageRenderService.test.ts`
 `src/features/export/services/__tests__/PDFPrintService.test.ts`
 `bun run verify:katex-export`
@@ -769,11 +770,18 @@ When a `.gv-mermaid-wrapper` contains a rendered diagram SVG, emit a clean
 `.gv-export-mermaid` clone for rich exports while preserving the original fenced
 source in text output. Recurse through Mermaid response wrappers and preserve
 list structure with indented fenced source. Fall back to the source block when
-no SVG is available.
+no SVG is available. Before opening the regular PDF print dialog or rendering a
+whole-document PNG, rasterize only the Mermaid clone at 2x resolution: browser
+renderers can otherwise preserve the SVG shapes while dropping or clipping
+labels inside `foreignObject`. Keep the rest of the PDF as native text, and cap
+the diagram to one printable page with proportional scaling. If rasterization
+fails, replace the original SVG with a sanitized SVG data image directly; never
+leave the raw SVG in the print DOM.
 
 Regression test:
 `src/features/export/services/__tests__/DOMContentExtractor.test.ts`
 `src/features/export/services/__tests__/PDFPrintService.test.ts`
+`src/features/export/services/__tests__/ImageRenderService.test.ts`
 `src/features/export/services/__tests__/ImageExportService.test.ts`
 
 Commit:

--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -751,3 +751,30 @@ Regression tests:
 (`testDriveFolderIdentityMigratesOnlyAnUnambiguousLegacyName`). A live Drive
 check must also preserve the original folder ID, parent location, and JSON
 contents while changing only the legacy display name.
+
+## Mermaid exports must prefer the rendered diagram over hidden source
+
+Symptom:
+PDF and image exports showed Mermaid source code even when Voyager displayed a
+rendered diagram in the conversation.
+
+Root cause:
+The Mermaid wrapper contains both the hidden `code-block` and the rendered SVG.
+The DOM extractor's generic nested-code-block branch matched the wrapper first,
+emitted `<pre><code>`, and skipped the diagram. The same shortcut could match a
+parent `response-element` or list before traversal reached the wrapper.
+
+Fix:
+When a `.gv-mermaid-wrapper` contains a rendered diagram SVG, emit a clean
+`.gv-export-mermaid` clone for rich exports while preserving the original fenced
+source in text output. Recurse through Mermaid response wrappers and preserve
+list structure with indented fenced source. Fall back to the source block when
+no SVG is available.
+
+Regression test:
+`src/features/export/services/__tests__/DOMContentExtractor.test.ts`
+`src/features/export/services/__tests__/PDFPrintService.test.ts`
+`src/features/export/services/__tests__/ImageExportService.test.ts`
+
+Commit:
+`fix(export): render Mermaid diagrams in exports`

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -43,6 +43,11 @@ function queryOutsideThoughts<T extends Element = Element>(
   }
   return null;
 }
+
+const MERMAID_WRAPPER_SELECTOR = '.gv-mermaid-wrapper';
+const MERMAID_RENDERED_SVG_SELECTOR = '.gv-mermaid-diagram svg';
+const MERMAID_EXPORT_CLASS = 'gv-export-mermaid';
+
 export class DOMContentExtractor {
   private static DEBUG = false;
   /**
@@ -436,8 +441,35 @@ export class DOMContentExtractor {
         }
       }
 
+      // Mermaid keeps the hidden source code and rendered diagram in the same wrapper.
+      // Export the rendered SVG for rich formats while preserving source for text formats.
+      const mermaidContent = child.matches(MERMAID_WRAPPER_SELECTOR)
+        ? this.extractMermaidContent(child as HTMLElement)
+        : null;
+      if (mermaidContent) {
+        htmlParts.push(mermaidContent.html);
+        if (mermaidContent.text) {
+          flags.hasCode = true;
+          textParts.push(`\n${mermaidContent.text}\n`);
+        }
+        continue;
+      }
+
+      // Gemini may wrap the Mermaid component in a response-element. Recurse to the
+      // wrapper before the generic descendant code-block shortcut can consume it.
+      if (
+        tagName === 'response-element' &&
+        child.querySelector(`${MERMAID_WRAPPER_SELECTOR} ${MERMAID_RENDERED_SVG_SELECTOR}`)
+      ) {
+        this.processNodes(child, htmlParts, textParts, flags);
+        continue;
+      }
+
       // Code block (check for nested code-block first)
-      const codeBlock = child.querySelector('code-block');
+      const codeBlock = Array.from(child.querySelectorAll('code-block')).find((candidate) => {
+        const containingList = candidate.closest('ul, ol');
+        return !containingList || !child.contains(containingList);
+      });
       if (tagName === 'code-block' || child.classList.contains('code-block') || codeBlock) {
         if (this.DEBUG) console.log('[DOMContentExtractor] Found code block!');
         const elementToExtract = (codeBlock || child) as HTMLElement;
@@ -588,6 +620,7 @@ export class DOMContentExtractor {
       if (tagName === 'ul' || tagName === 'ol') {
         const listContent = this.extractList(child as HTMLElement);
         if (listContent.hasFormulas) flags.hasFormulas = true;
+        if (listContent.hasCode) flags.hasCode = true;
         htmlParts.push(listContent.html);
         textParts.push(`\n${listContent.text}\n`);
         continue;
@@ -850,6 +883,27 @@ export class DOMContentExtractor {
   }
 
   /**
+   * Extract Mermaid content for rich and text exports.
+   * Rendered SVG is preferred, with source HTML as a safe fallback.
+   */
+  private static extractMermaidContent(
+    wrapper: HTMLElement,
+  ): { html: string; text: string } | null {
+    const svg = wrapper.querySelector<SVGSVGElement>(MERMAID_RENDERED_SVG_SELECTOR);
+    const codeBlock = wrapper.querySelector<HTMLElement>('code-block, .code-block');
+    const codeContent = codeBlock ? this.extractCodeBlock(codeBlock) : { html: '', text: '' };
+
+    if (svg) {
+      const exportContainer = document.createElement('div');
+      exportContainer.className = MERMAID_EXPORT_CLASS;
+      exportContainer.appendChild(svg.cloneNode(true));
+      return { html: exportContainer.outerHTML, text: codeContent.text };
+    }
+
+    return codeContent.text ? codeContent : null;
+  }
+
+  /**
    * Extract code block content
    */
   private static extractCodeBlock(element: HTMLElement): { html: string; text: string } {
@@ -971,13 +1025,14 @@ export class DOMContentExtractor {
   private static extractList(
     element: HTMLElement,
     depth: number = 0,
-  ): { html: string; text: string; hasFormulas: boolean } {
+  ): { html: string; text: string; hasFormulas: boolean; hasCode: boolean } {
     const isOrdered = element.tagName === 'OL';
     const items = Array.from(element.querySelectorAll(':scope > li'));
     const indent = '  '.repeat(depth); // 2 spaces per level
 
     const textLines: string[] = [];
     let hasFormulas = false;
+    let hasCode = false;
     items.forEach((item, index) => {
       // Create a temporary container with only direct children (excluding nested lists)
       const tempContainer = document.createElement('div');
@@ -995,19 +1050,51 @@ export class DOMContentExtractor {
         }
       });
 
+      const blockTexts: string[] = [];
+      tempContainer
+        .querySelectorAll<HTMLElement>(`${MERMAID_WRAPPER_SELECTOR}, code-block, .code-block`)
+        .forEach((block) => {
+          const isMermaid = block.matches(MERMAID_WRAPPER_SELECTOR);
+          if (!isMermaid && block.closest(MERMAID_WRAPPER_SELECTOR)) return;
+          if (!isMermaid && block.parentElement?.closest('code-block, .code-block')) return;
+
+          const content = isMermaid
+            ? this.extractMermaidContent(block)
+            : this.extractCodeBlock(block);
+          if (content?.text) {
+            hasCode = true;
+            blockTexts.push(content.text);
+          }
+          block.remove();
+        });
+
       // Process inline content (handles formulas, emphasis, etc.)
       const processed = this.processInlineContent(tempContainer);
       if (processed.hasFormulas) hasFormulas = true;
       const itemText = processed.text || this.normalizeText(tempContainer.textContent || '');
 
       const prefix = isOrdered ? `${index + 1}. ` : '- ';
-      textLines.push(indent + prefix + itemText);
+      if (blockTexts.length === 0) {
+        textLines.push(indent + prefix + itemText);
+      } else {
+        textLines.push(itemText ? indent + prefix + itemText : indent + prefix.trimEnd());
+        const continuationIndent = indent + ' '.repeat(prefix.length);
+        blockTexts.forEach((blockText) => {
+          textLines.push(
+            blockText
+              .split('\n')
+              .map((line) => continuationIndent + line)
+              .join('\n'),
+          );
+        });
+      }
 
       // Process nested lists
       const nestedLists = item.querySelectorAll(':scope > ul, :scope > ol');
       nestedLists.forEach((nestedList) => {
         const nestedResult = this.extractList(nestedList as HTMLElement, depth + 1);
         if (nestedResult.hasFormulas) hasFormulas = true;
+        if (nestedResult.hasCode) hasCode = true;
         if (nestedResult.text) {
           textLines.push(nestedResult.text);
         }
@@ -1016,9 +1103,31 @@ export class DOMContentExtractor {
 
     const cleanList = element.cloneNode(true) as HTMLElement;
     this.stripExportArtifacts(cleanList);
+    cleanList.querySelectorAll<HTMLElement>(MERMAID_WRAPPER_SELECTOR).forEach((wrapper) => {
+      const content = this.extractMermaidContent(wrapper);
+      if (!content) return;
+
+      const replacement = document.createElement('div');
+      replacement.innerHTML = content.html;
+      if (replacement.firstElementChild) {
+        wrapper.replaceWith(replacement.firstElementChild);
+      }
+    });
+    cleanList.querySelectorAll<HTMLElement>('code-block, .code-block').forEach((codeBlock) => {
+      if (codeBlock.closest(MERMAID_WRAPPER_SELECTOR)) return;
+      if (codeBlock.parentElement?.closest('code-block, .code-block')) return;
+
+      const content = this.extractCodeBlock(codeBlock);
+      const replacement = document.createElement('div');
+      replacement.innerHTML = content.html;
+      if (replacement.firstElementChild) {
+        codeBlock.replaceWith(replacement.firstElementChild);
+      }
+    });
 
     return {
       hasFormulas,
+      hasCode,
       html: cleanList.outerHTML,
       text: textLines.join('\n'),
     };

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -1034,71 +1034,80 @@ export class DOMContentExtractor {
     let hasFormulas = false;
     let hasCode = false;
     items.forEach((item, index) => {
-      // Create a temporary container with only direct children (excluding nested lists)
-      const tempContainer = document.createElement('div');
-      const childNodes = Array.from(item.childNodes);
-
-      childNodes.forEach((node) => {
-        if (node.nodeType === Node.TEXT_NODE) {
-          tempContainer.appendChild(node.cloneNode(true));
-        } else if (node.nodeType === Node.ELEMENT_NODE) {
-          const el = node as Element;
-          // Skip nested lists, we'll process them separately
-          if (el.tagName !== 'UL' && el.tagName !== 'OL') {
-            tempContainer.appendChild(el.cloneNode(true));
-          }
-        }
-      });
-
-      const blockTexts: string[] = [];
-      tempContainer
-        .querySelectorAll<HTMLElement>(`${MERMAID_WRAPPER_SELECTOR}, code-block, .code-block`)
-        .forEach((block) => {
-          const isMermaid = block.matches(MERMAID_WRAPPER_SELECTOR);
-          if (!isMermaid && block.closest(MERMAID_WRAPPER_SELECTOR)) return;
-          if (!isMermaid && block.parentElement?.closest('code-block, .code-block')) return;
-
-          const content = isMermaid
-            ? this.extractMermaidContent(block)
-            : this.extractCodeBlock(block);
-          if (content?.text) {
-            hasCode = true;
-            blockTexts.push(content.text);
-          }
-          block.remove();
-        });
-
-      // Process inline content (handles formulas, emphasis, etc.)
-      const processed = this.processInlineContent(tempContainer);
-      if (processed.hasFormulas) hasFormulas = true;
-      const itemText = processed.text || this.normalizeText(tempContainer.textContent || '');
-
       const prefix = isOrdered ? `${index + 1}. ` : '- ';
-      if (blockTexts.length === 0) {
-        textLines.push(indent + prefix + itemText);
-      } else {
-        textLines.push(itemText ? indent + prefix + itemText : indent + prefix.trimEnd());
-        const continuationIndent = indent + ' '.repeat(prefix.length);
-        blockTexts.forEach((blockText) => {
-          textLines.push(
-            blockText
-              .split('\n')
-              .map((line) => continuationIndent + line)
-              .join('\n'),
-          );
-        });
-      }
+      const continuationIndent = indent + ' '.repeat(prefix.length);
+      let hasItemContent = false;
+      let proseNodes: Node[] = [];
 
-      // Process nested lists
-      const nestedLists = item.querySelectorAll(':scope > ul, :scope > ol');
-      nestedLists.forEach((nestedList) => {
-        const nestedResult = this.extractList(nestedList as HTMLElement, depth + 1);
-        if (nestedResult.hasFormulas) hasFormulas = true;
-        if (nestedResult.hasCode) hasCode = true;
-        if (nestedResult.text) {
-          textLines.push(nestedResult.text);
+      const ensureItemMarker = (): void => {
+        if (!hasItemContent) {
+          textLines.push(indent + prefix.trimEnd());
+          hasItemContent = true;
         }
+      };
+
+      const flushProse = (): void => {
+        if (proseNodes.length === 0) return;
+
+        const proseContainer = document.createElement('div');
+        proseNodes.forEach((node) => proseContainer.appendChild(node.cloneNode(true)));
+        proseNodes = [];
+
+        const processed = this.processInlineContent(proseContainer);
+        if (processed.hasFormulas) hasFormulas = true;
+        const prose = this.normalizeText(processed.text || proseContainer.textContent || '');
+        if (!prose) return;
+
+        textLines.push((hasItemContent ? continuationIndent : indent + prefix) + prose);
+        hasItemContent = true;
+      };
+
+      Array.from(item.childNodes).forEach((node) => {
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+          proseNodes.push(node);
+          return;
+        }
+
+        const child = node as HTMLElement;
+        if (child.tagName === 'UL' || child.tagName === 'OL') {
+          flushProse();
+          const nestedResult = this.extractList(child, depth + 1);
+          if (nestedResult.hasFormulas) hasFormulas = true;
+          if (nestedResult.hasCode) hasCode = true;
+          if (nestedResult.text) {
+            ensureItemMarker();
+            textLines.push(nestedResult.text);
+          }
+          return;
+        }
+
+        const isMermaid = child.matches(MERMAID_WRAPPER_SELECTOR);
+        const isCodeBlock = child.matches('code-block, .code-block');
+        if (!isMermaid && !isCodeBlock) {
+          proseNodes.push(node);
+          return;
+        }
+
+        flushProse();
+        const content = isMermaid
+          ? this.extractMermaidContent(child)
+          : this.extractCodeBlock(child);
+        if (!content?.text) return;
+
+        ensureItemMarker();
+        hasCode = true;
+        textLines.push(
+          content.text
+            .split('\n')
+            .map((line) => continuationIndent + line)
+            .join('\n'),
+        );
       });
+
+      flushProse();
+      if (!hasItemContent) {
+        textLines.push(indent + prefix);
+      }
     });
 
     const cleanList = element.cloneNode(true) as HTMLElement;

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -459,10 +459,12 @@ export class DOMContentExtractor {
         continue;
       }
 
-      // Gemini may wrap the Mermaid component in a response-element. Recurse to the
-      // wrapper before the generic descendant code-block shortcut can consume it.
+      // Recurse through non-list containers with a rendered Mermaid wrapper before the
+      // generic descendant code-block shortcut can consume its hidden source. Lists keep
+      // their dedicated extraction path to preserve item structure and Markdown indentation.
       if (
-        tagName === 'response-element' &&
+        tagName !== 'ul' &&
+        tagName !== 'ol' &&
         child.querySelector(`${MERMAID_WRAPPER_SELECTOR} ${MERMAID_RENDERED_SVG_SELECTOR}`)
       ) {
         this.processNodes(child, htmlParts, textParts, flags);

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -52,6 +52,10 @@ const MERMAID_THEME_ATTRIBUTE = 'data-gv-mermaid-theme';
 const isMermaidTheme = (value: string | null): value is 'dark' | 'light' =>
   value === 'dark' || value === 'light';
 
+type ExportCodeBlock =
+  | { kind: 'mermaid'; element: HTMLElement }
+  | { kind: 'code'; element: HTMLElement };
+
 export class DOMContentExtractor {
   private static DEBUG = false;
   /**
@@ -445,47 +449,27 @@ export class DOMContentExtractor {
         }
       }
 
-      // Mermaid keeps the hidden source code and rendered diagram in the same wrapper.
-      // Export the rendered SVG for rich formats while preserving source for text formats.
-      const mermaidContent = child.matches(MERMAID_WRAPPER_SELECTOR)
-        ? this.extractMermaidContent(child as HTMLElement)
-        : null;
-      if (mermaidContent) {
-        htmlParts.push(mermaidContent.html);
-        if (mermaidContent.text) {
+      const exportCodeBlocks = this.findExportCodeBlocks(child);
+      const directExportCodeBlock = exportCodeBlocks.find(({ element }) => element === child);
+      if (directExportCodeBlock) {
+        const content =
+          directExportCodeBlock.kind === 'mermaid'
+            ? this.extractMermaidContent(directExportCodeBlock.element)
+            : this.extractCodeBlock(directExportCodeBlock.element);
+        if (content) {
+          htmlParts.push(content.html);
+        }
+        if (content?.text) {
           flags.hasCode = true;
-          textParts.push(`\n${mermaidContent.text}\n`);
+          textParts.push(`\n${content.text}\n`);
         }
         continue;
       }
 
-      // Recurse through non-list containers with a rendered Mermaid wrapper before the
-      // generic descendant code-block shortcut can consume its hidden source. Lists keep
-      // their dedicated extraction path to preserve item structure and Markdown indentation.
-      if (
-        tagName !== 'ul' &&
-        tagName !== 'ol' &&
-        child.querySelector(`${MERMAID_WRAPPER_SELECTOR} ${MERMAID_RENDERED_SVG_SELECTOR}`)
-      ) {
+      // Traverse containers that own export blocks instead of consuming only their first
+      // descendant. This keeps prose, code, and Mermaid output in DOM order.
+      if (tagName !== 'ul' && tagName !== 'ol' && exportCodeBlocks.length > 0) {
         this.processNodes(child, htmlParts, textParts, flags);
-        continue;
-      }
-
-      // Code block (check for nested code-block first)
-      const codeBlock = Array.from(child.querySelectorAll('code-block')).find((candidate) => {
-        const containingList = candidate.closest('ul, ol');
-        return !containingList || !child.contains(containingList);
-      });
-      if (tagName === 'code-block' || child.classList.contains('code-block') || codeBlock) {
-        if (this.DEBUG) console.log('[DOMContentExtractor] Found code block!');
-        const elementToExtract = (codeBlock || child) as HTMLElement;
-        const codeContent = this.extractCodeBlock(elementToExtract);
-        if (this.DEBUG) console.log('[DOMContentExtractor] Code content:', codeContent.text);
-        if (codeContent.text) {
-          flags.hasCode = true;
-          htmlParts.push(codeContent.html);
-          textParts.push(`\n${codeContent.text}\n`);
-        }
         continue;
       }
 
@@ -897,7 +881,9 @@ export class DOMContentExtractor {
   ): { html: string; text: string } | null {
     const svg = wrapper.querySelector<SVGSVGElement>(MERMAID_RENDERED_SVG_SELECTOR);
     const codeBlock = wrapper.querySelector<HTMLElement>('code-block, .code-block');
-    const codeContent = codeBlock ? this.extractCodeBlock(codeBlock) : { html: '', text: '' };
+    const codeContent = codeBlock
+      ? this.extractCodeBlock(codeBlock, 'mermaid')
+      : { html: '', text: '' };
 
     if (svg) {
       const exportContainer = document.createElement('div');
@@ -914,15 +900,39 @@ export class DOMContentExtractor {
   }
 
   /**
+   * Find top-level Mermaid and ordinary code blocks in DOM order.
+   * Hidden source blocks inside Mermaid wrappers and nested code-block shells are excluded.
+   */
+  private static findExportCodeBlocks(container: Element): ExportCodeBlock[] {
+    const selector = `${MERMAID_WRAPPER_SELECTOR}, code-block, .code-block`;
+    const elements = [
+      ...(container.matches(selector) ? [container as HTMLElement] : []),
+      ...Array.from(container.querySelectorAll<HTMLElement>(selector)),
+    ];
+
+    return elements.flatMap((element): ExportCodeBlock[] => {
+      if (element.matches(MERMAID_WRAPPER_SELECTOR)) {
+        return [{ kind: 'mermaid', element }];
+      }
+      if (element.closest(MERMAID_WRAPPER_SELECTOR)) return [];
+      if (element.parentElement?.closest('code-block, .code-block')) return [];
+      return [{ kind: 'code', element }];
+    });
+  }
+
+  /**
    * Extract code block content
    */
-  private static extractCodeBlock(element: HTMLElement): { html: string; text: string } {
+  private static extractCodeBlock(
+    element: HTMLElement,
+    languageOverride?: string,
+  ): { html: string; text: string } {
     const codeElement = element.querySelector('code[role="text"], code');
     const code = codeElement?.textContent || '';
 
     // Try to detect language from class or label
-    let language = '';
-    const langLabel = element.querySelector('.code-block-decoration');
+    let language = languageOverride ?? '';
+    const langLabel = languageOverride ? null : element.querySelector('.code-block-decoration');
     if (langLabel) {
       language = this.normalizeText(langLabel.textContent || '').toLowerCase();
     }
@@ -1072,57 +1082,58 @@ export class DOMContentExtractor {
         hasItemContent = true;
       };
 
-      Array.from(item.childNodes).forEach((node) => {
-        if (node.nodeType !== Node.ELEMENT_NODE) {
-          proseNodes.push(node);
-          return;
-        }
-
-        const child = node as HTMLElement;
-        if (child.tagName === 'UL' || child.tagName === 'OL') {
-          flushProse();
-          const nestedResult = this.extractList(child, depth + 1);
-          if (nestedResult.hasFormulas) hasFormulas = true;
-          if (nestedResult.hasCode) hasCode = true;
-          if (nestedResult.text) {
-            ensureItemMarker();
-            textLines.push(nestedResult.text);
+      const processItemNodes = (nodes: Node[]): void => {
+        nodes.forEach((node) => {
+          if (node.nodeType !== Node.ELEMENT_NODE) {
+            proseNodes.push(node);
+            return;
           }
-          return;
-        }
 
-        const directMermaid = child.matches(MERMAID_WRAPPER_SELECTOR) ? child : null;
-        const wrappedMermaid =
-          child.tagName === 'RESPONSE-ELEMENT'
-            ? child.querySelector<HTMLElement>(MERMAID_WRAPPER_SELECTOR)
-            : null;
-        const mermaidBlock = directMermaid || wrappedMermaid;
-        const directCodeBlock = child.matches('code-block, .code-block') ? child : null;
-        const wrappedCodeBlock =
-          child.tagName === 'RESPONSE-ELEMENT' && !mermaidBlock
-            ? child.querySelector<HTMLElement>('code-block, .code-block')
-            : null;
-        const codeBlock = directCodeBlock || wrappedCodeBlock;
-        if (!mermaidBlock && !codeBlock) {
+          const child = node as HTMLElement;
+          if (child.tagName === 'UL' || child.tagName === 'OL') {
+            flushProse();
+            const nestedResult = this.extractList(child, depth + 1);
+            if (nestedResult.hasFormulas) hasFormulas = true;
+            if (nestedResult.hasCode) hasCode = true;
+            if (nestedResult.text) {
+              ensureItemMarker();
+              textLines.push(nestedResult.text);
+            }
+            return;
+          }
+
+          const exportCodeBlocks = this.findExportCodeBlocks(child);
+          const directExportCodeBlock = exportCodeBlocks.find(({ element }) => element === child);
+          if (directExportCodeBlock) {
+            flushProse();
+            const content =
+              directExportCodeBlock.kind === 'mermaid'
+                ? this.extractMermaidContent(directExportCodeBlock.element)
+                : this.extractCodeBlock(directExportCodeBlock.element);
+            if (!content?.text) return;
+
+            ensureItemMarker();
+            hasCode = true;
+            textLines.push(
+              content.text
+                .split('\n')
+                .map((line) => continuationIndent + line)
+                .join('\n'),
+            );
+            return;
+          }
+
+          if (exportCodeBlocks.length > 0 || child.querySelector('ul, ol')) {
+            flushProse();
+            processItemNodes(Array.from(child.childNodes));
+            return;
+          }
+
           proseNodes.push(node);
-          return;
-        }
+        });
+      };
 
-        flushProse();
-        const content = mermaidBlock
-          ? this.extractMermaidContent(mermaidBlock)
-          : this.extractCodeBlock(codeBlock!);
-        if (!content?.text) return;
-
-        ensureItemMarker();
-        hasCode = true;
-        textLines.push(
-          content.text
-            .split('\n')
-            .map((line) => continuationIndent + line)
-            .join('\n'),
-        );
-      });
+      processItemNodes(Array.from(item.childNodes));
 
       flushProse();
       if (!hasItemContent) {

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -46,11 +46,9 @@ function queryOutsideThoughts<T extends Element = Element>(
 
 const MERMAID_WRAPPER_SELECTOR = '.gv-mermaid-wrapper';
 const MERMAID_RENDERED_SVG_SELECTOR = '.gv-mermaid-diagram svg';
+const MERMAID_LIGHT_EXPORT_TEMPLATE_SELECTOR = 'template.gv-mermaid-light-export';
 const MERMAID_EXPORT_CLASS = 'gv-export-mermaid';
 const MERMAID_THEME_ATTRIBUTE = 'data-gv-mermaid-theme';
-
-const isMermaidTheme = (value: string | null): value is 'dark' | 'light' =>
-  value === 'dark' || value === 'light';
 
 type ExportCodeBlock =
   | { kind: 'mermaid'; element: HTMLElement }
@@ -879,19 +877,22 @@ export class DOMContentExtractor {
   private static extractMermaidContent(
     wrapper: HTMLElement,
   ): { html: string; text: string } | null {
-    const svg = wrapper.querySelector<SVGSVGElement>(MERMAID_RENDERED_SVG_SELECTOR);
+    const renderedSvg = wrapper.querySelector<SVGSVGElement>(MERMAID_RENDERED_SVG_SELECTOR);
+    const lightExportSvg = wrapper
+      .querySelector<HTMLTemplateElement>(MERMAID_LIGHT_EXPORT_TEMPLATE_SELECTOR)
+      ?.content.querySelector<SVGSVGElement>('svg');
     const codeBlock = wrapper.querySelector<HTMLElement>('code-block, .code-block');
     const codeContent = codeBlock
       ? this.extractCodeBlock(codeBlock, 'mermaid')
       : { html: '', text: '' };
+    const renderedTheme = wrapper.getAttribute(MERMAID_THEME_ATTRIBUTE);
+    const svg =
+      renderedTheme === 'light' ? renderedSvg : renderedTheme === 'dark' ? lightExportSvg : null;
 
     if (svg) {
       const exportContainer = document.createElement('div');
       exportContainer.className = MERMAID_EXPORT_CLASS;
-      const theme = wrapper.getAttribute(MERMAID_THEME_ATTRIBUTE);
-      if (isMermaidTheme(theme)) {
-        exportContainer.setAttribute(MERMAID_THEME_ATTRIBUTE, theme);
-      }
+      exportContainer.setAttribute(MERMAID_THEME_ATTRIBUTE, 'light');
       exportContainer.appendChild(svg.cloneNode(true));
       return { html: exportContainer.outerHTML, text: codeContent.text };
     }

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -47,6 +47,10 @@ function queryOutsideThoughts<T extends Element = Element>(
 const MERMAID_WRAPPER_SELECTOR = '.gv-mermaid-wrapper';
 const MERMAID_RENDERED_SVG_SELECTOR = '.gv-mermaid-diagram svg';
 const MERMAID_EXPORT_CLASS = 'gv-export-mermaid';
+const MERMAID_THEME_ATTRIBUTE = 'data-gv-mermaid-theme';
+
+const isMermaidTheme = (value: string | null): value is 'dark' | 'light' =>
+  value === 'dark' || value === 'light';
 
 export class DOMContentExtractor {
   private static DEBUG = false;
@@ -896,6 +900,10 @@ export class DOMContentExtractor {
     if (svg) {
       const exportContainer = document.createElement('div');
       exportContainer.className = MERMAID_EXPORT_CLASS;
+      const theme = wrapper.getAttribute(MERMAID_THEME_ATTRIBUTE);
+      if (isMermaidTheme(theme)) {
+        exportContainer.setAttribute(MERMAID_THEME_ATTRIBUTE, theme);
+      }
       exportContainer.appendChild(svg.cloneNode(true));
       return { html: exportContainer.outerHTML, text: codeContent.text };
     }

--- a/src/features/export/services/DOMContentExtractor.ts
+++ b/src/features/export/services/DOMContentExtractor.ts
@@ -1081,17 +1081,27 @@ export class DOMContentExtractor {
           return;
         }
 
-        const isMermaid = child.matches(MERMAID_WRAPPER_SELECTOR);
-        const isCodeBlock = child.matches('code-block, .code-block');
-        if (!isMermaid && !isCodeBlock) {
+        const directMermaid = child.matches(MERMAID_WRAPPER_SELECTOR) ? child : null;
+        const wrappedMermaid =
+          child.tagName === 'RESPONSE-ELEMENT'
+            ? child.querySelector<HTMLElement>(MERMAID_WRAPPER_SELECTOR)
+            : null;
+        const mermaidBlock = directMermaid || wrappedMermaid;
+        const directCodeBlock = child.matches('code-block, .code-block') ? child : null;
+        const wrappedCodeBlock =
+          child.tagName === 'RESPONSE-ELEMENT' && !mermaidBlock
+            ? child.querySelector<HTMLElement>('code-block, .code-block')
+            : null;
+        const codeBlock = directCodeBlock || wrappedCodeBlock;
+        if (!mermaidBlock && !codeBlock) {
           proseNodes.push(node);
           return;
         }
 
         flushProse();
-        const content = isMermaid
-          ? this.extractMermaidContent(child)
-          : this.extractCodeBlock(child);
+        const content = mermaidBlock
+          ? this.extractMermaidContent(mermaidBlock)
+          : this.extractCodeBlock(codeBlock!);
         if (!content?.text) return;
 
         ensureItemMarker();

--- a/src/features/export/services/DeepResearchPDFPrintService.ts
+++ b/src/features/export/services/DeepResearchPDFPrintService.ts
@@ -500,6 +500,14 @@ export class DeepResearchPDFPrintService {
           page-break-inside: avoid;
         }
 
+        body.${this.PRINT_BODY_CLASS} .gv-dr-print-report .gv-export-mermaid[data-gv-mermaid-theme="dark"] {
+          background: #1f2020;
+          padding: 16px;
+          border-radius: 8px;
+          print-color-adjust: exact;
+          -webkit-print-color-adjust: exact;
+        }
+
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-report pre,
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-report code {
           font-family: 'Courier New', monospace;

--- a/src/features/export/services/DeepResearchPDFPrintService.ts
+++ b/src/features/export/services/DeepResearchPDFPrintService.ts
@@ -3,6 +3,7 @@ import { isSafari } from '@/core/utils/browser';
 import type { PrintableDocumentContent } from './PDFPrintService';
 import { buildKatexExportStyles } from './katexExportStyles';
 import { buildMermaidExportStyles } from './mermaidExportStyles';
+import { isolateMermaidSvgImages } from './mermaidSvgImage';
 
 /**
  * Dedicated PDF print path for Deep Research reports.
@@ -13,8 +14,6 @@ export class DeepResearchPDFPrintService {
   private static PRINT_CONTAINER_ID = 'gv-deep-research-pdf-print-container';
   private static PRINT_BODY_CLASS = 'gv-deep-research-pdf-printing';
   private static PRINT_SAFARI_BODY_CLASS = 'gv-deep-research-pdf-safari-printing';
-  private static MERMAID_EXPORT_SELECTOR = '.gv-export-mermaid';
-  private static MERMAID_EXPORT_IMAGE_CLASS = 'gv-export-mermaid-image';
   private static CLEANUP_FALLBACK_DELAY_MS = 60_000;
   private static INLINE_FETCH_TIMEOUT_MS = 2_000;
   private static INLINE_DECODE_TIMEOUT_MS = 1_000;
@@ -193,7 +192,7 @@ export class DeepResearchPDFPrintService {
 
     const container = document.createElement('div');
     container.innerHTML = trimmed;
-    this.isolateMermaidSvgImages(container);
+    isolateMermaidSvgImages(container);
     container.querySelectorAll('script, style, template').forEach((element) => element.remove());
 
     const elements = Array.from(container.querySelectorAll<HTMLElement>('*'));
@@ -207,43 +206,6 @@ export class DeepResearchPDFPrintService {
     });
 
     return container.innerHTML.trim();
-  }
-
-  /**
-   * Mermaid SVGs depend on embedded styles. Keep those styles inside a data image so the
-   * generic printable HTML sanitizer can continue to remove arbitrary document styles.
-   */
-  private static isolateMermaidSvgImages(container: HTMLElement): void {
-    const svgSelector = `${this.MERMAID_EXPORT_SELECTOR} svg`;
-    const svgs = Array.from(container.querySelectorAll<SVGSVGElement>(svgSelector));
-
-    svgs.forEach((svg) => {
-      try {
-        const cleanSvg = svg.cloneNode(true) as SVGSVGElement;
-        cleanSvg.querySelectorAll('script, template').forEach((element) => element.remove());
-
-        const svgElements: Element[] = [cleanSvg, ...Array.from(cleanSvg.querySelectorAll('*'))];
-        svgElements.forEach((element) => {
-          Array.from(element.attributes).forEach((attribute) => {
-            if (attribute.name.toLowerCase().startsWith('on')) {
-              element.removeAttribute(attribute.name);
-            }
-          });
-        });
-
-        const serializedSvg = new XMLSerializer().serializeToString(cleanSvg);
-        const image = document.createElement('img');
-        image.className = this.MERMAID_EXPORT_IMAGE_CLASS;
-        image.alt = svg.getAttribute('aria-label') || 'Mermaid diagram';
-        const width = svg.getAttribute('width') || svg.style.width;
-        if (width) image.style.width = width;
-        if (svg.style.maxWidth) image.style.maxWidth = svg.style.maxWidth;
-        image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serializedSvg)}`;
-        svg.replaceWith(image);
-      } catch {
-        // Leave the SVG for the existing sanitizer fallback if serialization is unavailable.
-      }
-    });
   }
 
   private static extractPlainTextFromHtml(html: string): string {
@@ -492,6 +454,7 @@ export class DeepResearchPDFPrintService {
           diagramMargin: '0.75em auto',
           avoidDiagramBreak: true,
           preservePrintBackground: true,
+          diagramMaxHeight: '160mm',
         })}
 
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-report pre,

--- a/src/features/export/services/DeepResearchPDFPrintService.ts
+++ b/src/features/export/services/DeepResearchPDFPrintService.ts
@@ -234,6 +234,9 @@ export class DeepResearchPDFPrintService {
         const image = document.createElement('img');
         image.className = this.MERMAID_EXPORT_IMAGE_CLASS;
         image.alt = svg.getAttribute('aria-label') || 'Mermaid diagram';
+        const width = svg.getAttribute('width') || svg.style.width;
+        if (width) image.style.width = width;
+        if (svg.style.maxWidth) image.style.maxWidth = svg.style.maxWidth;
         image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serializedSvg)}`;
         svg.replaceWith(image);
       } catch {

--- a/src/features/export/services/DeepResearchPDFPrintService.ts
+++ b/src/features/export/services/DeepResearchPDFPrintService.ts
@@ -2,6 +2,7 @@ import { isSafari } from '@/core/utils/browser';
 
 import type { PrintableDocumentContent } from './PDFPrintService';
 import { buildKatexExportStyles } from './katexExportStyles';
+import { buildMermaidExportStyles } from './mermaidExportStyles';
 
 /**
  * Dedicated PDF print path for Deep Research reports.
@@ -484,29 +485,14 @@ export class DeepResearchPDFPrintService {
           page-break-inside: avoid;
         }
 
-        body.${this.PRINT_BODY_CLASS} .gv-dr-print-report .gv-export-mermaid {
-          max-width: 100%;
-          text-align: center;
-          break-inside: avoid;
-          page-break-inside: avoid;
-        }
-
-        body.${this.PRINT_BODY_CLASS} .gv-dr-print-report .gv-export-mermaid > img {
-          max-width: 100%;
-          height: auto;
-          display: block;
-          margin: 0.75em auto;
-          break-inside: avoid;
-          page-break-inside: avoid;
-        }
-
-        body.${this.PRINT_BODY_CLASS} .gv-dr-print-report .gv-export-mermaid[data-gv-mermaid-theme="dark"] {
-          background: #1f2020;
-          padding: 16px;
-          border-radius: 8px;
-          print-color-adjust: exact;
-          -webkit-print-color-adjust: exact;
-        }
+        ${buildMermaidExportStyles(`body.${this.PRINT_BODY_CLASS} .gv-dr-print-report`, {
+          containerMaxWidth: true,
+          avoidContainerBreak: true,
+          diagramSelector: '> img',
+          diagramMargin: '0.75em auto',
+          avoidDiagramBreak: true,
+          preservePrintBackground: true,
+        })}
 
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-report pre,
         body.${this.PRINT_BODY_CLASS} .gv-dr-print-report code {

--- a/src/features/export/services/DeepResearchPDFPrintService.ts
+++ b/src/features/export/services/DeepResearchPDFPrintService.ts
@@ -12,6 +12,8 @@ export class DeepResearchPDFPrintService {
   private static PRINT_CONTAINER_ID = 'gv-deep-research-pdf-print-container';
   private static PRINT_BODY_CLASS = 'gv-deep-research-pdf-printing';
   private static PRINT_SAFARI_BODY_CLASS = 'gv-deep-research-pdf-safari-printing';
+  private static MERMAID_EXPORT_SELECTOR = '.gv-export-mermaid';
+  private static MERMAID_EXPORT_IMAGE_CLASS = 'gv-export-mermaid-image';
   private static CLEANUP_FALLBACK_DELAY_MS = 60_000;
   private static INLINE_FETCH_TIMEOUT_MS = 2_000;
   private static INLINE_DECODE_TIMEOUT_MS = 1_000;
@@ -190,6 +192,7 @@ export class DeepResearchPDFPrintService {
 
     const container = document.createElement('div');
     container.innerHTML = trimmed;
+    this.isolateMermaidSvgImages(container);
     container.querySelectorAll('script, style, template').forEach((element) => element.remove());
 
     const elements = Array.from(container.querySelectorAll<HTMLElement>('*'));
@@ -203,6 +206,40 @@ export class DeepResearchPDFPrintService {
     });
 
     return container.innerHTML.trim();
+  }
+
+  /**
+   * Mermaid SVGs depend on embedded styles. Keep those styles inside a data image so the
+   * generic printable HTML sanitizer can continue to remove arbitrary document styles.
+   */
+  private static isolateMermaidSvgImages(container: HTMLElement): void {
+    const svgSelector = `${this.MERMAID_EXPORT_SELECTOR} svg`;
+    const svgs = Array.from(container.querySelectorAll<SVGSVGElement>(svgSelector));
+
+    svgs.forEach((svg) => {
+      try {
+        const cleanSvg = svg.cloneNode(true) as SVGSVGElement;
+        cleanSvg.querySelectorAll('script, template').forEach((element) => element.remove());
+
+        const svgElements: Element[] = [cleanSvg, ...Array.from(cleanSvg.querySelectorAll('*'))];
+        svgElements.forEach((element) => {
+          Array.from(element.attributes).forEach((attribute) => {
+            if (attribute.name.toLowerCase().startsWith('on')) {
+              element.removeAttribute(attribute.name);
+            }
+          });
+        });
+
+        const serializedSvg = new XMLSerializer().serializeToString(cleanSvg);
+        const image = document.createElement('img');
+        image.className = this.MERMAID_EXPORT_IMAGE_CLASS;
+        image.alt = svg.getAttribute('aria-label') || 'Mermaid diagram';
+        image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serializedSvg)}`;
+        svg.replaceWith(image);
+      } catch {
+        // Leave the SVG for the existing sanitizer fallback if serialization is unavailable.
+      }
+    });
   }
 
   private static extractPlainTextFromHtml(html: string): string {
@@ -441,6 +478,22 @@ export class DeepResearchPDFPrintService {
           height: auto;
           display: block;
           margin: 0.75em 0;
+          page-break-inside: avoid;
+        }
+
+        body.${this.PRINT_BODY_CLASS} .gv-dr-print-report .gv-export-mermaid {
+          max-width: 100%;
+          text-align: center;
+          break-inside: avoid;
+          page-break-inside: avoid;
+        }
+
+        body.${this.PRINT_BODY_CLASS} .gv-dr-print-report .gv-export-mermaid > img {
+          max-width: 100%;
+          height: auto;
+          display: block;
+          margin: 0.75em auto;
+          break-inside: avoid;
           page-break-inside: avoid;
         }
 

--- a/src/features/export/services/ImageExportService.ts
+++ b/src/features/export/services/ImageExportService.ts
@@ -262,6 +262,12 @@ export class ImageExportService {
         margin: 0 auto;
       }
 
+      .gv-image-export-content .gv-export-mermaid[data-gv-mermaid-theme="dark"] {
+        background: #1f2020;
+        padding: 16px;
+        border-radius: 8px;
+      }
+
       .gv-image-export-content .gv-export-attachment {
         display: flex;
         align-items: center;
@@ -414,6 +420,12 @@ export class ImageExportService {
         max-width: 100%;
         height: auto;
         margin: 0 auto;
+      }
+
+      .gv-image-export-report-content .gv-export-mermaid[data-gv-mermaid-theme="dark"] {
+        background: #1f2020;
+        padding: 16px;
+        border-radius: 8px;
       }
 
       .gv-image-export-report-content pre {

--- a/src/features/export/services/ImageExportService.ts
+++ b/src/features/export/services/ImageExportService.ts
@@ -17,6 +17,7 @@ import { DOMContentExtractor } from './DOMContentExtractor';
 import { renderElementToImageBlob } from './ImageRenderService';
 import { buildKatexExportStyles } from './katexExportStyles';
 import { buildMermaidExportStyles } from './mermaidExportStyles';
+import { rasterizeMermaidSvgImages } from './mermaidSvgImage';
 
 export interface RenderableDocumentContent {
   title: string;
@@ -257,6 +258,7 @@ export class ImageExportService {
 
       ${buildMermaidExportStyles('.gv-image-export-content', {
         containerMargin: '20px auto',
+        diagramSelector: '> img',
       })}
 
       .gv-image-export-content .gv-export-attachment {
@@ -407,6 +409,7 @@ export class ImageExportService {
 
       ${buildMermaidExportStyles('.gv-image-export-report-content', {
         containerMargin: '1em auto',
+        diagramSelector: '> img',
       })}
 
       .gv-image-export-report-content pre {
@@ -555,6 +558,7 @@ export class ImageExportService {
     document.body.appendChild(container);
 
     try {
+      await rasterizeMermaidSvgImages(container);
       await this.inlineImages(container);
       return await this.renderWithSafariFallback(container);
     } finally {

--- a/src/features/export/services/ImageExportService.ts
+++ b/src/features/export/services/ImageExportService.ts
@@ -214,6 +214,10 @@ export class ImageExportService {
         gap: 8px;
       }
 
+      .gv-image-export-doc a {
+        color: #2563eb !important;
+      }
+
       .gv-image-export-turn {
         margin: 24px 0;
         padding: 20px 0;
@@ -378,6 +382,10 @@ export class ImageExportService {
         font-size: 0.9em;
         display: grid;
         gap: 0.4em;
+      }
+
+      .gv-image-export-doc a {
+        color: #2563eb !important;
       }
 
       .gv-image-export-report-content {

--- a/src/features/export/services/ImageExportService.ts
+++ b/src/features/export/services/ImageExportService.ts
@@ -16,6 +16,7 @@ import {
 import { DOMContentExtractor } from './DOMContentExtractor';
 import { renderElementToImageBlob } from './ImageRenderService';
 import { buildKatexExportStyles } from './katexExportStyles';
+import { buildMermaidExportStyles } from './mermaidExportStyles';
 
 export interface RenderableDocumentContent {
   title: string;
@@ -250,23 +251,9 @@ export class ImageExportService {
         margin: 12px 0;
       }
 
-      .gv-image-export-content .gv-export-mermaid {
-        margin: 20px auto;
-        text-align: center;
-      }
-
-      .gv-image-export-content .gv-export-mermaid svg {
-        display: block;
-        max-width: 100%;
-        height: auto;
-        margin: 0 auto;
-      }
-
-      .gv-image-export-content .gv-export-mermaid[data-gv-mermaid-theme="dark"] {
-        background: #1f2020;
-        padding: 16px;
-        border-radius: 8px;
-      }
+      ${buildMermaidExportStyles('.gv-image-export-content', {
+        containerMargin: '20px auto',
+      })}
 
       .gv-image-export-content .gv-export-attachment {
         display: flex;
@@ -410,23 +397,9 @@ export class ImageExportService {
         margin: 0.6em 0;
       }
 
-      .gv-image-export-report-content .gv-export-mermaid {
-        margin: 1em auto;
-        text-align: center;
-      }
-
-      .gv-image-export-report-content .gv-export-mermaid svg {
-        display: block;
-        max-width: 100%;
-        height: auto;
-        margin: 0 auto;
-      }
-
-      .gv-image-export-report-content .gv-export-mermaid[data-gv-mermaid-theme="dark"] {
-        background: #1f2020;
-        padding: 16px;
-        border-radius: 8px;
-      }
+      ${buildMermaidExportStyles('.gv-image-export-report-content', {
+        containerMargin: '1em auto',
+      })}
 
       .gv-image-export-report-content pre {
         background: rgba(0,0,0,0.05);

--- a/src/features/export/services/ImageExportService.ts
+++ b/src/features/export/services/ImageExportService.ts
@@ -250,6 +250,18 @@ export class ImageExportService {
         margin: 12px 0;
       }
 
+      .gv-image-export-content .gv-export-mermaid {
+        margin: 20px auto;
+        text-align: center;
+      }
+
+      .gv-image-export-content .gv-export-mermaid svg {
+        display: block;
+        max-width: 100%;
+        height: auto;
+        margin: 0 auto;
+      }
+
       .gv-image-export-content .gv-export-attachment {
         display: flex;
         align-items: center;
@@ -390,6 +402,18 @@ export class ImageExportService {
         height: auto;
         display: block;
         margin: 0.6em 0;
+      }
+
+      .gv-image-export-report-content .gv-export-mermaid {
+        margin: 1em auto;
+        text-align: center;
+      }
+
+      .gv-image-export-report-content .gv-export-mermaid svg {
+        display: block;
+        max-width: 100%;
+        height: auto;
+        margin: 0 auto;
       }
 
       .gv-image-export-report-content pre {

--- a/src/features/export/services/ImageRenderService.ts
+++ b/src/features/export/services/ImageRenderService.ts
@@ -321,6 +321,7 @@ async function buildKatexFontEmbedCss(target: HTMLElement): Promise<string> {
 }
 
 export type RenderElementToImageBlobOptions = {
+  pixelRatio?: number;
   maxAttempts?: number;
   retryDelayMs?: number;
   shouldRetry?: (error: unknown) => boolean;
@@ -344,7 +345,7 @@ export function isImageResourceRenderError(error: unknown): boolean {
   );
 }
 
-async function renderTargetToBlob(target: HTMLElement): Promise<Blob> {
+async function renderTargetToBlob(target: HTMLElement, pixelRatio: number): Promise<Blob> {
   stripXmlIllegalChars(target);
   inlineKatexLayoutStyles(target);
   inlineKatexSvgStyles(target);
@@ -353,7 +354,7 @@ async function renderTargetToBlob(target: HTMLElement): Promise<Blob> {
   const { toBlob } = await import('html-to-image');
   const blob = await toBlob(target, {
     cacheBust: true,
-    pixelRatio: 1.2,
+    pixelRatio,
     backgroundColor: '#ffffff',
     skipFonts: !containsMath,
     fontEmbedCSS: containsMath ? await buildKatexFontEmbedCss(target) : undefined,
@@ -398,7 +399,11 @@ function resolveRenderableWidth(target: HTMLElement): number {
   return DEFAULT_RENDER_WIDTH;
 }
 
-async function renderUsingSanitizedClone(target: HTMLElement, selector: string): Promise<Blob> {
+async function renderUsingSanitizedClone(
+  target: HTMLElement,
+  selector: string,
+  pixelRatio: number,
+): Promise<Blob> {
   const container = document.createElement('div');
   container.style.position = 'fixed';
   container.style.left = DEFAULT_OFFSCREEN_LEFT;
@@ -417,7 +422,7 @@ async function renderUsingSanitizedClone(target: HTMLElement, selector: string):
   document.body.appendChild(container);
 
   try {
-    return await renderTargetToBlob(renderRoot);
+    return await renderTargetToBlob(renderRoot, pixelRatio);
   } finally {
     container.remove();
   }
@@ -431,6 +436,7 @@ export async function renderElementToImageBlob(
   target: HTMLElement,
   options: RenderElementToImageBlobOptions = {},
 ): Promise<Blob> {
+  const pixelRatio = Math.max(1, options.pixelRatio ?? 1.2);
   const maxAttempts = Math.max(1, options.maxAttempts ?? 1);
   const retryDelayMs = Math.max(0, options.retryDelayMs ?? 0);
   const shouldRetry = options.shouldRetry ?? (() => false);
@@ -438,7 +444,7 @@ export async function renderElementToImageBlob(
   let primaryError: unknown;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      return await renderTargetToBlob(target);
+      return await renderTargetToBlob(target, pixelRatio);
     } catch (error) {
       primaryError = error;
       const canRetry = attempt < maxAttempts && shouldRetry(error);
@@ -461,5 +467,6 @@ export async function renderElementToImageBlob(
   return await renderUsingSanitizedClone(
     target,
     options.sanitizeSelector ?? DEFAULT_SANITIZE_SELECTOR,
+    pixelRatio,
   );
 }

--- a/src/features/export/services/ImageRenderService.ts
+++ b/src/features/export/services/ImageRenderService.ts
@@ -4,6 +4,9 @@ const DEFAULT_OFFSCREEN_LEFT = '-100000px';
 const DEFAULT_SANITIZE_SELECTOR = 'img, video, iframe, canvas, svg image';
 const DEFAULT_RENDER_WIDTH = 720;
 const MATH_RENDER_SELECTOR = '.katex, .math-inline, .math-block, [data-math]';
+const MERMAID_FOREIGN_OBJECT_SELECTOR = '.gv-export-mermaid svg foreignObject';
+const MERMAID_FOREIGN_OBJECT_STYLE_PROPERTIES = ['color', 'fill'] as const;
+const WEBKIT_TEXT_FILL_COLOR_PROPERTY = '-webkit-text-fill-color';
 const FONT_FACE_RULE_TYPE = 5;
 const WOFF2_SOURCE_RE = /url\((["']?)([^"')]+)\1\)\s*format\((["']?)woff2\3\)/i;
 
@@ -191,6 +194,22 @@ function inlineKatexSvgStyles(root: HTMLElement): void {
   });
 }
 
+function inlineMermaidForeignObjectStyles(root: HTMLElement): void {
+  root
+    .querySelectorAll<SVGForeignObjectElement>(MERMAID_FOREIGN_OBJECT_SELECTOR)
+    .forEach((foreignObject) => {
+      foreignObject.querySelectorAll<HTMLElement>('*').forEach((element) => {
+        const computedStyle = getComputedStyle(element);
+        MERMAID_FOREIGN_OBJECT_STYLE_PROPERTIES.forEach((property) => {
+          const value = computedStyle.getPropertyValue(property);
+          if (value) setStyle(element, property, value);
+        });
+        const color = computedStyle.getPropertyValue('color');
+        if (color) setStyle(element, WEBKIT_TEXT_FILL_COLOR_PROPERTY, color);
+      });
+    });
+}
+
 function hasMathContent(target: HTMLElement): boolean {
   return target.matches(MATH_RENDER_SELECTOR) || !!target.querySelector(MATH_RENDER_SELECTOR);
 }
@@ -329,6 +348,7 @@ async function renderTargetToBlob(target: HTMLElement): Promise<Blob> {
   stripXmlIllegalChars(target);
   inlineKatexLayoutStyles(target);
   inlineKatexSvgStyles(target);
+  inlineMermaidForeignObjectStyles(target);
   const containsMath = hasMathContent(target);
   const { toBlob } = await import('html-to-image');
   const blob = await toBlob(target, {

--- a/src/features/export/services/PDFPrintService.ts
+++ b/src/features/export/services/PDFPrintService.ts
@@ -9,6 +9,7 @@ import type { ChatTurn, ConversationMetadata } from '../types/export';
 import { DOMContentExtractor } from './DOMContentExtractor';
 import { buildKatexExportStyles } from './katexExportStyles';
 import { buildMermaidExportStyles } from './mermaidExportStyles';
+import { isolateMermaidSvgImages, rasterizeMermaidSvgImages } from './mermaidSvgImage';
 
 export interface PrintableDocumentContent {
   title: string;
@@ -77,8 +78,15 @@ export class PDFPrintService {
     // Ensure we don't leave a previous export container around (e.g. if a prior export failed)
     this.cleanup();
 
+    const safari = isSafari();
+
     // Create print container
     const container = this.createPrintContainer(turns, metadata, preferMetadataTitle);
+    if (safari) {
+      isolateMermaidSvgImages(container);
+    } else {
+      await rasterizeMermaidSvgImages(container);
+    }
     document.body.appendChild(container);
 
     // Remove existing print styles so we can re-inject with new font size
@@ -95,8 +103,6 @@ export class PDFPrintService {
     if (printDialogTitle) {
       document.title = printDialogTitle;
     }
-
-    const safari = isSafari();
 
     // Inline images as data URLs (best-effort) to avoid auth-bound links failing in print.
     // Safari is very strict about `window.print()` being called with a user gesture; awaiting here
@@ -197,7 +203,6 @@ export class PDFPrintService {
         ${this.renderFooter(metadata)}
       </div>
     `;
-
     return container;
   }
 
@@ -907,8 +912,10 @@ export class PDFPrintService {
         ${buildMermaidExportStyles('.gv-print-turn-text', {
           containerMargin: '1em auto',
           avoidContainerBreak: true,
+          diagramSelector: '> img',
           importantDisplay: true,
           preservePrintBackground: true,
+          diagramMaxHeight: '160mm',
         })}
 
         .gv-print-turn-assistant .gv-print-turn-text {

--- a/src/features/export/services/PDFPrintService.ts
+++ b/src/features/export/services/PDFPrintService.ts
@@ -903,6 +903,20 @@ export class PDFPrintService {
           overflow-wrap: anywhere;
         }
 
+        .gv-print-turn-text .gv-export-mermaid {
+          margin: 1em auto;
+          text-align: center;
+          break-inside: avoid;
+          page-break-inside: avoid;
+        }
+
+        .gv-print-turn-text .gv-export-mermaid svg {
+          display: block !important;
+          max-width: 100%;
+          height: auto;
+          margin: 0 auto;
+        }
+
         .gv-print-turn-assistant .gv-print-turn-text {
           border-left-color: #93c5fd;
         }

--- a/src/features/export/services/PDFPrintService.ts
+++ b/src/features/export/services/PDFPrintService.ts
@@ -917,6 +917,14 @@ export class PDFPrintService {
           margin: 0 auto;
         }
 
+        .gv-print-turn-text .gv-export-mermaid[data-gv-mermaid-theme="dark"] {
+          background: #1f2020;
+          padding: 16px;
+          border-radius: 8px;
+          print-color-adjust: exact;
+          -webkit-print-color-adjust: exact;
+        }
+
         .gv-print-turn-assistant .gv-print-turn-text {
           border-left-color: #93c5fd;
         }

--- a/src/features/export/services/PDFPrintService.ts
+++ b/src/features/export/services/PDFPrintService.ts
@@ -8,6 +8,7 @@ import { isSafari } from '@/core/utils/browser';
 import type { ChatTurn, ConversationMetadata } from '../types/export';
 import { DOMContentExtractor } from './DOMContentExtractor';
 import { buildKatexExportStyles } from './katexExportStyles';
+import { buildMermaidExportStyles } from './mermaidExportStyles';
 
 export interface PrintableDocumentContent {
   title: string;
@@ -903,27 +904,12 @@ export class PDFPrintService {
           overflow-wrap: anywhere;
         }
 
-        .gv-print-turn-text .gv-export-mermaid {
-          margin: 1em auto;
-          text-align: center;
-          break-inside: avoid;
-          page-break-inside: avoid;
-        }
-
-        .gv-print-turn-text .gv-export-mermaid svg {
-          display: block !important;
-          max-width: 100%;
-          height: auto;
-          margin: 0 auto;
-        }
-
-        .gv-print-turn-text .gv-export-mermaid[data-gv-mermaid-theme="dark"] {
-          background: #1f2020;
-          padding: 16px;
-          border-radius: 8px;
-          print-color-adjust: exact;
-          -webkit-print-color-adjust: exact;
-        }
+        ${buildMermaidExportStyles('.gv-print-turn-text', {
+          containerMargin: '1em auto',
+          avoidContainerBreak: true,
+          importantDisplay: true,
+          preservePrintBackground: true,
+        })}
 
         .gv-print-turn-assistant .gv-print-turn-text {
           border-left-color: #93c5fd;

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -200,6 +200,92 @@ describe('DOMContentExtractor', () => {
     expect(extracted.text).toContain('- Example\n  ```typescript\n  const answer = 42;\n  ```');
   });
 
+  it('preserves prose, ordinary code, and subsequent prose order inside list items', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <ul>
+            <li>
+              <span>Before ordinary code.</span>
+              <code-block>
+                <div class="code-block-decoration">typescript</div>
+                <pre><code role="text">const answer = 42;</code></pre>
+              </code-block>
+              <span>After ordinary code.</span>
+            </li>
+          </ul>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.hasCode).toBe(true);
+    expect(extracted.text).toContain(
+      '- Before ordinary code.\n  ```typescript\n  const answer = 42;\n  ```\n  After ordinary code.',
+    );
+  });
+
+  it('preserves Mermaid blocks and nested lists at their original list-item positions', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <ul>
+            <li>
+              <span>Before Mermaid.</span>
+              <div class="gv-mermaid-wrapper">
+                <code-block><div class="code-block-decoration">mermaid</div><pre><code role="text">flowchart TD\nA --&gt; B</code></pre></code-block>
+                <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"><text>Diagram</text></svg></div>
+              </div>
+              <ul><li>Nested item</li></ul>
+              <span>After Mermaid.</span>
+            </li>
+          </ul>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.hasCode).toBe(true);
+    expect(extracted.html).toContain('class="gv-export-mermaid"');
+    expect(extracted.text).toContain(
+      '- Before Mermaid.\n  ```mermaid\n  flowchart TD\n  A --> B\n  ```\n  - Nested item\n  After Mermaid.',
+    );
+  });
+
+  it('keeps interleaved ordinary and Mermaid blocks in list DOM order', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <ol>
+            <li>
+              <span>First prose.</span>
+              <code-block><div class="code-block-decoration">json</div><pre><code role="text">{}</code></pre></code-block>
+              <span>Second prose.</span>
+              <div class="gv-mermaid-wrapper">
+                <code-block><div class="code-block-decoration">mermaid</div><pre><code role="text">graph LR\nA --&gt; B</code></pre></code-block>
+                <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"><text>Diagram</text></svg></div>
+              </div>
+              <span>Third prose with <span class="math-inline" data-math="x^2">x²</span>.</span>
+            </li>
+          </ol>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.hasCode).toBe(true);
+    expect(extracted.hasFormulas).toBe(true);
+    expect(extracted.text).toContain(
+      '1. First prose.\n   ```json\n   {}\n   ```\n   Second prose.\n   ```mermaid\n   graph LR\n   A --> B\n   ```\n   Third prose with $x^2$.',
+    );
+  });
+
   it('should strip Gemini inline source chips (link icons) from assistant export', () => {
     const assistant = document.createElement('div');
     assistant.innerHTML = `

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -56,7 +56,7 @@ describe('DOMContentExtractor', () => {
     assistant.innerHTML = `
       <message-content>
         <div class="markdown">
-          <div class="gv-mermaid-wrapper">
+          <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="dark">
             <code-block style="display: none;">
               <div class="code-block-decoration">mermaid</div>
               <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
@@ -82,7 +82,27 @@ describe('DOMContentExtractor', () => {
     expect(extracted.html).toContain('<svg viewBox="0 0 120 80" aria-label="Flowchart">');
     expect(extracted.html).not.toContain('<pre><code');
     expect(extracted.html).not.toContain('gv-mermaid-toggle');
+    expect(extracted.html).toContain('data-gv-mermaid-theme="dark"');
     expect(extracted.text).toContain('```mermaid\nflowchart TD\nA --> B\n```');
+  });
+
+  it('does not copy an invalid Mermaid theme marker into exports', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="neon">
+            <code-block><div class="code-block-decoration">mermaid</div><pre><code role="text">flowchart TD\nA --&gt; B</code></pre></code-block>
+            <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"><text>Diagram</text></svg></div>
+          </div>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.html).toContain('class="gv-export-mermaid"');
+    expect(extracted.html).not.toContain('data-gv-mermaid-theme');
   });
 
   it('falls back to Mermaid source when a rendered SVG is unavailable', () => {

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -158,6 +158,34 @@ describe('DOMContentExtractor', () => {
     expect(extracted.text).toContain('```mermaid\nflowchart TD\nA --> B\n```');
   });
 
+  it('reaches a rendered Mermaid wrapper through an intervening container', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <response-element>
+            <section>
+              <div class="gv-mermaid-wrapper">
+                <code-block style="display: none;">
+                  <div class="code-block-decoration">mermaid</div>
+                  <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
+                </code-block>
+                <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"><text>Rendered diagram</text></svg></div>
+              </div>
+            </section>
+          </response-element>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.html).toContain('class="gv-export-mermaid"');
+    expect(extracted.html).toContain('<svg viewBox="0 0 120 80">');
+    expect(extracted.html).not.toContain('<pre><code');
+    expect(extracted.text).toContain('```mermaid\nflowchart TD\nA --> B\n```');
+  });
+
   it('preserves rendered Mermaid diagrams and fenced source inside list items', () => {
     const assistant = document.createElement('div');
     assistant.innerHTML = `

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -286,6 +286,36 @@ describe('DOMContentExtractor', () => {
     );
   });
 
+  it('extracts Mermaid blocks wrapped by response elements inside list items', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <ul>
+            <li>
+              <span>Before wrapped Mermaid.</span>
+              <response-element>
+                <div class="gv-mermaid-wrapper">
+                  <code-block><div class="code-block-decoration">mermaid</div><pre><code role="text">flowchart LR\nA --&gt; B</code></pre></code-block>
+                  <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"><text>Diagram</text></svg></div>
+                </div>
+              </response-element>
+              <span>After wrapped Mermaid.</span>
+            </li>
+          </ul>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.hasCode).toBe(true);
+    expect(extracted.html).toContain('class="gv-export-mermaid"');
+    expect(extracted.text).toContain(
+      '- Before wrapped Mermaid.\n  ```mermaid\n  flowchart LR\n  A --> B\n  ```\n  After wrapped Mermaid.',
+    );
+  });
+
   it('should strip Gemini inline source chips (link icons) from assistant export', () => {
     const assistant = document.createElement('div');
     assistant.innerHTML = `

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -51,6 +51,155 @@ describe('DOMContentExtractor', () => {
     expect(extracted.text).not.toContain('📎 photo.png');
   });
 
+  it('exports rendered Mermaid SVG in HTML while preserving Mermaid source in text', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <div class="gv-mermaid-wrapper">
+            <code-block style="display: none;">
+              <div class="code-block-decoration">mermaid</div>
+              <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
+            </code-block>
+            <div class="gv-mermaid-toggle">
+              <button class="active">Diagram</button>
+              <button>Code</button>
+            </div>
+            <div class="gv-mermaid-diagram">
+              <svg viewBox="0 0 120 80" aria-label="Flowchart">
+                <g><text>A</text><text>B</text></g>
+              </svg>
+            </div>
+          </div>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.hasCode).toBe(true);
+    expect(extracted.html).toContain('class="gv-export-mermaid"');
+    expect(extracted.html).toContain('<svg viewBox="0 0 120 80" aria-label="Flowchart">');
+    expect(extracted.html).not.toContain('<pre><code');
+    expect(extracted.html).not.toContain('gv-mermaid-toggle');
+    expect(extracted.text).toContain('```mermaid\nflowchart TD\nA --> B\n```');
+  });
+
+  it('falls back to Mermaid source when a rendered SVG is unavailable', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <div class="gv-mermaid-wrapper">
+            <code-block>
+              <div class="code-block-decoration">mermaid</div>
+              <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
+            </code-block>
+            <div class="gv-mermaid-diagram"></div>
+          </div>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.hasCode).toBe(true);
+    expect(extracted.html).toContain('<pre><code class="language-mermaid">');
+    expect(extracted.html).not.toContain('class="gv-export-mermaid"');
+    expect(extracted.text).toContain('```mermaid\nflowchart TD\nA --> B\n```');
+  });
+
+  it('reaches a rendered Mermaid wrapper nested in a response element', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <response-element>
+            <div class="gv-mermaid-wrapper">
+              <code-block style="display: none;">
+                <div class="code-block-decoration">mermaid</div>
+                <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
+              </code-block>
+              <div class="gv-mermaid-toggle"><button>Diagram</button></div>
+              <div class="gv-mermaid-diagram">
+                <svg viewBox="0 0 120 80"><text>Rendered diagram</text></svg>
+              </div>
+            </div>
+          </response-element>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.html).toContain('class="gv-export-mermaid"');
+    expect(extracted.html).toContain('<svg viewBox="0 0 120 80">');
+    expect(extracted.html).not.toContain('<pre><code');
+    expect(extracted.text).toContain('```mermaid\nflowchart TD\nA --> B\n```');
+  });
+
+  it('preserves rendered Mermaid diagrams and fenced source inside list items', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <ul>
+            <li>
+              <span>Diagram</span>
+              <div class="gv-mermaid-wrapper">
+                <code-block style="display: none;">
+                  <div class="code-block-decoration">mermaid</div>
+                  <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
+                </code-block>
+                <div class="gv-mermaid-toggle"><button>Diagram</button></div>
+                <div class="gv-mermaid-diagram">
+                  <svg viewBox="0 0 120 80"><text>Rendered diagram</text></svg>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.hasCode).toBe(true);
+    expect(extracted.html).toContain('<ul>');
+    expect(extracted.html).toContain('class="gv-export-mermaid"');
+    expect(extracted.html).toContain('<svg viewBox="0 0 120 80">');
+    expect(extracted.html).not.toContain('gv-mermaid-wrapper');
+    expect(extracted.html).not.toContain('<pre><code');
+    expect(extracted.text).toContain('- Diagram\n  ```mermaid\n  flowchart TD\n  A --> B\n  ```');
+  });
+
+  it('preserves regular fenced code when list extraction handles block content', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <ul>
+            <li>
+              <span>Example</span>
+              <code-block>
+                <div class="code-block-decoration">typescript</div>
+                <pre><code role="text">const answer = 42;</code></pre>
+              </code-block>
+            </li>
+          </ul>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.hasCode).toBe(true);
+    expect(extracted.html).toContain('<ul>');
+    expect(extracted.html).toContain('<pre><code class="language-typescript">');
+    expect(extracted.html).not.toContain('<code-block>');
+    expect(extracted.text).toContain('- Example\n  ```typescript\n  const answer = 42;\n  ```');
+  });
+
   it('should strip Gemini inline source chips (link icons) from assistant export', () => {
     const assistant = document.createElement('div');
     assistant.innerHTML = `

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -66,10 +66,15 @@ describe('DOMContentExtractor', () => {
               <button>Code</button>
             </div>
             <div class="gv-mermaid-diagram">
-              <svg viewBox="0 0 120 80" aria-label="Flowchart">
+              <svg data-render-theme="dark" viewBox="0 0 120 80" aria-label="Flowchart">
                 <g><text>A</text><text>B</text></g>
               </svg>
             </div>
+            <template class="gv-mermaid-light-export">
+              <svg data-export-theme="light" viewBox="0 0 120 80" aria-label="Flowchart">
+                <g><text>A</text><text>B</text></g>
+              </svg>
+            </template>
           </div>
         </div>
       </message-content>
@@ -79,15 +84,16 @@ describe('DOMContentExtractor', () => {
 
     expect(extracted.hasCode).toBe(true);
     expect(extracted.html).toContain('class="gv-export-mermaid"');
-    expect(extracted.html).toContain('<svg viewBox="0 0 120 80" aria-label="Flowchart">');
+    expect(extracted.html).toContain('data-export-theme="light"');
+    expect(extracted.html).not.toContain('data-render-theme="dark"');
     expect(extracted.html).not.toContain('<pre><code');
     expect(extracted.html).not.toContain('gv-mermaid-toggle');
-    expect(extracted.html).toContain('data-gv-mermaid-theme="dark"');
+    expect(extracted.html).toContain('data-gv-mermaid-theme="light"');
     expect(extracted.text).toContain('```mermaid\nflowchart TD\nA --> B\n```');
     expect(extracted.text).not.toContain('```code snippet');
   });
 
-  it('does not copy an invalid Mermaid theme marker into exports', () => {
+  it('falls back to source for an invalid Mermaid theme marker', () => {
     const assistant = document.createElement('div');
     assistant.innerHTML = `
       <message-content>
@@ -102,8 +108,28 @@ describe('DOMContentExtractor', () => {
 
     const extracted = DOMContentExtractor.extractAssistantContent(assistant);
 
-    expect(extracted.html).toContain('class="gv-export-mermaid"');
+    expect(extracted.html).toContain('<pre><code class="language-mermaid">');
+    expect(extracted.html).not.toContain('class="gv-export-mermaid"');
     expect(extracted.html).not.toContain('data-gv-mermaid-theme');
+  });
+
+  it('falls back to source when a dark diagram has no light export SVG', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="dark">
+            <code-block><pre><code role="text">flowchart TD\nA --&gt; B</code></pre></code-block>
+            <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"></svg></div>
+          </div>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.html).toContain('<pre><code class="language-mermaid">');
+    expect(extracted.html).not.toContain('class="gv-export-mermaid"');
   });
 
   it('falls back to Mermaid source when a rendered SVG is unavailable', () => {
@@ -136,7 +162,7 @@ describe('DOMContentExtractor', () => {
       <message-content>
         <div class="markdown">
           <response-element>
-            <div class="gv-mermaid-wrapper">
+            <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="light">
               <code-block style="display: none;">
                 <div class="code-block-decoration">mermaid</div>
                 <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
@@ -166,7 +192,7 @@ describe('DOMContentExtractor', () => {
         <div class="markdown">
           <response-element>
             <section>
-              <div class="gv-mermaid-wrapper">
+              <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="light">
                 <code-block style="display: none;">
                   <div class="code-block-decoration">mermaid</div>
                   <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
@@ -195,7 +221,7 @@ describe('DOMContentExtractor', () => {
           <ul>
             <li>
               <span>Diagram</span>
-              <div class="gv-mermaid-wrapper">
+              <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="light">
                 <code-block style="display: none;">
                   <div class="code-block-decoration">mermaid</div>
                   <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
@@ -284,7 +310,7 @@ describe('DOMContentExtractor', () => {
           <ul>
             <li>
               <span>Before Mermaid.</span>
-              <div class="gv-mermaid-wrapper">
+              <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="light">
                 <code-block><div class="code-block-decoration">mermaid</div><pre><code role="text">flowchart TD\nA --&gt; B</code></pre></code-block>
                 <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"><text>Diagram</text></svg></div>
               </div>
@@ -315,7 +341,7 @@ describe('DOMContentExtractor', () => {
               <span>First prose.</span>
               <code-block><div class="code-block-decoration">json</div><pre><code role="text">{}</code></pre></code-block>
               <span>Second prose.</span>
-              <div class="gv-mermaid-wrapper">
+              <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="light">
                 <code-block><div class="code-block-decoration">mermaid</div><pre><code role="text">graph LR\nA --&gt; B</code></pre></code-block>
                 <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"><text>Diagram</text></svg></div>
               </div>
@@ -344,7 +370,7 @@ describe('DOMContentExtractor', () => {
             <li>
               <span>Before wrapped Mermaid.</span>
               <response-element>
-                <div class="gv-mermaid-wrapper">
+                <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="light">
                   <code-block><div class="code-block-decoration">mermaid</div><pre><code role="text">flowchart LR\nA --&gt; B</code></pre></code-block>
                   <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"><text>Diagram</text></svg></div>
                 </div>
@@ -380,7 +406,7 @@ describe('DOMContentExtractor', () => {
                 <p>Before Mermaid.</p>
                 <div>
                   <div>
-                    <div class="gv-mermaid-wrapper">
+                    <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="light">
                       <code-block><div class="code-block-decoration">Code snippet</div><pre><code role="text">flowchart TD\nA --&gt; B</code></pre></code-block>
                       <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"><text>Diagram</text></svg></div>
                     </div>

--- a/src/features/export/services/__tests__/DOMContentExtractor.test.ts
+++ b/src/features/export/services/__tests__/DOMContentExtractor.test.ts
@@ -58,7 +58,7 @@ describe('DOMContentExtractor', () => {
         <div class="markdown">
           <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="dark">
             <code-block style="display: none;">
-              <div class="code-block-decoration">mermaid</div>
+              <div class="code-block-decoration">Code snippet</div>
               <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
             </code-block>
             <div class="gv-mermaid-toggle">
@@ -84,6 +84,7 @@ describe('DOMContentExtractor', () => {
     expect(extracted.html).not.toContain('gv-mermaid-toggle');
     expect(extracted.html).toContain('data-gv-mermaid-theme="dark"');
     expect(extracted.text).toContain('```mermaid\nflowchart TD\nA --> B\n```');
+    expect(extracted.text).not.toContain('```code snippet');
   });
 
   it('does not copy an invalid Mermaid theme marker into exports', () => {
@@ -362,6 +363,46 @@ describe('DOMContentExtractor', () => {
     expect(extracted.text).toContain(
       '- Before wrapped Mermaid.\n  ```mermaid\n  flowchart LR\n  A --> B\n  ```\n  After wrapped Mermaid.',
     );
+  });
+
+  it('preserves block order through section and div containers inside list items', () => {
+    const assistant = document.createElement('div');
+    assistant.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <ul>
+            <li>
+              <section>
+                <p>Before ordinary code.</p>
+                <div>
+                  <code-block><div class="code-block-decoration">typescript</div><pre><code role="text">const answer = 42;</code></pre></code-block>
+                </div>
+                <p>Before Mermaid.</p>
+                <div>
+                  <div>
+                    <div class="gv-mermaid-wrapper">
+                      <code-block><div class="code-block-decoration">Code snippet</div><pre><code role="text">flowchart TD\nA --&gt; B</code></pre></code-block>
+                      <div class="gv-mermaid-diagram"><svg viewBox="0 0 120 80"><text>Diagram</text></svg></div>
+                    </div>
+                  </div>
+                </div>
+                <ol><li>Nested item</li></ol>
+                <p>After nested list.</p>
+              </section>
+            </li>
+          </ul>
+        </div>
+      </message-content>
+    `;
+
+    const extracted = DOMContentExtractor.extractAssistantContent(assistant);
+
+    expect(extracted.hasCode).toBe(true);
+    expect(extracted.html).toContain('class="gv-export-mermaid"');
+    expect(extracted.text).toContain(
+      '- Before ordinary code.\n  ```typescript\n  const answer = 42;\n  ```\n  Before Mermaid.\n  ```mermaid\n  flowchart TD\n  A --> B\n  ```\n  1. Nested item\n  After nested list.',
+    );
+    expect(extracted.text).not.toContain('```code snippet');
   });
 
   it('should strip Gemini inline source chips (link icons) from assistant export', () => {

--- a/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
@@ -126,7 +126,7 @@ describe('DeepResearchPDFPrintService', () => {
         <p class="outer-style" onclick="alert('unsafe')">Body</p>
         <span class="katex">x</span>
         <div class="gv-export-mermaid">
-          <svg viewBox="0 0 120 80" onclick="alert('unsafe')">
+          <svg viewBox="0 0 120 80" width="100%" style="max-width: 640px" onclick="alert('unsafe')">
             <style>.node { fill: red; }</style>
             <script>alert('unsafe')</script>
             <template><g></g></template>
@@ -145,6 +145,8 @@ describe('DeepResearchPDFPrintService', () => {
 
     expect(mermaidImage).toBeTruthy();
     expect(dataUrl).toMatch(/^data:image\/svg\+xml;charset=utf-8,/);
+    expect(mermaidImage?.style.width).toBe('100%');
+    expect(mermaidImage?.style.maxWidth).toBe('640px');
     expect(serializedSvg).toContain('<style>.node { fill: red; }</style>');
     expect(serializedSvg).not.toContain('<script');
     expect(serializedSvg).not.toContain('<template');

--- a/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
@@ -158,7 +158,9 @@ describe('DeepResearchPDFPrintService', () => {
       'dark',
     );
     expect(styleText).toContain('.gv-dr-print-report .gv-export-mermaid > img');
+    expect(styleText).toContain('margin: 0.75em auto;');
     expect(styleText).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
+    expect(styleText).toContain('background: #1f2020;');
     expect(styleText).toContain('print-color-adjust: exact;');
     expect(styleText).toContain('-webkit-print-color-adjust: exact;');
     expect(styleText).toContain('page-break-inside: avoid;');

--- a/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
@@ -113,6 +113,49 @@ describe('DeepResearchPDFPrintService', () => {
     expect(styleText).toContain('background: #fff !important;');
   });
 
+  it('isolates Mermaid SVG styles in a sanitized data image', async () => {
+    window.print = vi.fn();
+
+    await DeepResearchPDFPrintService.export({
+      title: 'Report',
+      url: 'https://gemini.google.com/app/abc12345',
+      exportedAt: new Date().toISOString(),
+      markdown: 'Body',
+      html: `
+        <style>.outer-style { color: red; }</style>
+        <p class="outer-style" onclick="alert('unsafe')">Body</p>
+        <span class="katex">x</span>
+        <div class="gv-export-mermaid">
+          <svg viewBox="0 0 120 80" onclick="alert('unsafe')">
+            <style>.node { fill: red; }</style>
+            <script>alert('unsafe')</script>
+            <template><g></g></template>
+            <g onload="alert('unsafe')"><text>Diagram</text></g>
+          </svg>
+        </div>
+      `,
+    });
+
+    const report = document.querySelector('.gv-dr-print-report');
+    const mermaidImage = report?.querySelector<HTMLImageElement>('.gv-export-mermaid img');
+    const dataUrl = mermaidImage?.getAttribute('src') || '';
+    const serializedSvg = decodeURIComponent(dataUrl.split(',')[1] || '');
+    const styleText =
+      document.getElementById('gv-deep-research-pdf-print-styles')?.textContent || '';
+
+    expect(mermaidImage).toBeTruthy();
+    expect(dataUrl).toMatch(/^data:image\/svg\+xml;charset=utf-8,/);
+    expect(serializedSvg).toContain('<style>.node { fill: red; }</style>');
+    expect(serializedSvg).not.toContain('<script');
+    expect(serializedSvg).not.toContain('<template');
+    expect(serializedSvg).not.toMatch(/\son[a-z]+=/i);
+    expect(report?.querySelector('style')).toBeNull();
+    expect(report?.querySelector('p')?.getAttribute('onclick')).toBeNull();
+    expect(report?.querySelector('.katex')?.textContent).toBe('x');
+    expect(styleText).toContain('.gv-dr-print-report .gv-export-mermaid > img');
+    expect(styleText).toContain('page-break-inside: avoid;');
+  });
+
   it('applies Safari-only print override class and style rules', async () => {
     setUserAgentVendor(
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15',

--- a/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
@@ -125,7 +125,7 @@ describe('DeepResearchPDFPrintService', () => {
         <style>.outer-style { color: red; }</style>
         <p class="outer-style" onclick="alert('unsafe')">Body</p>
         <span class="katex">x</span>
-        <div class="gv-export-mermaid" data-gv-mermaid-theme="dark">
+        <div class="gv-export-mermaid" data-gv-mermaid-theme="light">
           <svg viewBox="0 0 120 80" width="100%" style="max-width: 640px" onclick="alert('unsafe')">
             <style>.node { fill: red; }</style>
             <script>alert('unsafe')</script>
@@ -155,12 +155,12 @@ describe('DeepResearchPDFPrintService', () => {
     expect(report?.querySelector('p')?.getAttribute('onclick')).toBeNull();
     expect(report?.querySelector('.katex')?.textContent).toBe('x');
     expect(report?.querySelector('.gv-export-mermaid')?.getAttribute('data-gv-mermaid-theme')).toBe(
-      'dark',
+      'light',
     );
     expect(styleText).toContain('.gv-dr-print-report .gv-export-mermaid > img');
     expect(styleText).toContain('margin: 0.75em auto;');
-    expect(styleText).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
-    expect(styleText).toContain('background: #1f2020;');
+    expect(styleText).not.toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
+    expect(styleText).not.toContain('background: #1f2020;');
     expect(styleText).toContain('print-color-adjust: exact;');
     expect(styleText).toContain('-webkit-print-color-adjust: exact;');
     expect(styleText).toContain('page-break-inside: avoid;');

--- a/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
@@ -125,7 +125,7 @@ describe('DeepResearchPDFPrintService', () => {
         <style>.outer-style { color: red; }</style>
         <p class="outer-style" onclick="alert('unsafe')">Body</p>
         <span class="katex">x</span>
-        <div class="gv-export-mermaid">
+        <div class="gv-export-mermaid" data-gv-mermaid-theme="dark">
           <svg viewBox="0 0 120 80" width="100%" style="max-width: 640px" onclick="alert('unsafe')">
             <style>.node { fill: red; }</style>
             <script>alert('unsafe')</script>
@@ -154,7 +154,13 @@ describe('DeepResearchPDFPrintService', () => {
     expect(report?.querySelector('style')).toBeNull();
     expect(report?.querySelector('p')?.getAttribute('onclick')).toBeNull();
     expect(report?.querySelector('.katex')?.textContent).toBe('x');
+    expect(report?.querySelector('.gv-export-mermaid')?.getAttribute('data-gv-mermaid-theme')).toBe(
+      'dark',
+    );
     expect(styleText).toContain('.gv-dr-print-report .gv-export-mermaid > img');
+    expect(styleText).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
+    expect(styleText).toContain('print-color-adjust: exact;');
+    expect(styleText).toContain('-webkit-print-color-adjust: exact;');
     expect(styleText).toContain('page-break-inside: avoid;');
   });
 

--- a/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/DeepResearchPDFPrintService.test.ts
@@ -164,6 +164,8 @@ describe('DeepResearchPDFPrintService', () => {
     expect(styleText).toContain('print-color-adjust: exact;');
     expect(styleText).toContain('-webkit-print-color-adjust: exact;');
     expect(styleText).toContain('page-break-inside: avoid;');
+    expect(styleText).toContain('max-height: 160mm;');
+    expect(styleText).toContain('object-fit: contain;');
   });
 
   it('applies Safari-only print override class and style rules', async () => {

--- a/src/features/export/services/__tests__/ImageExportService.test.ts
+++ b/src/features/export/services/__tests__/ImageExportService.test.ts
@@ -38,6 +38,7 @@ describe('ImageExportService', () => {
   ];
 
   beforeEach(() => {
+    vi.clearAllMocks();
     setUserAgentVendor(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
       'Google Inc.',
@@ -158,10 +159,14 @@ describe('ImageExportService', () => {
     );
 
     const target = renderedTarget as HTMLElement | null;
-    expect(target?.querySelector('.gv-image-export-content .gv-export-mermaid svg')).toBeTruthy();
+    const mermaidImage = target?.querySelector<HTMLImageElement>(
+      '.gv-image-export-content .gv-export-mermaid > img.gv-export-mermaid-image',
+    );
+    expect(mermaidImage?.src).toMatch(/^data:image\/png;base64,/);
+    expect(target?.querySelector('.gv-image-export-content .gv-export-mermaid svg')).toBeNull();
     expect(target?.querySelector('pre, code-block, .gv-mermaid-toggle')).toBeNull();
     expect(renderedStyles).toContain('.gv-image-export-content .gv-export-mermaid');
-    expect(renderedStyles).toContain('.gv-image-export-content .gv-export-mermaid svg {');
+    expect(renderedStyles).toContain('.gv-image-export-content .gv-export-mermaid > img {');
     expect(renderedStyles).toContain('max-width: 100%;');
     expect(renderedStyles).toContain('height: auto;');
     expect(
@@ -169,9 +174,7 @@ describe('ImageExportService', () => {
         ?.querySelector('.gv-image-export-content .gv-export-mermaid')
         ?.getAttribute('data-gv-mermaid-theme'),
     ).toBe('light');
-    expect(target?.querySelector('.gv-export-mermaid svg')?.getAttribute('data-export-theme')).toBe(
-      'light',
-    );
+    expect(toBlob).toHaveBeenCalledTimes(2);
     expect(renderedStyles).not.toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
     expect(renderedStyles).not.toContain('background: #1f2020;');
   });
@@ -330,12 +333,18 @@ describe('ImageExportService', () => {
 
     const target = renderedTarget as HTMLElement | null;
     expect(
-      target?.querySelector('.gv-image-export-report-content .gv-export-mermaid svg'),
+      target?.querySelector(
+        '.gv-image-export-report-content .gv-export-mermaid > img.gv-export-mermaid-image',
+      ),
     ).toBeTruthy();
+    expect(
+      target?.querySelector('.gv-image-export-report-content .gv-export-mermaid svg'),
+    ).toBeNull();
     expect(renderedStyles).toContain('.gv-image-export-report-content .gv-export-mermaid');
-    expect(renderedStyles).toContain('.gv-image-export-report-content .gv-export-mermaid svg {');
+    expect(renderedStyles).toContain('.gv-image-export-report-content .gv-export-mermaid > img {');
     expect(renderedStyles).toContain('max-width: 100%;');
     expect(renderedStyles).toContain('height: auto;');
+    expect(toBlob).toHaveBeenCalledTimes(2);
     expect(renderedStyles).toContain('.gv-image-export-doc a {');
     expect(renderedStyles).toContain('color: #2563eb !important;');
     expect(renderedStyles).not.toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');

--- a/src/features/export/services/__tests__/ImageExportService.test.ts
+++ b/src/features/export/services/__tests__/ImageExportService.test.ts
@@ -158,6 +158,7 @@ describe('ImageExportService', () => {
     expect(target?.querySelector('.gv-image-export-content .gv-export-mermaid svg')).toBeTruthy();
     expect(target?.querySelector('pre, code-block, .gv-mermaid-toggle')).toBeNull();
     expect(renderedStyles).toContain('.gv-image-export-content .gv-export-mermaid');
+    expect(renderedStyles).toContain('.gv-image-export-content .gv-export-mermaid svg {');
     expect(renderedStyles).toContain('max-width: 100%;');
     expect(renderedStyles).toContain('height: auto;');
     expect(
@@ -166,6 +167,7 @@ describe('ImageExportService', () => {
         ?.getAttribute('data-gv-mermaid-theme'),
     ).toBe('dark');
     expect(renderedStyles).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
+    expect(renderedStyles).toContain('background: #1f2020;');
   });
 
   it('retries transient image render failures on Chrome and succeeds', async () => {
@@ -325,9 +327,11 @@ describe('ImageExportService', () => {
       target?.querySelector('.gv-image-export-report-content .gv-export-mermaid svg'),
     ).toBeTruthy();
     expect(renderedStyles).toContain('.gv-image-export-report-content .gv-export-mermaid');
+    expect(renderedStyles).toContain('.gv-image-export-report-content .gv-export-mermaid svg {');
     expect(renderedStyles).toContain('max-width: 100%;');
     expect(renderedStyles).toContain('height: auto;');
     expect(renderedStyles).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
+    expect(renderedStyles).toContain('background: #1f2020;');
   });
 
   it('fetches blob: image URLs so dom-to-image can rasterize generated images', async () => {

--- a/src/features/export/services/__tests__/ImageExportService.test.ts
+++ b/src/features/export/services/__tests__/ImageExportService.test.ts
@@ -134,8 +134,9 @@ describe('ImageExportService', () => {
             </code-block>
             <div class="gv-mermaid-toggle"><button>Diagram</button></div>
             <div class="gv-mermaid-diagram">
-              <svg viewBox="0 0 120 80"><g><text>A</text><text>B</text></g></svg>
+              <svg data-render-theme="dark" viewBox="0 0 120 80"><g><text>A</text><text>B</text></g></svg>
             </div>
+            <template class="gv-mermaid-light-export"><svg data-export-theme="light" viewBox="0 0 120 80"><g><text>A</text><text>B</text></g></svg></template>
           </div>
         </div>
       </message-content>
@@ -165,9 +166,12 @@ describe('ImageExportService', () => {
       target
         ?.querySelector('.gv-image-export-content .gv-export-mermaid')
         ?.getAttribute('data-gv-mermaid-theme'),
-    ).toBe('dark');
-    expect(renderedStyles).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
-    expect(renderedStyles).toContain('background: #1f2020;');
+    ).toBe('light');
+    expect(target?.querySelector('.gv-export-mermaid svg')?.getAttribute('data-export-theme')).toBe(
+      'light',
+    );
+    expect(renderedStyles).not.toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
+    expect(renderedStyles).not.toContain('background: #1f2020;');
   });
 
   it('retries transient image render failures on Chrome and succeeds', async () => {
@@ -319,7 +323,7 @@ describe('ImageExportService', () => {
       url: 'https://gemini.google.com/app/report',
       exportedAt: '2026-01-01T00:00:00.000Z',
       markdown: 'Diagram',
-      html: '<div class="gv-export-mermaid" data-gv-mermaid-theme="dark"><svg viewBox="0 0 120 80"></svg></div>',
+      html: '<div class="gv-export-mermaid" data-gv-mermaid-theme="light"><svg viewBox="0 0 120 80"></svg></div>',
     });
 
     const target = renderedTarget as HTMLElement | null;
@@ -330,8 +334,8 @@ describe('ImageExportService', () => {
     expect(renderedStyles).toContain('.gv-image-export-report-content .gv-export-mermaid svg {');
     expect(renderedStyles).toContain('max-width: 100%;');
     expect(renderedStyles).toContain('height: auto;');
-    expect(renderedStyles).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
-    expect(renderedStyles).toContain('background: #1f2020;');
+    expect(renderedStyles).not.toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
+    expect(renderedStyles).not.toContain('background: #1f2020;');
   });
 
   it('fetches blob: image URLs so dom-to-image can rasterize generated images', async () => {

--- a/src/features/export/services/__tests__/ImageExportService.test.ts
+++ b/src/features/export/services/__tests__/ImageExportService.test.ts
@@ -118,6 +118,8 @@ describe('ImageExportService', () => {
 
     expect(renderedAttachmentText).toContain('proposal.pdf');
     expect(renderedStyles).toContain('.gv-image-export-content .gv-export-attachment');
+    expect(renderedStyles).toContain('.gv-image-export-doc a {');
+    expect(renderedStyles).toContain('color: #2563eb !important;');
   });
 
   it('renders Mermaid SVG with scoped image export styles', async () => {
@@ -334,6 +336,8 @@ describe('ImageExportService', () => {
     expect(renderedStyles).toContain('.gv-image-export-report-content .gv-export-mermaid svg {');
     expect(renderedStyles).toContain('max-width: 100%;');
     expect(renderedStyles).toContain('height: auto;');
+    expect(renderedStyles).toContain('.gv-image-export-doc a {');
+    expect(renderedStyles).toContain('color: #2563eb !important;');
     expect(renderedStyles).not.toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
     expect(renderedStyles).not.toContain('background: #1f2020;');
   });

--- a/src/features/export/services/__tests__/ImageExportService.test.ts
+++ b/src/features/export/services/__tests__/ImageExportService.test.ts
@@ -120,6 +120,48 @@ describe('ImageExportService', () => {
     expect(renderedStyles).toContain('.gv-image-export-content .gv-export-attachment');
   });
 
+  it('renders Mermaid SVG with scoped image export styles', async () => {
+    let renderedTarget: HTMLElement | null = null;
+    let renderedStyles = '';
+    const assistantElement = document.createElement('div');
+    assistantElement.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <div class="gv-mermaid-wrapper">
+            <code-block style="display: none;">
+              <div class="code-block-decoration">mermaid</div>
+              <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
+            </code-block>
+            <div class="gv-mermaid-toggle"><button>Diagram</button></div>
+            <div class="gv-mermaid-diagram">
+              <svg viewBox="0 0 120 80"><g><text>A</text><text>B</text></g></svg>
+            </div>
+          </div>
+        </div>
+      </message-content>
+    `;
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (node: HTMLElement) => {
+        renderedTarget = node;
+        renderedStyles = node.parentElement?.querySelector('style')?.textContent ?? '';
+        return new Blob(['x'], { type: 'image/png' });
+      },
+    );
+
+    await ImageExportService.renderConversationBlob(
+      [{ user: 'Diagram', assistant: '', starred: false, assistantElement }],
+      mockMetadata,
+      {},
+    );
+
+    const target = renderedTarget as HTMLElement | null;
+    expect(target?.querySelector('.gv-image-export-content .gv-export-mermaid svg')).toBeTruthy();
+    expect(target?.querySelector('pre, code-block, .gv-mermaid-toggle')).toBeNull();
+    expect(renderedStyles).toContain('.gv-image-export-content .gv-export-mermaid');
+    expect(renderedStyles).toContain('max-width: 100%;');
+    expect(renderedStyles).toContain('height: auto;');
+  });
+
   it('retries transient image render failures on Chrome and succeeds', async () => {
     (toBlob as unknown as ReturnType<typeof vi.fn>).mockReset();
     (toBlob as unknown as ReturnType<typeof vi.fn>)
@@ -250,6 +292,35 @@ describe('ImageExportService', () => {
 
     expect(capturedWidth).toBe('1360px');
     expect(capturedFontSize).toBe('24px');
+  });
+
+  it('applies scoped Mermaid sizing to document image exports', async () => {
+    let renderedTarget: HTMLElement | null = null;
+    let renderedStyles = '';
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockReset();
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (node: HTMLElement) => {
+        renderedTarget = node;
+        renderedStyles = node.parentElement?.querySelector('style')?.textContent ?? '';
+        return new Blob(['x'], { type: 'image/png' });
+      },
+    );
+
+    await ImageExportService.renderDocumentBlob({
+      title: 'Report',
+      url: 'https://gemini.google.com/app/report',
+      exportedAt: '2026-01-01T00:00:00.000Z',
+      markdown: 'Diagram',
+      html: '<div class="gv-export-mermaid"><svg viewBox="0 0 120 80"></svg></div>',
+    });
+
+    const target = renderedTarget as HTMLElement | null;
+    expect(
+      target?.querySelector('.gv-image-export-report-content .gv-export-mermaid svg'),
+    ).toBeTruthy();
+    expect(renderedStyles).toContain('.gv-image-export-report-content .gv-export-mermaid');
+    expect(renderedStyles).toContain('max-width: 100%;');
+    expect(renderedStyles).toContain('height: auto;');
   });
 
   it('fetches blob: image URLs so dom-to-image can rasterize generated images', async () => {

--- a/src/features/export/services/__tests__/ImageExportService.test.ts
+++ b/src/features/export/services/__tests__/ImageExportService.test.ts
@@ -127,7 +127,7 @@ describe('ImageExportService', () => {
     assistantElement.innerHTML = `
       <message-content>
         <div class="markdown">
-          <div class="gv-mermaid-wrapper">
+          <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="dark">
             <code-block style="display: none;">
               <div class="code-block-decoration">mermaid</div>
               <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
@@ -160,6 +160,12 @@ describe('ImageExportService', () => {
     expect(renderedStyles).toContain('.gv-image-export-content .gv-export-mermaid');
     expect(renderedStyles).toContain('max-width: 100%;');
     expect(renderedStyles).toContain('height: auto;');
+    expect(
+      target
+        ?.querySelector('.gv-image-export-content .gv-export-mermaid')
+        ?.getAttribute('data-gv-mermaid-theme'),
+    ).toBe('dark');
+    expect(renderedStyles).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
   });
 
   it('retries transient image render failures on Chrome and succeeds', async () => {
@@ -311,7 +317,7 @@ describe('ImageExportService', () => {
       url: 'https://gemini.google.com/app/report',
       exportedAt: '2026-01-01T00:00:00.000Z',
       markdown: 'Diagram',
-      html: '<div class="gv-export-mermaid"><svg viewBox="0 0 120 80"></svg></div>',
+      html: '<div class="gv-export-mermaid" data-gv-mermaid-theme="dark"><svg viewBox="0 0 120 80"></svg></div>',
     });
 
     const target = renderedTarget as HTMLElement | null;
@@ -321,6 +327,7 @@ describe('ImageExportService', () => {
     expect(renderedStyles).toContain('.gv-image-export-report-content .gv-export-mermaid');
     expect(renderedStyles).toContain('max-width: 100%;');
     expect(renderedStyles).toContain('height: auto;');
+    expect(renderedStyles).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
   });
 
   it('fetches blob: image URLs so dom-to-image can rasterize generated images', async () => {

--- a/src/features/export/services/__tests__/ImageRenderService.test.ts
+++ b/src/features/export/services/__tests__/ImageRenderService.test.ts
@@ -186,6 +186,54 @@ describe('ImageRenderService', () => {
     expect(root?.style.getPropertyPriority('margin-left')).toBe('important');
   });
 
+  it('inlines Mermaid foreignObject label colors before rendering', async () => {
+    const style = document.createElement('style');
+    style.dataset.gvTestStyle = 'mermaid-label';
+    style.textContent = `
+      .nodeLabel,
+      .ordinaryLabel {
+        color: rgb(204, 204, 204);
+        fill: rgb(204, 204, 204);
+      }
+    `;
+    document.head.appendChild(style);
+
+    const target = document.createElement('div');
+    target.innerHTML = `
+      <div class="gv-export-mermaid" data-gv-mermaid-theme="dark">
+        <svg xmlns="http://www.w3.org/2000/svg">
+          <foreignObject>
+            <div xmlns="http://www.w3.org/1999/xhtml">
+              <span class="nodeLabel">Analysis</span>
+            </div>
+          </foreignObject>
+        </svg>
+      </div>
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <foreignObject>
+          <div xmlns="http://www.w3.org/1999/xhtml">
+            <span class="ordinaryLabel">Untouched</span>
+          </div>
+        </foreignObject>
+      </svg>
+    `;
+    document.body.appendChild(target);
+    const blob = new Blob(['ok'], { type: 'image/png' });
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(blob);
+
+    await renderElementToImageBlob(target);
+
+    const label = target.querySelector<HTMLElement>('.nodeLabel');
+    const ordinaryLabel = target.querySelector<HTMLElement>('.ordinaryLabel');
+    expect(label?.style.getPropertyValue('color')).toBe('rgb(204, 204, 204)');
+    expect(label?.style.getPropertyValue('fill')).toBe('rgb(204, 204, 204)');
+    expect(label?.style.getPropertyValue('-webkit-text-fill-color')).toBe('rgb(204, 204, 204)');
+    expect(label?.style.getPropertyPriority('color')).toBe('important');
+    expect(ordinaryLabel?.style.getPropertyValue('color')).toBe('');
+    expect(ordinaryLabel?.style.getPropertyValue('fill')).toBe('');
+    expect(ordinaryLabel?.style.getPropertyValue('-webkit-text-fill-color')).toBe('');
+  });
+
   it('retries when shouldRetry returns true and later succeeds', async () => {
     const target = document.createElement('div');
     const blob = new Blob(['ok'], { type: 'image/png' });

--- a/src/features/export/services/__tests__/ImageRenderService.test.ts
+++ b/src/features/export/services/__tests__/ImageRenderService.test.ts
@@ -27,7 +27,20 @@ describe('ImageRenderService', () => {
 
     expect(result).toBe(blob);
     expect(toBlob).toHaveBeenCalledTimes(1);
-    expect(toBlob).toHaveBeenCalledWith(target, expect.objectContaining({ skipFonts: true }));
+    expect(toBlob).toHaveBeenCalledWith(
+      target,
+      expect.objectContaining({ pixelRatio: 1.2, skipFonts: true }),
+    );
+  });
+
+  it('uses the requested pixel ratio', async () => {
+    const target = document.createElement('div');
+    const blob = new Blob(['ok'], { type: 'image/png' });
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(blob);
+
+    await renderElementToImageBlob(target, { pixelRatio: 2 });
+
+    expect(toBlob).toHaveBeenCalledWith(target, expect.objectContaining({ pixelRatio: 2 }));
   });
 
   it('embeds fonts for math content so KaTeX radicals render correctly', async () => {

--- a/src/features/export/services/__tests__/PDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/PDFPrintService.test.ts
@@ -233,6 +233,8 @@ describe('PDFPrintService', () => {
     expect(turnText?.querySelector('.gv-export-mermaid svg')).toBeTruthy();
     expect(turnText?.querySelector('pre, code-block, .gv-mermaid-toggle')).toBeNull();
     expect(styleText).toContain('.gv-print-turn-text .gv-export-mermaid');
+    expect(styleText).toContain('.gv-print-turn-text .gv-export-mermaid svg {');
+    expect(styleText).toContain('display: block !important;');
     expect(styleText).toContain('break-inside: avoid;');
     expect(styleText).toContain('page-break-inside: avoid;');
     expect(styleText).toContain('max-width: 100%;');
@@ -241,6 +243,7 @@ describe('PDFPrintService', () => {
       turnText?.querySelector('.gv-export-mermaid')?.getAttribute('data-gv-mermaid-theme'),
     ).toBe('dark');
     expect(styleText).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
+    expect(styleText).toContain('background: #1f2020;');
     expect(styleText).toContain('print-color-adjust: exact;');
     expect(styleText).toContain('-webkit-print-color-adjust: exact;');
   });

--- a/src/features/export/services/__tests__/PDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/PDFPrintService.test.ts
@@ -204,7 +204,7 @@ describe('PDFPrintService', () => {
     assistantElement.innerHTML = `
       <message-content>
         <div class="markdown">
-          <div class="gv-mermaid-wrapper">
+          <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="dark">
             <code-block style="display: none;">
               <div class="code-block-decoration">mermaid</div>
               <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
@@ -237,6 +237,12 @@ describe('PDFPrintService', () => {
     expect(styleText).toContain('page-break-inside: avoid;');
     expect(styleText).toContain('max-width: 100%;');
     expect(styleText).toContain('height: auto;');
+    expect(
+      turnText?.querySelector('.gv-export-mermaid')?.getAttribute('data-gv-mermaid-theme'),
+    ).toBe('dark');
+    expect(styleText).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
+    expect(styleText).toContain('print-color-adjust: exact;');
+    expect(styleText).toContain('-webkit-print-color-adjust: exact;');
   });
 
   it('normalizes metadata title suffix when page title is generic', async () => {

--- a/src/features/export/services/__tests__/PDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/PDFPrintService.test.ts
@@ -211,8 +211,9 @@ describe('PDFPrintService', () => {
             </code-block>
             <div class="gv-mermaid-toggle"><button>Diagram</button></div>
             <div class="gv-mermaid-diagram">
-              <svg viewBox="0 0 120 80"><g><text>A</text><text>B</text></g></svg>
+              <svg data-render-theme="dark" viewBox="0 0 120 80"><g><text>A</text><text>B</text></g></svg>
             </div>
+            <template class="gv-mermaid-light-export"><svg data-export-theme="light" viewBox="0 0 120 80"><g><text>A</text><text>B</text></g></svg></template>
           </div>
         </div>
       </message-content>
@@ -241,9 +242,12 @@ describe('PDFPrintService', () => {
     expect(styleText).toContain('height: auto;');
     expect(
       turnText?.querySelector('.gv-export-mermaid')?.getAttribute('data-gv-mermaid-theme'),
-    ).toBe('dark');
-    expect(styleText).toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
-    expect(styleText).toContain('background: #1f2020;');
+    ).toBe('light');
+    expect(
+      turnText?.querySelector('.gv-export-mermaid svg')?.getAttribute('data-export-theme'),
+    ).toBe('light');
+    expect(styleText).not.toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
+    expect(styleText).not.toContain('background: #1f2020;');
     expect(styleText).toContain('print-color-adjust: exact;');
     expect(styleText).toContain('-webkit-print-color-adjust: exact;');
   });

--- a/src/features/export/services/__tests__/PDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/PDFPrintService.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { renderElementToImageBlob } from '../ImageRenderService';
 import { PDFPrintService } from '../PDFPrintService';
+
+vi.mock('../ImageRenderService', () => ({
+  renderElementToImageBlob: vi.fn(async () => new Blob(['png'], { type: 'image/png' })),
+}));
 
 describe('PDFPrintService', () => {
   afterEach(() => {
@@ -10,6 +15,7 @@ describe('PDFPrintService', () => {
       /* ignore */
     }
     vi.useRealTimers();
+    vi.clearAllMocks();
     document.body.innerHTML = '';
     document.title = 'Gemini';
     try {
@@ -211,9 +217,17 @@ describe('PDFPrintService', () => {
             </code-block>
             <div class="gv-mermaid-toggle"><button>Diagram</button></div>
             <div class="gv-mermaid-diagram">
-              <svg data-render-theme="dark" viewBox="0 0 120 80"><g><text>A</text><text>B</text></g></svg>
+              <svg data-render-theme="dark" viewBox="0 0 640 1190"><g><text>A</text><text>B</text></g></svg>
             </div>
-            <template class="gv-mermaid-light-export"><svg data-export-theme="light" viewBox="0 0 120 80"><g><text>A</text><text>B</text></g></svg></template>
+            <template class="gv-mermaid-light-export">
+              <svg data-export-theme="light" viewBox="0 0 640 1190">
+                <foreignObject width="160" height="24">
+                  <div xmlns="http://www.w3.org/1999/xhtml" style="display: table-cell">
+                    <span class="nodeLabel"><p>核心能力构建</p></span>
+                  </div>
+                </foreignObject>
+              </svg>
+            </template>
           </div>
         </div>
       </message-content>
@@ -231,25 +245,79 @@ describe('PDFPrintService', () => {
 
     const turnText = document.querySelector('.gv-print-turn-assistant .gv-print-turn-text');
     const styleText = document.getElementById('gv-pdf-print-styles')?.textContent ?? '';
-    expect(turnText?.querySelector('.gv-export-mermaid svg')).toBeTruthy();
+    const mermaidImage = turnText?.querySelector<HTMLImageElement>(
+      '.gv-export-mermaid img.gv-export-mermaid-image',
+    );
+    const dataUrl = mermaidImage?.getAttribute('src') || '';
+    expect(mermaidImage).toBeTruthy();
+    expect(dataUrl).toMatch(/^data:image\/png;base64,/);
+    expect(turnText?.querySelector('.gv-export-mermaid svg')).toBeNull();
     expect(turnText?.querySelector('pre, code-block, .gv-mermaid-toggle')).toBeNull();
     expect(styleText).toContain('.gv-print-turn-text .gv-export-mermaid');
-    expect(styleText).toContain('.gv-print-turn-text .gv-export-mermaid svg {');
+    expect(styleText).toContain('.gv-print-turn-text .gv-export-mermaid > img {');
     expect(styleText).toContain('display: block !important;');
     expect(styleText).toContain('break-inside: avoid;');
     expect(styleText).toContain('page-break-inside: avoid;');
     expect(styleText).toContain('max-width: 100%;');
     expect(styleText).toContain('height: auto;');
+    expect(styleText).toContain('max-height: 160mm;');
+    expect(styleText).toContain('object-fit: contain;');
+    expect(vi.mocked(renderElementToImageBlob)).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ pixelRatio: 2 }),
+    );
+    expect(turnText?.textContent).not.toContain('核心能力构建');
     expect(
       turnText?.querySelector('.gv-export-mermaid')?.getAttribute('data-gv-mermaid-theme'),
-    ).toBe('light');
-    expect(
-      turnText?.querySelector('.gv-export-mermaid svg')?.getAttribute('data-export-theme'),
     ).toBe('light');
     expect(styleText).not.toContain('.gv-export-mermaid[data-gv-mermaid-theme="dark"]');
     expect(styleText).not.toContain('background: #1f2020;');
     expect(styleText).toContain('print-color-adjust: exact;');
     expect(styleText).toContain('-webkit-print-color-adjust: exact;');
+  });
+
+  it('falls back to an isolated Mermaid SVG image when rasterization fails', async () => {
+    window.print = vi.fn();
+    vi.mocked(renderElementToImageBlob).mockRejectedValueOnce(
+      new Error('Mermaid rasterization failed'),
+    );
+    const assistantElement = document.createElement('div');
+    assistantElement.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <div class="gv-mermaid-wrapper" data-gv-mermaid-theme="light">
+            <code-block style="display: none;">
+              <div class="code-block-decoration">mermaid</div>
+              <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
+            </code-block>
+            <div class="gv-mermaid-diagram">
+              <svg aria-label="Workflow diagram" viewBox="0 0 640 480">
+                <g><text>A</text><text>B</text></g>
+              </svg>
+            </div>
+          </div>
+        </div>
+      </message-content>
+    `;
+
+    await PDFPrintService.export(
+      [{ user: 'Diagram', assistant: '', starred: false, assistantElement }],
+      {
+        url: 'https://gemini.google.com/app/x',
+        exportedAt: new Date().toISOString(),
+        count: 1,
+        title: 'Mermaid Fallback Export',
+      },
+    );
+
+    const wrapper = document.querySelector<HTMLElement>(
+      '.gv-print-turn-assistant .gv-export-mermaid',
+    );
+    const image = wrapper?.querySelector<HTMLImageElement>('img.gv-export-mermaid-image');
+    expect(image?.src).toMatch(/^data:image\/svg\+xml;charset=utf-8,/);
+    expect(image?.alt).toBe('Workflow diagram');
+    expect(wrapper?.querySelector('svg')).toBeNull();
+    expect(wrapper?.getAttribute('data-gv-mermaid-theme')).toBe('light');
   });
 
   it('normalizes metadata title suffix when page title is generic', async () => {

--- a/src/features/export/services/__tests__/PDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/PDFPrintService.test.ts
@@ -198,6 +198,47 @@ describe('PDFPrintService', () => {
     expect(styleText).toContain('.gv-print-turn-text .gv-export-attachment');
   });
 
+  it('renders Mermaid SVG with print-safe scoped styles', async () => {
+    window.print = vi.fn();
+    const assistantElement = document.createElement('div');
+    assistantElement.innerHTML = `
+      <message-content>
+        <div class="markdown">
+          <div class="gv-mermaid-wrapper">
+            <code-block style="display: none;">
+              <div class="code-block-decoration">mermaid</div>
+              <pre><code role="text">flowchart TD\nA --&gt; B</code></pre>
+            </code-block>
+            <div class="gv-mermaid-toggle"><button>Diagram</button></div>
+            <div class="gv-mermaid-diagram">
+              <svg viewBox="0 0 120 80"><g><text>A</text><text>B</text></g></svg>
+            </div>
+          </div>
+        </div>
+      </message-content>
+    `;
+
+    await PDFPrintService.export(
+      [{ user: 'Diagram', assistant: '', starred: false, assistantElement }],
+      {
+        url: 'https://gemini.google.com/app/x',
+        exportedAt: new Date().toISOString(),
+        count: 1,
+        title: 'Mermaid Export',
+      },
+    );
+
+    const turnText = document.querySelector('.gv-print-turn-assistant .gv-print-turn-text');
+    const styleText = document.getElementById('gv-pdf-print-styles')?.textContent ?? '';
+    expect(turnText?.querySelector('.gv-export-mermaid svg')).toBeTruthy();
+    expect(turnText?.querySelector('pre, code-block, .gv-mermaid-toggle')).toBeNull();
+    expect(styleText).toContain('.gv-print-turn-text .gv-export-mermaid');
+    expect(styleText).toContain('break-inside: avoid;');
+    expect(styleText).toContain('page-break-inside: avoid;');
+    expect(styleText).toContain('max-width: 100%;');
+    expect(styleText).toContain('height: auto;');
+  });
+
   it('normalizes metadata title suffix when page title is generic', async () => {
     document.title = 'Gemini';
     window.print = vi.fn();

--- a/src/features/export/services/mermaidExportStyles.ts
+++ b/src/features/export/services/mermaidExportStyles.ts
@@ -6,6 +6,7 @@ interface MermaidExportStyleOptions {
   diagramMargin?: string;
   importantDisplay?: boolean;
   avoidDiagramBreak?: boolean;
+  diagramMaxHeight?: string;
   preservePrintBackground?: boolean;
 }
 
@@ -34,6 +35,11 @@ export function buildMermaidExportStyles(
         break-inside: avoid;
         page-break-inside: avoid;`
     : '';
+  const diagramMaxHeight = options.diagramMaxHeight
+    ? `
+        max-height: ${options.diagramMaxHeight};
+        object-fit: contain;`
+    : '';
   const printBackgroundStyles = options.preservePrintBackground
     ? `
         print-color-adjust: exact;
@@ -49,7 +55,7 @@ export function buildMermaidExportStyles(
         display: block${displayImportant};
         max-width: 100%;
         height: auto;
-        margin: ${diagramMargin};${diagramBreakStyles}
+        margin: ${diagramMargin};${diagramBreakStyles}${diagramMaxHeight}
       }
 
   `;

--- a/src/features/export/services/mermaidExportStyles.ts
+++ b/src/features/export/services/mermaidExportStyles.ts
@@ -42,7 +42,7 @@ export function buildMermaidExportStyles(
 
   return `
       ${scope} .gv-export-mermaid {${containerMargin}${containerMaxWidth}
-        text-align: center;${containerBreakStyles}
+        text-align: center;${containerBreakStyles}${printBackgroundStyles}
       }
 
       ${scope} .gv-export-mermaid ${diagramSelector} {
@@ -52,10 +52,5 @@ export function buildMermaidExportStyles(
         margin: ${diagramMargin};${diagramBreakStyles}
       }
 
-      ${scope} .gv-export-mermaid[data-gv-mermaid-theme="dark"] {
-        background: #1f2020;
-        padding: 16px;
-        border-radius: 8px;${printBackgroundStyles}
-      }
   `;
 }

--- a/src/features/export/services/mermaidExportStyles.ts
+++ b/src/features/export/services/mermaidExportStyles.ts
@@ -1,0 +1,61 @@
+interface MermaidExportStyleOptions {
+  containerMargin?: string;
+  containerMaxWidth?: boolean;
+  avoidContainerBreak?: boolean;
+  diagramSelector?: 'svg' | '> img';
+  diagramMargin?: string;
+  importantDisplay?: boolean;
+  avoidDiagramBreak?: boolean;
+  preservePrintBackground?: boolean;
+}
+
+export function buildMermaidExportStyles(
+  scope: string,
+  options: MermaidExportStyleOptions = {},
+): string {
+  const diagramSelector = options.diagramSelector ?? 'svg';
+  const diagramMargin = options.diagramMargin ?? '0 auto';
+  const displayImportant = options.importantDisplay ? ' !important' : '';
+  const containerMargin = options.containerMargin
+    ? `
+        margin: ${options.containerMargin};`
+    : '';
+  const containerMaxWidth = options.containerMaxWidth
+    ? `
+        max-width: 100%;`
+    : '';
+  const containerBreakStyles = options.avoidContainerBreak
+    ? `
+        break-inside: avoid;
+        page-break-inside: avoid;`
+    : '';
+  const diagramBreakStyles = options.avoidDiagramBreak
+    ? `
+        break-inside: avoid;
+        page-break-inside: avoid;`
+    : '';
+  const printBackgroundStyles = options.preservePrintBackground
+    ? `
+        print-color-adjust: exact;
+        -webkit-print-color-adjust: exact;`
+    : '';
+
+  return `
+      ${scope} .gv-export-mermaid {${containerMargin}${containerMaxWidth}
+        text-align: center;${containerBreakStyles}
+      }
+
+      ${scope} .gv-export-mermaid ${diagramSelector} {
+        display: block${displayImportant};
+        max-width: 100%;
+        height: auto;
+        margin: ${diagramMargin};${diagramBreakStyles}
+      }
+
+      ${scope} .gv-export-mermaid[data-gv-mermaid-theme="dark"] {
+        background: #1f2020;
+        padding: 16px;
+        border-radius: 8px;${printBackgroundStyles}
+      }
+  `;
+}

--- a/src/features/export/services/mermaidSvgImage.ts
+++ b/src/features/export/services/mermaidSvgImage.ts
@@ -1,0 +1,135 @@
+import { renderElementToImageBlob } from './ImageRenderService';
+
+const MERMAID_EXPORT_SELECTOR = '.gv-export-mermaid';
+export const MERMAID_EXPORT_IMAGE_CLASS = 'gv-export-mermaid-image';
+const MERMAID_PRINT_PIXEL_RATIO = 2;
+const MERMAID_PRINT_MAX_WIDTH = 720;
+const MERMAID_PRINT_MIN_WIDTH = 360;
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('readAsDataURL failed'));
+    reader.onload = () => resolve(String(reader.result || ''));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function getSvgRenderWidth(svg: SVGSVGElement): number {
+  const viewBoxWidth = Number(svg.getAttribute('viewBox')?.trim().split(/\s+/)[2]);
+  const preferredWidth =
+    Number.isFinite(viewBoxWidth) && viewBoxWidth > 0 ? viewBoxWidth : MERMAID_PRINT_MAX_WIDTH;
+  return Math.round(
+    Math.min(MERMAID_PRINT_MAX_WIDTH, Math.max(MERMAID_PRINT_MIN_WIDTH, preferredWidth)),
+  );
+}
+
+function createMermaidImage(svg: SVGSVGElement, src: string): HTMLImageElement {
+  const image = document.createElement('img');
+  image.className = MERMAID_EXPORT_IMAGE_CLASS;
+  image.alt = svg.getAttribute('aria-label') || 'Mermaid diagram';
+  const width = svg.getAttribute('width') || svg.style.width;
+  if (width) image.style.width = width;
+  if (svg.style.maxWidth) image.style.maxWidth = svg.style.maxWidth;
+  image.src = src;
+  return image;
+}
+
+function createIsolatedMermaidSvgImage(svg: SVGSVGElement): HTMLImageElement | null {
+  try {
+    const cleanSvg = svg.cloneNode(true) as SVGSVGElement;
+    cleanSvg.querySelectorAll('script, template').forEach((element) => element.remove());
+
+    const svgElements: Element[] = [cleanSvg, ...Array.from(cleanSvg.querySelectorAll('*'))];
+    svgElements.forEach((element) => {
+      Array.from(element.attributes).forEach((attribute) => {
+        if (attribute.name.toLowerCase().startsWith('on')) {
+          element.removeAttribute(attribute.name);
+        }
+      });
+    });
+
+    const serializedSvg = new XMLSerializer().serializeToString(cleanSvg);
+    return createMermaidImage(
+      svg,
+      `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serializedSvg)}`,
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Isolate Mermaid's embedded SVG styles from host-page CSS while keeping the
+ * diagram as scalable SVG data rather than rasterizing it.
+ */
+export function isolateMermaidSvgImages(container: ParentNode): void {
+  const svgs = Array.from(
+    container.querySelectorAll<SVGSVGElement>(`${MERMAID_EXPORT_SELECTOR} svg`),
+  );
+
+  svgs.forEach((svg) => {
+    const image = createIsolatedMermaidSvgImage(svg);
+    if (image) svg.replaceWith(image);
+  });
+}
+
+/**
+ * Browser PDF renderers can drop Mermaid SVG text nodes. Render only the diagram
+ * to a high-resolution PNG first, leaving the rest of the PDF as native text.
+ */
+export async function rasterizeMermaidSvgImages(container: ParentNode): Promise<void> {
+  const svgs = Array.from(
+    container.querySelectorAll<SVGSVGElement>(`${MERMAID_EXPORT_SELECTOR} svg`),
+  );
+
+  for (const svg of svgs) {
+    const stage = document.createElement('div');
+    const wrapper = svg.closest<HTMLElement>(MERMAID_EXPORT_SELECTOR);
+    const renderTarget = (wrapper?.cloneNode(true) ?? svg.cloneNode(true)) as HTMLElement;
+    const renderSvg = renderTarget.matches('svg')
+      ? (renderTarget as unknown as SVGSVGElement)
+      : renderTarget.querySelector<SVGSVGElement>('svg');
+    if (!renderSvg) continue;
+
+    const renderWidth = getSvgRenderWidth(svg);
+    Object.assign(stage.style, {
+      position: 'fixed',
+      left: '-10000px',
+      top: '0',
+      width: `${renderWidth}px`,
+      background: '#ffffff',
+      color: '#333333',
+      zIndex: '-1',
+      pointerEvents: 'none',
+    } as Partial<CSSStyleDeclaration>);
+    Object.assign(renderTarget.style, {
+      display: 'block',
+      width: `${renderWidth}px`,
+      maxWidth: 'none',
+      background: '#ffffff',
+    } as Partial<CSSStyleDeclaration>);
+    renderSvg.style.setProperty('display', 'block', 'important');
+    renderSvg.style.setProperty('width', '100%', 'important');
+    renderSvg.style.setProperty('height', 'auto', 'important');
+    renderSvg.style.setProperty('max-width', 'none', 'important');
+
+    stage.appendChild(renderTarget);
+    document.body.appendChild(stage);
+
+    try {
+      const blob = await renderElementToImageBlob(renderTarget, {
+        pixelRatio: MERMAID_PRINT_PIXEL_RATIO,
+        maxAttempts: 2,
+        retryDelayMs: 120,
+        shouldRetry: () => true,
+      });
+      svg.replaceWith(createMermaidImage(svg, await blobToDataUrl(blob)));
+    } catch {
+      const image = createIsolatedMermaidSvgImage(svg);
+      if (image) svg.replaceWith(image);
+    } finally {
+      stage.remove();
+    }
+  }
+}

--- a/src/pages/content/mermaid/__tests__/mermaid.test.ts
+++ b/src/pages/content/mermaid/__tests__/mermaid.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  _initMermaidForTest,
   _openFullscreenForTest,
   _renderMermaidForTest,
   _resetMermaidLoader,
@@ -24,6 +25,8 @@ describe('Mermaid dynamic loading', () => {
   beforeEach(() => {
     _resetMermaidLoader();
     vi.clearAllMocks();
+    document.body.innerHTML = '';
+    document.body.className = '';
   });
 
   describe('loadMermaid', () => {
@@ -120,8 +123,21 @@ describe('Mermaid dynamic loading', () => {
   });
 
   describe('rendered diagram theme marker', () => {
-    const renderIntoTheme = async (theme: 'dark' | 'light'): Promise<HTMLElement | null> => {
+    const setPageTheme = (theme: 'dark' | 'light') => {
       document.body.className = theme === 'dark' ? 'dark-theme' : '';
+    };
+
+    const initializeTheme = async (theme: 'dark' | 'light') => {
+      setPageTheme(theme);
+      await _initMermaidForTest();
+
+      const mermaid = await loadMermaid();
+      expect(mermaid?.initialize).toHaveBeenLastCalledWith(
+        expect.objectContaining({ theme: theme === 'dark' ? 'dark' : 'default' }),
+      );
+    };
+
+    const renderDiagram = async (): Promise<HTMLElement | null> => {
       const host = document.createElement('code-block');
       const code = document.createElement('code');
       host.appendChild(code);
@@ -136,6 +152,15 @@ describe('Mermaid dynamic loading', () => {
       return host.parentElement;
     };
 
+    const renderIntoTheme = async (
+      initialTheme: 'dark' | 'light',
+      renderTheme: 'dark' | 'light' = initialTheme,
+    ): Promise<HTMLElement | null> => {
+      await initializeTheme(initialTheme);
+      setPageTheme(renderTheme);
+      return renderDiagram();
+    };
+
     it('marks rendered Mermaid wrappers with the active dark theme', async () => {
       const wrapper = await renderIntoTheme('dark');
 
@@ -144,6 +169,50 @@ describe('Mermaid dynamic loading', () => {
 
     it('marks rendered Mermaid wrappers with the active light theme', async () => {
       const wrapper = await renderIntoTheme('light');
+
+      expect(wrapper?.dataset.gvMermaidTheme).toBe('light');
+    });
+
+    it('keeps the dark marker after the page switches to light mode', async () => {
+      const wrapper = await renderIntoTheme('dark', 'light');
+
+      expect(wrapper?.dataset.gvMermaidTheme).toBe('dark');
+    });
+
+    it('keeps the light marker after the page switches to dark mode', async () => {
+      const wrapper = await renderIntoTheme('light', 'dark');
+
+      expect(wrapper?.dataset.gvMermaidTheme).toBe('light');
+    });
+
+    it('does not retain a reset Mermaid theme after reinitialization', async () => {
+      await initializeTheme('dark');
+      _resetMermaidLoader();
+
+      const wrapperAfterReset = await renderDiagram();
+      expect(wrapperAfterReset?.dataset.gvMermaidTheme).toBeUndefined();
+
+      await initializeTheme('light');
+      setPageTheme('dark');
+      const wrapperAfterReinitialization = await renderDiagram();
+
+      expect(wrapperAfterReinitialization?.dataset.gvMermaidTheme).toBe('light');
+    });
+
+    it('does not write a marker when Mermaid has not initialized', async () => {
+      setPageTheme('dark');
+
+      const wrapper = await renderDiagram();
+
+      expect(wrapper?.dataset.gvMermaidTheme).toBeUndefined();
+    });
+
+    it('updates the marker when Mermaid initializes again without a reset', async () => {
+      await initializeTheme('dark');
+      await initializeTheme('light');
+      setPageTheme('dark');
+
+      const wrapper = await renderDiagram();
 
       expect(wrapper?.dataset.gvMermaidTheme).toBe('light');
     });

--- a/src/pages/content/mermaid/__tests__/mermaid.test.ts
+++ b/src/pages/content/mermaid/__tests__/mermaid.test.ts
@@ -137,15 +137,21 @@ describe('Mermaid dynamic loading', () => {
       );
     };
 
-    const renderDiagram = async (): Promise<HTMLElement | null> => {
+    const renderDiagram = async (failLightExport = false): Promise<HTMLElement | null> => {
       const host = document.createElement('code-block');
       const code = document.createElement('code');
       host.appendChild(code);
       document.body.appendChild(host);
 
       const mermaid = await loadMermaid();
-      (mermaid?.render as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
-        '<svg viewBox="0 0 120 80"></svg>',
+      (mermaid?.render as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+        async (_id: string, source: string) => {
+          if (source.includes('config:\n  theme: default')) {
+            if (failLightExport) throw new Error('light export failed');
+            return { svg: '<svg data-export-theme="light" viewBox="0 0 120 80"></svg>' };
+          }
+          return '<svg data-page-theme="active" viewBox="0 0 120 80"></svg>';
+        },
       );
 
       await _renderMermaidForTest(code, 'flowchart TD\nA --> B\nB --> C');
@@ -165,12 +171,34 @@ describe('Mermaid dynamic loading', () => {
       const wrapper = await renderIntoTheme('dark');
 
       expect(wrapper?.dataset.gvMermaidTheme).toBe('dark');
+      expect(
+        wrapper
+          ?.querySelector<HTMLTemplateElement>('template.gv-mermaid-light-export')
+          ?.content.querySelector('svg')
+          ?.getAttribute('data-export-theme'),
+      ).toBe('light');
+      const mermaid = await loadMermaid();
+      const renderMock = mermaid?.render as unknown as ReturnType<typeof vi.fn>;
+      expect(renderMock).toHaveBeenCalledTimes(2);
+      expect(renderMock.mock.calls[1][1]).toMatch(
+        /^---\nconfig:\n  theme: default\n---\nflowchart TD/,
+      );
     });
 
     it('marks rendered Mermaid wrappers with the active light theme', async () => {
       const wrapper = await renderIntoTheme('light');
 
       expect(wrapper?.dataset.gvMermaidTheme).toBe('light');
+      expect(wrapper?.querySelector('template.gv-mermaid-light-export')).toBeNull();
+    });
+
+    it('keeps the page diagram when light export rendering fails', async () => {
+      await initializeTheme('dark');
+
+      const wrapper = await renderDiagram(true);
+
+      expect(wrapper?.querySelector('.gv-mermaid-diagram svg')).toBeTruthy();
+      expect(wrapper?.querySelector('template.gv-mermaid-light-export')).toBeNull();
     });
 
     it('keeps the dark marker after the page switches to light mode', async () => {

--- a/src/pages/content/mermaid/__tests__/mermaid.test.ts
+++ b/src/pages/content/mermaid/__tests__/mermaid.test.ts
@@ -137,7 +137,10 @@ describe('Mermaid dynamic loading', () => {
       );
     };
 
-    const renderDiagram = async (failLightExport = false): Promise<HTMLElement | null> => {
+    const renderDiagram = async (
+      failLightExport = false,
+      source = 'flowchart TD\nA --> B\nB --> C',
+    ): Promise<HTMLElement | null> => {
       const host = document.createElement('code-block');
       const code = document.createElement('code');
       host.appendChild(code);
@@ -146,7 +149,7 @@ describe('Mermaid dynamic loading', () => {
       const mermaid = await loadMermaid();
       (mermaid?.render as unknown as ReturnType<typeof vi.fn>).mockImplementation(
         async (_id: string, source: string) => {
-          if (source.includes('config:\n  theme: default')) {
+          if (source.endsWith('%%{init: {"theme":"default"}}%%')) {
             if (failLightExport) throw new Error('light export failed');
             return { svg: '<svg data-export-theme="light" viewBox="0 0 120 80"></svg>' };
           }
@@ -154,7 +157,7 @@ describe('Mermaid dynamic loading', () => {
         },
       );
 
-      await _renderMermaidForTest(code, 'flowchart TD\nA --> B\nB --> C');
+      await _renderMermaidForTest(code, source);
       return host.parentElement;
     };
 
@@ -180,9 +183,27 @@ describe('Mermaid dynamic loading', () => {
       const mermaid = await loadMermaid();
       const renderMock = mermaid?.render as unknown as ReturnType<typeof vi.fn>;
       expect(renderMock).toHaveBeenCalledTimes(2);
-      expect(renderMock.mock.calls[1][1]).toMatch(
-        /^---\nconfig:\n  theme: default\n---\nflowchart TD/,
+      expect(renderMock.mock.calls[1][1]).toBe(
+        'flowchart TD\nA --> B\nB --> C\n%%{init: {"theme":"default"}}%%',
       );
+    });
+
+    it('keeps existing frontmatter before the cross-version light theme directive', async () => {
+      await initializeTheme('dark');
+      const mermaid = await loadMermaid();
+      const renderMock = mermaid?.render as unknown as ReturnType<typeof vi.fn>;
+      const source = `---
+title: Existing metadata
+config:
+  theme: dark
+---
+flowchart TD
+A --> B
+B --> C`;
+
+      await renderDiagram(false, source);
+
+      expect(renderMock.mock.calls[1][1]).toBe(`${source}\n%%{init: {"theme":"default"}}%%`);
     });
 
     it('marks rendered Mermaid wrappers with the active light theme', async () => {

--- a/src/pages/content/mermaid/__tests__/mermaid.test.ts
+++ b/src/pages/content/mermaid/__tests__/mermaid.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   _openFullscreenForTest,
+  _renderMermaidForTest,
   _resetMermaidLoader,
   isGenericLanguageLabel,
   isMermaidCode,
@@ -115,6 +116,36 @@ describe('Mermaid dynamic loading', () => {
       vi.runAllTimers();
       expect(document.querySelector('.gv-mermaid-modal')).toBeNull();
       vi.useRealTimers();
+    });
+  });
+
+  describe('rendered diagram theme marker', () => {
+    const renderIntoTheme = async (theme: 'dark' | 'light'): Promise<HTMLElement | null> => {
+      document.body.className = theme === 'dark' ? 'dark-theme' : '';
+      const host = document.createElement('code-block');
+      const code = document.createElement('code');
+      host.appendChild(code);
+      document.body.appendChild(host);
+
+      const mermaid = await loadMermaid();
+      (mermaid?.render as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+        '<svg viewBox="0 0 120 80"></svg>',
+      );
+
+      await _renderMermaidForTest(code, 'flowchart TD\nA --> B\nB --> C');
+      return host.parentElement;
+    };
+
+    it('marks rendered Mermaid wrappers with the active dark theme', async () => {
+      const wrapper = await renderIntoTheme('dark');
+
+      expect(wrapper?.dataset.gvMermaidTheme).toBe('dark');
+    });
+
+    it('marks rendered Mermaid wrappers with the active light theme', async () => {
+      const wrapper = await renderIntoTheme('light');
+
+      expect(wrapper?.dataset.gvMermaidTheme).toBe('light');
     });
   });
 

--- a/src/pages/content/mermaid/index.ts
+++ b/src/pages/content/mermaid/index.ts
@@ -10,6 +10,12 @@ type MermaidTheme = 'dark' | 'light';
 
 let initializedMermaidTheme: MermaidTheme | null = null;
 
+const MERMAID_LIGHT_EXPORT_TEMPLATE_CLASS = 'gv-mermaid-light-export';
+const MERMAID_LIGHT_THEME_FRONTMATTER = `---
+config:
+  theme: default
+---`;
+
 const getMermaidTheme = (): MermaidTheme => {
   const isDarkMode =
     document.body.classList.contains('dark-theme') ||
@@ -613,11 +619,13 @@ const renderMermaid = async (codeBlock: HTMLElement, code: string) => {
     // First, try to render to validate the code
     const uniqueId = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
     let svg: string;
+    let renderedDiagram = false;
 
     try {
       // v9.x render returns string directly, v10.x returns {svg: string}
       const result = await mermaid.render(uniqueId, normalizedCode);
       svg = typeof result === 'string' ? result : (result as { svg: string }).svg;
+      renderedDiagram = true;
     } catch (renderError) {
       // Mermaid failed - likely incomplete or invalid syntax
 
@@ -643,6 +651,21 @@ const renderMermaid = async (codeBlock: HTMLElement, code: string) => {
                     <div style="margin-top: 12px; font-size: 13px;">Click <b>"&lt;/&gt; Code"</b> to view source</div>
                 </div>
             `;
+    }
+
+    let lightExportSvg: string | null = null;
+    if (renderedDiagram && initializedMermaidTheme === 'dark') {
+      const exportId = `${uniqueId}-export`;
+      try {
+        const exportResult = await mermaid.render(
+          exportId,
+          `${MERMAID_LIGHT_THEME_FRONTMATTER}\n${normalizedCode}`,
+        );
+        lightExportSvg =
+          typeof exportResult === 'string' ? exportResult : (exportResult as { svg: string }).svg;
+      } catch {
+        document.getElementById(exportId)?.remove();
+      }
     }
 
     // Rendering succeeded! Now create or update the UI
@@ -722,6 +745,18 @@ const renderMermaid = async (codeBlock: HTMLElement, code: string) => {
 
     if (initializedMermaidTheme) {
       wrapper.dataset.gvMermaidTheme = initializedMermaidTheme;
+    }
+
+    const existingLightExport = wrapper.querySelector<HTMLTemplateElement>(
+      `template.${MERMAID_LIGHT_EXPORT_TEMPLATE_CLASS}`,
+    );
+    if (lightExportSvg) {
+      const lightExport = existingLightExport ?? document.createElement('template');
+      lightExport.className = MERMAID_LIGHT_EXPORT_TEMPLATE_CLASS;
+      lightExport.innerHTML = lightExportSvg;
+      if (!existingLightExport) wrapper.appendChild(lightExport);
+    } else {
+      existingLightExport?.remove();
     }
 
     const diagramContainer = wrapper.querySelector('.gv-mermaid-diagram') as HTMLElement;

--- a/src/pages/content/mermaid/index.ts
+++ b/src/pages/content/mermaid/index.ts
@@ -13,16 +13,6 @@ let initializedMermaidTheme: MermaidTheme | null = null;
 const MERMAID_LIGHT_EXPORT_TEMPLATE_CLASS = 'gv-mermaid-light-export';
 const MERMAID_LIGHT_THEME_DIRECTIVE = '%%{init: {"theme":"default"}}%%';
 
-const getMermaidTheme = (): MermaidTheme => {
-  const isDarkMode =
-    document.body.classList.contains('dark-theme') ||
-    document.body.getAttribute('data-theme') === 'dark' ||
-    document.documentElement.classList.contains('dark') ||
-    window.matchMedia('(prefers-color-scheme: dark)').matches;
-
-  return isDarkMode ? 'dark' : 'light';
-};
-
 /**
  * Reset internal loader state. Only for testing.
  * @internal
@@ -85,6 +75,12 @@ export function resolveMermaidTheme(doc: Document, prefersDark: boolean): 'dark'
   return prefersDark ? 'dark' : 'default';
 }
 
+const getMermaidTheme = (): MermaidTheme =>
+  resolveMermaidTheme(document, window.matchMedia('(prefers-color-scheme: dark)').matches) ===
+  'dark'
+    ? 'dark'
+    : 'light';
+
 /**
  * Initialize Mermaid configuration
  */
@@ -92,11 +88,7 @@ const initMermaid = async (): Promise<boolean> => {
   const mermaid = await loadMermaid();
   if (!mermaid) return false;
 
-  const theme: MermaidTheme =
-    resolveMermaidTheme(document, window.matchMedia('(prefers-color-scheme: dark)').matches) ===
-    'dark'
-      ? 'dark'
-      : 'light';
+  const theme = getMermaidTheme();
 
   mermaid.initialize({
     startOnLoad: false,

--- a/src/pages/content/mermaid/index.ts
+++ b/src/pages/content/mermaid/index.ts
@@ -11,10 +11,7 @@ type MermaidTheme = 'dark' | 'light';
 let initializedMermaidTheme: MermaidTheme | null = null;
 
 const MERMAID_LIGHT_EXPORT_TEMPLATE_CLASS = 'gv-mermaid-light-export';
-const MERMAID_LIGHT_THEME_FRONTMATTER = `---
-config:
-  theme: default
----`;
+const MERMAID_LIGHT_THEME_DIRECTIVE = '%%{init: {"theme":"default"}}%%';
 
 const getMermaidTheme = (): MermaidTheme => {
   const isDarkMode =
@@ -659,7 +656,7 @@ const renderMermaid = async (codeBlock: HTMLElement, code: string) => {
       try {
         const exportResult = await mermaid.render(
           exportId,
-          `${MERMAID_LIGHT_THEME_FRONTMATTER}\n${normalizedCode}`,
+          `${normalizedCode}\n${MERMAID_LIGHT_THEME_DIRECTIVE}`,
         );
         lightExportSvg =
           typeof exportResult === 'string' ? exportResult : (exportResult as { svg: string }).svg;

--- a/src/pages/content/mermaid/index.ts
+++ b/src/pages/content/mermaid/index.ts
@@ -6,6 +6,18 @@
 let mermaidInstance: Awaited<typeof import('mermaid')>['default'] | null = null;
 let mermaidLoadFailed = false;
 
+type MermaidTheme = 'dark' | 'light';
+
+const getMermaidTheme = (): MermaidTheme => {
+  const isDarkMode =
+    document.body.classList.contains('dark-theme') ||
+    document.body.getAttribute('data-theme') === 'dark' ||
+    document.documentElement.classList.contains('dark') ||
+    window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+  return isDarkMode ? 'dark' : 'light';
+};
+
 /**
  * Reset internal loader state. Only for testing.
  * @internal
@@ -700,6 +712,8 @@ const renderMermaid = async (codeBlock: HTMLElement, code: string) => {
       });
     }
 
+    wrapper.dataset.gvMermaidTheme = getMermaidTheme();
+
     const diagramContainer = wrapper.querySelector('.gv-mermaid-diagram') as HTMLElement;
     if (!diagramContainer) {
       codeBlock.dataset.mermaidProcessing = 'false';
@@ -721,6 +735,9 @@ const renderMermaid = async (codeBlock: HTMLElement, code: string) => {
     }
   }
 };
+
+/** @internal Exported for theme-marker testing. */
+export const _renderMermaidForTest = renderMermaid;
 
 /**
  * Get the language label from a code block's header decoration

--- a/src/pages/content/mermaid/index.ts
+++ b/src/pages/content/mermaid/index.ts
@@ -8,6 +8,8 @@ let mermaidLoadFailed = false;
 
 type MermaidTheme = 'dark' | 'light';
 
+let initializedMermaidTheme: MermaidTheme | null = null;
+
 const getMermaidTheme = (): MermaidTheme => {
   const isDarkMode =
     document.body.classList.contains('dark-theme') ||
@@ -25,6 +27,7 @@ const getMermaidTheme = (): MermaidTheme => {
 export const _resetMermaidLoader = () => {
   mermaidInstance = null;
   mermaidLoadFailed = false;
+  initializedMermaidTheme = null;
 };
 
 /**
@@ -86,21 +89,26 @@ const initMermaid = async (): Promise<boolean> => {
   const mermaid = await loadMermaid();
   if (!mermaid) return false;
 
-  const theme = resolveMermaidTheme(
-    document,
-    window.matchMedia('(prefers-color-scheme: dark)').matches,
-  );
+  const theme: MermaidTheme =
+    resolveMermaidTheme(document, window.matchMedia('(prefers-color-scheme: dark)').matches) ===
+    'dark'
+      ? 'dark'
+      : 'light';
 
   mermaid.initialize({
     startOnLoad: false,
-    theme,
+    theme: theme === 'dark' ? 'dark' : 'default',
     securityLevel: 'loose',
     fontFamily: 'Google Sans, Roboto, sans-serif',
     logLevel: 5, // 5 = fatal, only log fatal errors (v9.x uses numbers)
   });
+  initializedMermaidTheme = theme;
 
   return true;
 };
+
+/** @internal Exported for theme-marker testing. */
+export const _initMermaidForTest = initMermaid;
 
 /**
  * Check if a code block contains Mermaid syntax and appears complete enough to render
@@ -712,7 +720,9 @@ const renderMermaid = async (codeBlock: HTMLElement, code: string) => {
       });
     }
 
-    wrapper.dataset.gvMermaidTheme = getMermaidTheme();
+    if (initializedMermaidTheme) {
+      wrapper.dataset.gvMermaidTheme = initializedMermaidTheme;
+    }
 
     const diagramContainer = wrapper.querySelector('.gv-mermaid-diagram') as HTMLElement;
     if (!diagramContainer) {


### PR DESCRIPTION
### AI-Assisted PR Policy / AI 辅助 PR 政策

- The maintainer reviewed the final scope, implementation, diff, and validation results.
- The expected behavior, affected export paths, fallback behavior, and verification plan were agreed before implementation.

---

### Description / 描述

Voyager rendered Mermaid blocks in Gemini, but rich exports could still select the hidden source block or lose SVG labels in browser PDF/PNG renderers. This PR now:

- exports rendered Mermaid diagrams for PDF and image output;
- preserves fenced Mermaid source for Markdown/text output;
- preserves list order, nested containers, neighboring code blocks, and the existing `hasCode` behavior;
- normalizes Mermaid export output to the existing light document surface;
- rasterizes only the Mermaid clone at 2x for browser-sensitive PDF and whole-document PNG rendering;
- keeps the rest of PDF content as native text;
- scales each diagram proportionally to no more than one printable page;
- falls back to a sanitized SVG data image if Mermaid-only rasterization fails;
- shares Mermaid sizing/isolation logic across conversation PDF, image export, and Deep Research PDF.

Root causes:

1. `.gv-mermaid-wrapper` contains both a hidden `code-block` and the rendered SVG, and generic code-block extraction could win before traversal reached the diagram.
2. Browser renderers can retain SVG geometry while dropping or clipping text inside Mermaid `foreignObject` labels.
3. The earlier rasterization error path left the raw SVG in the print DOM instead of applying the intended isolated-image fallback.

### Related work / 关联

- Closes #840
- Traditional Chinese source-page rendering was tracked separately in #855 and fixed through #856.
- Explicit Gemini Mermaid theme handling from #859 is preserved after rebasing onto current `main`.

### Browser verification / 浏览器验证

Final implementation head: `fb9ceb8e`

- **Chrome**: real Gemini conversation with a locally loaded Voyager build; PDF retained Mermaid labels, and a tall diagram stayed on one printable page.
- **Firefox 152.0.5**: temporary production `dist_firefox` on a real signed-out Gemini conversation; source page rendered the diagram, PDF retained all Chinese labels, PNG retained all labels without right-edge clipping, and Markdown preserved fenced Mermaid source.
- **Safari**: optional under `.github/CONTRIBUTING.md`. The previous community run on `3cb226b` was inconclusive because the source page had not rendered Mermaid. Safari image export is disabled by existing product guards, so it is not treated as a PNG merge gate.

The successful Chrome/Firefox workflows were run on `d43a3498`. The only delta in final `fb9ceb8e` is the induced rasterization-failure fallback; it is covered by a regression test that forces the renderer to reject and verifies the sanitized data image, removal of the raw SVG, wrapper theme metadata, and accessible label.

Detailed maintainer verification:
https://github.com/Nagi-ovo/voyager/pull/847#issuecomment-5071380082

### Validation

- `bun run test`: **248 files / 2284 tests passed**
- `bun run typecheck`: passed
- `bun run lint`: passed with **0 errors** (209 existing warnings)
- `bun run build:chrome`: passed
- `bun run build:firefox`: passed
- `git diff --check`: passed
- GitHub Actions CI is required again on the final head before merge.

### Acknowledgements

Thanks @hulyhulyhuly for the Safari report that exposed the separate Traditional Chinese source-page precondition and helped keep this PR scoped correctly.

### Checklist / 检查清单

- [x] The final implementation and affected export paths were reviewed.
- [x] Real Chrome and mandatory Firefox workflows were manually verified.
- [x] Markdown, PDF, PNG, nested list/code behavior, and failure fallback have regression coverage.
- [x] The change remains focused on Mermaid rendering inside exports.
- [x] Local lint, typecheck, full tests, and Chrome/Firefox builds pass.
