### PR TITLE
docs: fix broken README and changelog links

### DIFF
--- a/.github/README_AR.md
+++ b/.github/README_AR.md
@@ -14,10 +14,10 @@
     <img src="https://img.shields.io/badge/Brave-✓-FB542B?style=flat-square&logo=brave&logoColor=white" alt="Brave">
   </p>
   <p>
-    <img src="../badges/github-stars.svg" alt="GitHub stars">
-    <img src="../badges/github-forks.svg" alt="GitHub forks">
-    <img src="../badges/github-release.svg" alt="Latest version">
-    <img src="../badges/github-downloads.svg" alt="GitHub downloads">
+    <img src="../docs/public/badges/github-stars.svg" alt="GitHub stars">
+    <img src="../docs/public/badges/github-forks.svg" alt="GitHub forks">
+    <img src="../docs/public/badges/github-release.svg" alt="Latest version">
+    <img src="../docs/public/badges/github-downloads.svg" alt="GitHub downloads">
     <img src="https://img.shields.io/chrome-web-store/users/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store users">
     <img src="https://img.shields.io/chrome-web-store/rating/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store rating">
     <img src="https://img.shields.io/badge/edge%20users-50k%2B-0078D7?style=flat-square&logo=microsoftedge&logoColor=white" alt="Edge Add-ons users">
@@ -212,7 +212,7 @@
 
 نرحب بالمساهمات!
 
