### PR TITLE
fix(mermaid): honor explicit Gemini light theme

### DIFF
--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -35,13 +35,14 @@ Mermaid diagrams rendered with the dark theme.
 
 Root cause:
 
-Mermaid combined explicit dark-page markers and `prefers-color-scheme: dark`
-with OR logic, so it could not represent an explicit light page state.
+Mermaid treated generic `body`/`html` dark markers as equal to Gemini's
+higher-priority `.theme-host.light-theme`, so stale outer markers could
+override the active Gemini theme.
 
 Fix:
 
-Resolve explicit Gemini dark and light signals before falling back to the
-browser preference.
+Resolve `.theme-host` first, then generic page markers, and only then fall back
+to the browser preference.
 
 Regression test:
 

--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -26,6 +26,32 @@ Regression test:
 Commit:
 ```
 
+## Mermaid must honor Gemini explicit light theme
+
+Symptom:
+
+With Gemini set to light while the browser reported a dark system preference,
+Mermaid diagrams rendered with the dark theme.
+
+Root cause:
+
+Mermaid combined explicit dark-page markers and `prefers-color-scheme: dark`
+with OR logic, so it could not represent an explicit light page state.
+
+Fix:
+
+Resolve explicit Gemini dark and light signals before falling back to the
+browser preference.
+
+Regression test:
+
+`src/pages/content/mermaid/__tests__/mermaid.test.ts`
+(`resolveMermaidTheme`).
+
+Commit:
+
+`fix(mermaid): honor explicit Gemini light theme`
+
 ## Folder recovery must remove untracked sidebar clones
 
 Symptom:

--- a/src/pages/content/mermaid/__tests__/mermaid.test.ts
+++ b/src/pages/content/mermaid/__tests__/mermaid.test.ts
@@ -8,6 +8,7 @@ import {
   loadMermaid,
   normalizeMermaidCode,
   normalizeWhitespace,
+  resolveMermaidTheme,
 } from '../index';
 
 // Mock the dynamic import of 'mermaid'
@@ -46,6 +47,36 @@ describe('Mermaid dynamic loading', () => {
       // Second call returns cached instance immediately (no new import)
       const second = await loadMermaid();
       expect(second).toBe(first);
+    });
+  });
+
+  describe('resolveMermaidTheme', () => {
+    it('prefers an explicit Gemini light theme over a dark system preference', () => {
+      const page = document.implementation.createHTMLDocument();
+      const themeHost = page.createElement('div');
+      themeHost.className = 'theme-host light-theme';
+      page.body.append(themeHost);
+
+      expect(resolveMermaidTheme(page, true)).toBe('default');
+    });
+
+    it('prefers an explicit Gemini dark theme over a light system preference', () => {
+      const page = document.implementation.createHTMLDocument();
+      page.body.dataset.theme = 'dark';
+
+      expect(resolveMermaidTheme(page, false)).toBe('dark');
+    });
+
+    it('falls back to a dark system preference when Gemini exposes no theme', () => {
+      const page = document.implementation.createHTMLDocument();
+
+      expect(resolveMermaidTheme(page, true)).toBe('dark');
+    });
+
+    it('falls back to the default theme when Gemini exposes no theme and the system is light', () => {
+      const page = document.implementation.createHTMLDocument();
+
+      expect(resolveMermaidTheme(page, false)).toBe('default');
     });
   });
 

--- a/src/pages/content/mermaid/__tests__/mermaid.test.ts
+++ b/src/pages/content/mermaid/__tests__/mermaid.test.ts
@@ -51,20 +51,38 @@ describe('Mermaid dynamic loading', () => {
   });
 
   describe('resolveMermaidTheme', () => {
-    it('prefers an explicit Gemini light theme over a dark system preference', () => {
+    it('prefers an explicit Gemini light host over generic dark markers', () => {
       const page = document.implementation.createHTMLDocument();
       const themeHost = page.createElement('div');
       themeHost.className = 'theme-host light-theme';
       page.body.append(themeHost);
+      page.body.classList.add('dark-theme');
+      page.documentElement.classList.add('dark');
+      page.body.dataset.theme = 'dark';
 
       expect(resolveMermaidTheme(page, true)).toBe('default');
     });
 
-    it('prefers an explicit Gemini dark theme over a light system preference', () => {
+    it('prefers an explicit Gemini dark host over generic light markers', () => {
       const page = document.implementation.createHTMLDocument();
-      page.body.dataset.theme = 'dark';
+      const themeHost = page.createElement('div');
+      themeHost.className = 'theme-host dark-theme';
+      page.body.append(themeHost);
+      page.body.classList.add('light-theme');
+      page.documentElement.classList.add('light');
+      page.body.dataset.theme = 'light';
 
       expect(resolveMermaidTheme(page, false)).toBe('dark');
+    });
+
+    it('uses generic page markers when Gemini exposes no theme host', () => {
+      const darkPage = document.implementation.createHTMLDocument();
+      darkPage.body.dataset.theme = 'dark';
+      expect(resolveMermaidTheme(darkPage, false)).toBe('dark');
+
+      const lightPage = document.implementation.createHTMLDocument();
+      lightPage.body.dataset.theme = 'light';
+      expect(resolveMermaidTheme(lightPage, true)).toBe('default');
     });
 
     it('falls back to a dark system preference when Gemini exposes no theme', () => {

--- a/src/pages/content/mermaid/index.ts
+++ b/src/pages/content/mermaid/index.ts
@@ -47,17 +47,18 @@ export function resolveMermaidTheme(doc: Document, prefersDark: boolean): 'dark'
   const body = doc.body;
   const root = doc.documentElement;
 
+  if (doc.querySelector('.theme-host.dark-theme')) return 'dark';
+  if (doc.querySelector('.theme-host.light-theme')) return 'default';
+
   const hasExplicitDarkTheme = Boolean(
-    doc.querySelector('.theme-host.dark-theme') ||
-      body.classList.contains('dark-theme') ||
+    body.classList.contains('dark-theme') ||
       root.classList.contains('dark') ||
       body.getAttribute('data-theme') === 'dark',
   );
   if (hasExplicitDarkTheme) return 'dark';
 
   const hasExplicitLightTheme = Boolean(
-    doc.querySelector('.theme-host.light-theme') ||
-      body.classList.contains('light-theme') ||
+    body.classList.contains('light-theme') ||
       root.classList.contains('light') ||
       body.getAttribute('data-theme') === 'light',
   );

--- a/src/pages/content/mermaid/index.ts
+++ b/src/pages/content/mermaid/index.ts
@@ -39,21 +39,48 @@ export const loadMermaid = async (): Promise<typeof mermaidInstance> => {
 };
 
 /**
+ * Resolve the Mermaid theme from Gemini's explicit page state before falling
+ * back to the browser's system preference.
+ * @internal Exported for testing
+ */
+export function resolveMermaidTheme(doc: Document, prefersDark: boolean): 'dark' | 'default' {
+  const body = doc.body;
+  const root = doc.documentElement;
+
+  const hasExplicitDarkTheme = Boolean(
+    doc.querySelector('.theme-host.dark-theme') ||
+      body.classList.contains('dark-theme') ||
+      root.classList.contains('dark') ||
+      body.getAttribute('data-theme') === 'dark',
+  );
+  if (hasExplicitDarkTheme) return 'dark';
+
+  const hasExplicitLightTheme = Boolean(
+    doc.querySelector('.theme-host.light-theme') ||
+      body.classList.contains('light-theme') ||
+      root.classList.contains('light') ||
+      body.getAttribute('data-theme') === 'light',
+  );
+  if (hasExplicitLightTheme) return 'default';
+
+  return prefersDark ? 'dark' : 'default';
+}
+
+/**
  * Initialize Mermaid configuration
  */
 const initMermaid = async (): Promise<boolean> => {
   const mermaid = await loadMermaid();
   if (!mermaid) return false;
 
-  const isDarkMode =
-    document.body.classList.contains('dark-theme') ||
-    document.body.getAttribute('data-theme') === 'dark' ||
-    document.documentElement.classList.contains('dark') ||
-    window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const theme = resolveMermaidTheme(
+    document,
+    window.matchMedia('(prefers-color-scheme: dark)').matches,
+  );
 
   mermaid.initialize({
     startOnLoad: false,
-    theme: isDarkMode ? 'dark' : 'default',
+    theme,
     securityLevel: 'loose',
     fontFamily: 'Google Sans, Roboto, sans-serif',
     logLevel: 5, // 5 = fatal, only log fatal errors (v9.x uses numbers)


### PR DESCRIPTION
## 描述

修复 Gemini 页面已明确设置为浅色主题、但浏览器或系统偏好为深色时，Mermaid 图表仍错误使用深色主题的问题。

本次修改会优先识别 Gemini 页面显式声明的深色或浅色主题；仅在页面未提供主题信号时，才回退使用 `prefers-color-scheme`。同时补充了页面主题与系统主题四种组合的回归测试，未改动 Mermaid 的渲染、导出逻辑，也未增加运行时主题监听。