-- **Issues**: استخدم نماذجنا لـ [تقرير الأخطاء](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) أو [طلب الميزات](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml).
+- **Issues**: استخدم نماذجنا لـ [تقرير الأخطاء](https://github.com/Nagi-ovo/voyager/issues/new?template=bug_report.yml) أو [طلب الميزات](https://github.com/Nagi-ovo/voyager/issues/new?template=feature_request.yml).
 - **Pull Requests**: تحقق من [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 شكراً لمساعدتك في جعل Voyager أفضل! ❤️

--- a/.github/README_ES.md
+++ b/.github/README_ES.md
@@ -14,10 +14,10 @@
     <img src="https://img.shields.io/badge/Brave-✓-FB542B?style=flat-square&logo=brave&logoColor=white" alt="Brave">
   </p>
   <p>
-    <img src="../badges/github-stars.svg" alt="GitHub stars">
-    <img src="../badges/github-forks.svg" alt="GitHub forks">
-    <img src="../badges/github-release.svg" alt="Latest version">
-    <img src="../badges/github-downloads.svg" alt="GitHub downloads">
+    <img src="../docs/public/badges/github-stars.svg" alt="GitHub stars">
+    <img src="../docs/public/badges/github-forks.svg" alt="GitHub forks">
+    <img src="../docs/public/badges/github-release.svg" alt="Latest version">
+    <img src="../docs/public/badges/github-downloads.svg" alt="GitHub downloads">
     <img src="https://img.shields.io/chrome-web-store/users/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store users">
     <img src="https://img.shields.io/chrome-web-store/rating/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store rating">
     <img src="https://img.shields.io/badge/edge%20users-50k%2B-0078D7?style=flat-square&logo=microsoftedge&logoColor=white" alt="Edge Add-ons users">
@@ -212,7 +212,7 @@ Recomiendo encarecidamente **[Typeless (typeless.com)](https://www.typeless.com/
 
 ¡Damos la bienvenida a las contribuciones!
 
-- **Issues**: Usa nuestras plantillas de [informe de errores](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) o [solicitud de funcionalidades](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml).
+- **Issues**: Usa nuestras plantillas de [informe de errores](https://github.com/Nagi-ovo/voyager/issues/new?template=bug_report.yml) o [solicitud de funcionalidades](https://github.com/Nagi-ovo/voyager/issues/new?template=feature_request.yml).
 - **Pull Requests**: Revisa [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ¡Gracias por ayudar a que Voyager sea mejor! ❤️

--- a/.github/README_FR.md
+++ b/.github/README_FR.md
@@ -14,10 +14,10 @@
     <img src="https://img.shields.io/badge/Brave-✓-FB542B?style=flat-square&logo=brave&logoColor=white" alt="Brave">
   </p>
   <p>
-    <img src="../badges/github-stars.svg" alt="GitHub stars">
-    <img src="../badges/github-forks.svg" alt="GitHub forks">
-    <img src="../badges/github-release.svg" alt="Latest version">
-    <img src="../badges/github-downloads.svg" alt="GitHub downloads">
+    <img src="../docs/public/badges/github-stars.svg" alt="GitHub stars">
+    <img src="../docs/public/badges/github-forks.svg" alt="GitHub forks">
+    <img src="../docs/public/badges/github-release.svg" alt="Latest version">
+    <img src="../docs/public/badges/github-downloads.svg" alt="GitHub downloads">
     <img src="https://img.shields.io/chrome-web-store/users/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store users">
     <img src="https://img.shields.io/chrome-web-store/rating/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store rating">
     <img src="https://img.shields.io/badge/edge%20users-50k%2B-0078D7?style=flat-square&logo=microsoftedge&logoColor=white" alt="Edge Add-ons users">
@@ -212,7 +212,7 @@ Je recommande vivement **[Typeless (typeless.com)](https://www.typeless.com/?via
 
 Toute contribution est la bienvenue !
 
-- **Issues** : Utilisez nos templates de [bug report](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) ou [feature request](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml).
+- **Issues** : Utilisez nos templates de [bug report](https://github.com/Nagi-ovo/voyager/issues/new?template=bug_report.yml) ou [feature request](https://github.com/Nagi-ovo/voyager/issues/new?template=feature_request.yml).
 - **Pull Requests** : Consultez [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 Merci d'aider à rendre Voyager meilleur ! ❤️

--- a/.github/README_JA.md
+++ b/.github/README_JA.md
@@ -14,10 +14,10 @@
     <img src="https://img.shields.io/badge/Brave-✓-FB542B?style=flat-square&logo=brave&logoColor=white" alt="Brave">
   </p>
   <p>
-    <img src="../badges/github-stars.svg" alt="GitHub Star">
-    <img src="../badges/github-forks.svg" alt="GitHub Fork">
-    <img src="../badges/github-release.svg" alt="最新バージョン">
-    <img src="../badges/github-downloads.svg" alt="GitHub ダウンロード数">
+    <img src="../docs/public/badges/github-stars.svg" alt="GitHub Star">
+    <img src="../docs/public/badges/github-forks.svg" alt="GitHub Fork">
+    <img src="../docs/public/badges/github-release.svg" alt="最新バージョン">
+    <img src="../docs/public/badges/github-downloads.svg" alt="GitHub ダウンロード数">
     <img src="https://img.shields.io/chrome-web-store/users/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome ユーザー数">
     <img src="https://img.shields.io/chrome-web-store/rating/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome 評価">
     <img src="https://img.shields.io/badge/edge%20users-50k%2B-0078D7?style=flat-square&logo=microsoftedge&logoColor=white" alt="Edge ユーザー数">
@@ -212,7 +212,7 @@ Voyager の開発中、私は AI 音声入力ツール **[Typeless (typeless.com
 
 バグ報告、機能提案、ドキュメントの改善など、あらゆる貢献を歓迎します！
 
-- **Issues**: [バグ報告](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) または [機能提案](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml) テンプレートを使用してください。
+- **Issues**: [バグ報告](https://github.com/Nagi-ovo/voyager/issues/new?template=bug_report.yml) または [機能提案](https://github.com/Nagi-ovo/voyager/issues/new?template=feature_request.yml) テンプレートを使用してください。
 - **Pull Requests**: [CONTRIBUTING.md](./CONTRIBUTING.md) をご確認ください。
 
 <details>

--- a/.github/README_KO.md
+++ b/.github/README_KO.md
@@ -14,10 +14,10 @@
     <img src="https://img.shields.io/badge/Brave-✓-FB542B?style=flat-square&logo=brave&logoColor=white" alt="Brave">
   </p>
   <p>
-    <img src="../badges/github-stars.svg" alt="GitHub stars">
-    <img src="../badges/github-forks.svg" alt="GitHub forks">
-    <img src="../badges/github-release.svg" alt="Latest version">
-    <img src="../badges/github-downloads.svg" alt="GitHub downloads">
+    <img src="../docs/public/badges/github-stars.svg" alt="GitHub stars">
+    <img src="../docs/public/badges/github-forks.svg" alt="GitHub forks">
+    <img src="../docs/public/badges/github-release.svg" alt="Latest version">
+    <img src="../docs/public/badges/github-downloads.svg" alt="GitHub downloads">
     <img src="https://img.shields.io/chrome-web-store/users/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store users">
     <img src="https://img.shields.io/chrome-web-store/rating/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store rating">
     <img src="https://img.shields.io/badge/edge%20users-50k%2B-0078D7?style=flat-square&logo=microsoftedge&logoColor=white" alt="Edge Add-ons users">
@@ -237,7 +237,7 @@ Voyager 개발 중에 광범위하게 사용한 AI 음성 - 텍스트 변환 도
 
 여러분의 기여를 환영합니다! 버그 보고, 기능 제안, 문서 개선 또는 코드 제출 등 무엇이든 환영합니다:
 
-- **이슈**: [버그 보고](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) 또는 [기능 제안](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml) 템플릿을 사용하세요.
+- **이슈**: [버그 보고](https://github.com/Nagi-ovo/voyager/issues/new?template=bug_report.yml) 또는 [기능 제안](https://github.com/Nagi-ovo/voyager/issues/new?template=feature_request.yml) 템플릿을 사용하세요.
 - **풀 리퀘스트**: 가이드라인은 [CONTRIBUTING.md](../.github/CONTRIBUTING.md)를 확인하세요.
 
 <details>

--- a/.github/README_PT.md
+++ b/.github/README_PT.md
@@ -14,10 +14,10 @@
     <img src="https://img.shields.io/badge/Brave-✓-FB542B?style=flat-square&logo=brave&logoColor=white" alt="Brave">
   </p>
   <p>
-    <img src="../badges/github-stars.svg" alt="GitHub stars">
-    <img src="../badges/github-forks.svg" alt="GitHub forks">
-    <img src="../badges/github-release.svg" alt="Latest version">
-    <img src="../badges/github-downloads.svg" alt="GitHub downloads">
+    <img src="../docs/public/badges/github-stars.svg" alt="GitHub stars">
+    <img src="../docs/public/badges/github-forks.svg" alt="GitHub forks">
+    <img src="../docs/public/badges/github-release.svg" alt="Latest version">
+    <img src="../docs/public/badges/github-downloads.svg" alt="GitHub downloads">
     <img src="https://img.shields.io/chrome-web-store/users/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store users">
     <img src="https://img.shields.io/chrome-web-store/rating/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store rating">
     <img src="https://img.shields.io/badge/edge%20users-50k%2B-0078D7?style=flat-square&logo=microsoftedge&logoColor=white" alt="Edge Add-ons users">
@@ -218,7 +218,7 @@ Recomendo vivamente o **[Typeless (typeless.com)](https://www.typeless.com/?via=
 
 Damos as boas-vindas a contribuições!
 
-- **Issues**: Use os nossos templates de [relatório de erros](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) ou [pedido de funcionalidade](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml).
+- **Issues**: Use os nossos templates de [relatório de erros](https://github.com/Nagi-ovo/voyager/issues/new?template=bug_report.yml) ou [pedido de funcionalidade](https://github.com/Nagi-ovo/voyager/issues/new?template=feature_request.yml).
 - **Pull Requests**: Consulte [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 Obrigado por ajudar a tornar o Voyager melhor! ❤️

--- a/.github/README_RU.md
+++ b/.github/README_RU.md
@@ -14,10 +14,10 @@
     <img src="https://img.shields.io/badge/Brave-✓-FB542B?style=flat-square&logo=brave&logoColor=white" alt="Brave">
   </p>
   <p>
-    <img src="../badges/github-stars.svg" alt="GitHub stars">
-    <img src="../badges/github-forks.svg" alt="GitHub forks">
-    <img src="../badges/github-release.svg" alt="Latest version">
-    <img src="../badges/github-downloads.svg" alt="GitHub downloads">
+    <img src="../docs/public/badges/github-stars.svg" alt="GitHub stars">
+    <img src="../docs/public/badges/github-forks.svg" alt="GitHub forks">
+    <img src="../docs/public/badges/github-release.svg" alt="Latest version">
+    <img src="../docs/public/badges/github-downloads.svg" alt="GitHub downloads">
     <img src="https://img.shields.io/chrome-web-store/users/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store users">
     <img src="https://img.shields.io/chrome-web-store/rating/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome Web Store rating">
     <img src="https://img.shields.io/badge/edge%20users-50k%2B-0078D7?style=flat-square&logo=microsoftedge&logoColor=white" alt="Edge Add-ons users">
@@ -212,7 +212,7 @@
 
 Мы приветствуем любую помощь!
 
-- **Issues**: Используйте наши шаблоны для [отчетов об ошибках](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) или [предложений новых функций](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml).
+- **Issues**: Используйте наши шаблоны для [отчетов об ошибках](https://github.com/Nagi-ovo/voyager/issues/new?template=bug_report.yml) или [предложений новых функций](https://github.com/Nagi-ovo/voyager/issues/new?template=feature_request.yml).
 - **Pull Requests**: Ознакомьтесь с [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 Спасибо, что помогаете делать Voyager лучше! ❤️

--- a/.github/README_ZH.md
+++ b/.github/README_ZH.md
@@ -14,10 +14,10 @@
     <img src="https://img.shields.io/badge/Brave-✓-FB542B?style=flat-square&logo=brave&logoColor=white" alt="Brave">
   </p>
   <p>
-    <img src="../badges/github-stars.svg" alt="GitHub Star">
-    <img src="../badges/github-forks.svg" alt="GitHub Fork">
-    <img src="../badges/github-release.svg" alt="最新版本">
-    <img src="../badges/github-downloads.svg" alt="GitHub 下载量">
+    <img src="../docs/public/badges/github-stars.svg" alt="GitHub Star">
+    <img src="../docs/public/badges/github-forks.svg" alt="GitHub Fork">
+    <img src="../docs/public/badges/github-release.svg" alt="最新版本">
+    <img src="../docs/public/badges/github-downloads.svg" alt="GitHub 下载量">
     <img src="https://img.shields.io/chrome-web-store/users/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome 商店用户数">
     <img src="https://img.shields.io/chrome-web-store/rating/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome 商店评分">
     <img src="https://img.shields.io/badge/edge%20users-50k%2B-0078D7?style=flat-square&logo=microsoftedge&logoColor=white" alt="Edge 商店用户数">

--- a/.github/README_ZH_TW.md
+++ b/.github/README_ZH_TW.md
@@ -14,10 +14,10 @@
     <img src="https://img.shields.io/badge/Brave-✓-FB542B?style=flat-square&logo=brave&logoColor=white" alt="Brave">
   </p>
   <p>
-    <img src="../badges/github-stars.svg" alt="GitHub Star">
-    <img src="../badges/github-forks.svg" alt="GitHub Fork">
-    <img src="../badges/github-release.svg" alt="最新版本">
-    <img src="../badges/github-downloads.svg" alt="GitHub 下載量">
+    <img src="../docs/public/badges/github-stars.svg" alt="GitHub Star">
+    <img src="../docs/public/badges/github-forks.svg" alt="GitHub Fork">
+    <img src="../docs/public/badges/github-release.svg" alt="最新版本">
+    <img src="../docs/public/badges/github-downloads.svg" alt="GitHub 下載量">
     <img src="https://img.shields.io/chrome-web-store/users/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome 商店用戶數">
     <img src="https://img.shields.io/chrome-web-store/rating/iifacdnjakkhjjiengaffnegbndgingi?style=flat-square&logo=google-chrome" alt="Chrome 商店評分">
     <img src="https://img.shields.io/badge/edge%20users-50k%2B-0078D7?style=flat-square&logo=microsoftedge&logoColor=white" alt="Edge 商店用戶數">

--- a/.github/docs/CHANGELOG.md
+++ b/.github/docs/CHANGELOG.md
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Users
 
 - Chrome/Firefox: No changes needed
-- Safari: See [installation guide](.github/docs/safari/INSTALLATION.md)
+- Safari: See [installation guide](safari/INSTALLATION.md)
 
 ### Developers
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ I highly recommend **[Typeless (typeless.com)](https://www.typeless.com/refer?co
 
 We welcome contributions! Whether you want to report bugs, suggest features, improve documentation, or submit code:
 
-- **Issues**: Use our [bug report](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) or [feature request](https://github.com/Nagi-ovo/voyager/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml) templates
+- **Issues**: Use our [bug report](https://github.com/Nagi-ovo/voyager/issues/new?template=bug_report.yml) or [feature request](https://github.com/Nagi-ovo/voyager/issues/new?template=feature_request.yml) templates
 - **Pull Requests**: Check out [CONTRIBUTING.md](./.github/CONTRIBUTING.md) for guidelines
 
 <details>


### PR DESCRIPTION
Closes #852

## Summary

- Fix the stale Safari installation-guide link in .github/docs/CHANGELOG.md.
- Correct 36 badge image paths across nine localized README files.
- Route stale Bug Report and Feature Request README links to the corresponding GitHub Issue forms in the root README and seven affected localized README files.

## Verification

- bun run format
- bun run docs:build
- Verified the corrected local targets exist:
  - .github/docs/safari/INSTALLATION.md
  - docs/public/badges/github-{stars,forks,release,downloads}.svg
  - .github/ISSUE_TEMPLATE/{bug_report,feature_request}.yml