### PR TITLE
fix(ci): prevent fork sponsor roster updates

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   update-sponsors:
+    if: github.repository == 'Nagi-ovo/voyager'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -25,6 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SPONSORKIT_GITHUB_TOKEN }}
           AFDIAN_USER_ID: ${{ secrets.AFDIAN_USER_ID }}
           AFDIAN_TOKEN: ${{ secrets.AFDIAN_TOKEN }}
+          SPONSORS_STRICT: '1'
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5

--- a/scripts/generate-sponsors.cjs
+++ b/scripts/generate-sponsors.cjs
@@ -38,8 +38,8 @@ async function main() {
   await ensureDir(OUTPUT_DIR);
 
   const [githubSponsors, afdianSponsors] = await Promise.all([
-    fetchGitHubSponsors(githubToken),
-    fetchAfdianSponsors(afdianUserId, afdianToken),
+    fetchGitHubSponsors(githubToken, { strict }),
+    fetchAfdianSponsors(afdianUserId, afdianToken, { strict }),
   ]);
 
   const svgContent = await buildSvg({ githubSponsors, afdianSponsors, friends });
@@ -99,7 +99,14 @@ async function writeFileAtomic(target, content) {
   }
 }
 
-async function fetchGitHubSponsors(token, fetchImpl = fetch) {
+function handleSourceFailure(message, strict) {
+  if (strict) {
+    throw new Error(message);
+  }
+  console.error(message);
+}
+
+async function fetchGitHubSponsors(token, { fetchImpl = fetch, strict = false } = {}) {
   if (!token) {
     console.warn('⚠️  No GitHub token available, GitHub sponsors will be skipped.');
     return [];
@@ -161,16 +168,19 @@ async function fetchGitHubSponsors(token, fetchImpl = fetch) {
 
     if (!res.ok) {
       const text = await res.text();
-      throw new Error(`Failed to fetch GitHub sponsors (${res.status}): ${text}`);
+      handleSourceFailure(`Failed to fetch GitHub sponsors (${res.status}): ${text}`, strict);
+      return sponsors;
     }
 
     const payload = await res.json();
     if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
-      throw new Error(`GitHub Sponsors API error: ${JSON.stringify(payload.errors)}`);
+      handleSourceFailure(`GitHub Sponsors API error: ${JSON.stringify(payload.errors)}`, strict);
+      return sponsors;
     }
     const data = payload?.data?.user?.sponsorshipsAsMaintainer;
     if (!data || !Array.isArray(data.nodes) || !data.pageInfo) {
-      throw new Error('Unexpected response from GitHub Sponsors API.');
+      handleSourceFailure('Unexpected response from GitHub Sponsors API.', strict);
+      return sponsors;
     }
 
     for (const node of data.nodes || []) {
@@ -204,7 +214,7 @@ async function fetchGitHubSponsors(token, fetchImpl = fetch) {
   return sponsors;
 }
 
-async function fetchAfdianSponsors(userId, token, fetchImpl = fetch) {
+async function fetchAfdianSponsors(userId, token, { fetchImpl = fetch, strict = false } = {}) {
   if (!userId || !token) {
     console.warn('⚠️  No Afdian credentials available, Afdian sponsors will be skipped.');
     return [];
@@ -233,17 +243,20 @@ async function fetchAfdianSponsors(userId, token, fetchImpl = fetch) {
     });
 
     if (!res.ok) {
-      throw new Error(`Failed to fetch Afdian sponsors (${res.status})`);
+      handleSourceFailure(`Failed to fetch Afdian sponsors (${res.status})`, strict);
+      break;
     }
 
     const payload = await res.json();
     if (payload.ec !== 200) {
-      throw new Error(`Afdian API error: ${payload.em || 'unknown error'}`);
+      handleSourceFailure(`Afdian API error: ${payload.em || 'unknown error'}`, strict);
+      break;
     }
 
     const list = payload.data?.list;
     if (!Array.isArray(list)) {
-      throw new Error('Unexpected response from Afdian API.');
+      handleSourceFailure('Unexpected response from Afdian API.', strict);
+      break;
     }
     if (list.length === 0) break;
 

--- a/scripts/generate-sponsors.cjs
+++ b/scripts/generate-sponsors.cjs
@@ -3,12 +3,13 @@
  * Generate the sponsor board SVG with GitHub Sponsors, Afdian, and Tipping Friends.
  *
  * Usage:
- *   node sponsorkit/generate-sponsors.js
+ *   node scripts/generate-sponsors.cjs
  *
  * Environment variables:
  *   GITHUB_TOKEN - GitHub token for fetching sponsors
  *   AFDIAN_USER_ID - Afdian user ID
  *   AFDIAN_TOKEN - Afdian API token
+ *   SPONSORS_STRICT - Set to "1" in automation to require every credential
  */
 const fsp = require('fs/promises');
 const path = require('path');
@@ -27,12 +28,14 @@ const FONT_FAMILY =
   "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'";
 
 async function main() {
-  const friends = await loadFriends();
-  await ensureDir(OUTPUT_DIR);
-
   const githubToken = process.env.GITHUB_TOKEN;
   const afdianUserId = process.env.AFDIAN_USER_ID;
   const afdianToken = process.env.AFDIAN_TOKEN;
+  const strict = process.env.SPONSORS_STRICT === '1';
+  validateCredentials({ githubToken, afdianUserId, afdianToken }, strict);
+
+  const friends = await loadFriends(strict);
+  await ensureDir(OUTPUT_DIR);
 
   const [githubSponsors, afdianSponsors] = await Promise.all([
     fetchGitHubSponsors(githubToken),
@@ -40,13 +43,26 @@ async function main() {
   ]);
 
   const svgContent = await buildSvg({ githubSponsors, afdianSponsors, friends });
-  await fsp.writeFile(OUTPUT_PATH, svgContent, 'utf8');
+  await writeFileAtomic(OUTPUT_PATH, svgContent);
   console.log(
     `Generated ${path.relative(ROOT, OUTPUT_PATH)} with ${githubSponsors.length} GitHub sponsors, ${afdianSponsors.length} Afdian sponsors, and ${friends.length} tipping friends.`,
   );
 }
 
-async function loadFriends() {
+function validateCredentials({ githubToken, afdianUserId, afdianToken }, strict) {
+  if (!strict) return;
+
+  const missing = [];
+  if (!githubToken) missing.push('GITHUB_TOKEN');
+  if (!afdianUserId) missing.push('AFDIAN_USER_ID');
+  if (!afdianToken) missing.push('AFDIAN_TOKEN');
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required sponsor credentials: ${missing.join(', ')}`);
+  }
+}
+
+async function loadFriends(strict = false) {
   try {
     const raw = await fsp.readFile(FRIENDS_PATH, 'utf8');
     const list = JSON.parse(raw);
@@ -60,6 +76,9 @@ async function loadFriends() {
       })
       .filter(Boolean);
   } catch (e) {
+    if (strict) {
+      throw new Error(`Failed to load friends list: ${e.message}`);
+    }
     console.warn('⚠️  Failed to load friends list:', e.message);
     return [];
   }
@@ -69,7 +88,18 @@ async function ensureDir(target) {
   await fsp.mkdir(target, { recursive: true });
 }
 
-async function fetchGitHubSponsors(token) {
+async function writeFileAtomic(target, content) {
+  const tempPath = `${target}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await fsp.writeFile(tempPath, content, 'utf8');
+    await fsp.rename(tempPath, target);
+  } catch (error) {
+    await fsp.rm(tempPath, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+async function fetchGitHubSponsors(token, fetchImpl = fetch) {
   if (!token) {
     console.warn('⚠️  No GitHub token available, GitHub sponsors will be skipped.');
     return [];
@@ -123,7 +153,7 @@ async function fetchGitHubSponsors(token) {
       },
     };
 
-    const res = await fetch(GRAPHQL_ENDPOINT, {
+    const res = await fetchImpl(GRAPHQL_ENDPOINT, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
@@ -131,15 +161,16 @@ async function fetchGitHubSponsors(token) {
 
     if (!res.ok) {
       const text = await res.text();
-      console.error(`Failed to fetch GitHub sponsors (${res.status}): ${text}`);
-      return sponsors;
+      throw new Error(`Failed to fetch GitHub sponsors (${res.status}): ${text}`);
     }
 
     const payload = await res.json();
+    if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
+      throw new Error(`GitHub Sponsors API error: ${JSON.stringify(payload.errors)}`);
+    }
     const data = payload?.data?.user?.sponsorshipsAsMaintainer;
-    if (!data) {
-      console.error('Unexpected response from GitHub Sponsors API.');
-      return sponsors;
+    if (!data || !Array.isArray(data.nodes) || !data.pageInfo) {
+      throw new Error('Unexpected response from GitHub Sponsors API.');
     }
 
     for (const node of data.nodes || []) {
@@ -173,7 +204,7 @@ async function fetchGitHubSponsors(token) {
   return sponsors;
 }
 
-async function fetchAfdianSponsors(userId, token) {
+async function fetchAfdianSponsors(userId, token, fetchImpl = fetch) {
   if (!userId || !token) {
     console.warn('⚠️  No Afdian credentials available, Afdian sponsors will be skipped.');
     return [];
@@ -190,7 +221,7 @@ async function fetchAfdianSponsors(userId, token) {
       .update(`${token}params${params}ts${ts}user_id${userId}`)
       .digest('hex');
 
-    const res = await fetch(AFDIAN_API, {
+    const res = await fetchImpl(AFDIAN_API, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -202,17 +233,18 @@ async function fetchAfdianSponsors(userId, token) {
     });
 
     if (!res.ok) {
-      console.error(`Failed to fetch Afdian sponsors (${res.status})`);
-      break;
+      throw new Error(`Failed to fetch Afdian sponsors (${res.status})`);
     }
 
     const payload = await res.json();
     if (payload.ec !== 200) {
-      console.error('Afdian API error:', payload.em);
-      break;
+      throw new Error(`Afdian API error: ${payload.em || 'unknown error'}`);
     }
 
-    const list = payload.data?.list || [];
+    const list = payload.data?.list;
+    if (!Array.isArray(list)) {
+      throw new Error('Unexpected response from Afdian API.');
+    }
     if (list.length === 0) break;
 
     for (const item of list) {
@@ -436,7 +468,16 @@ function escapeAttr(value) {
   return escapeText(value).replace(/"/g, '&quot;');
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  fetchAfdianSponsors,
+  fetchGitHubSponsors,
+  validateCredentials,
+  writeFileAtomic,
+};

--- a/scripts/generate-sponsors.test.js
+++ b/scripts/generate-sponsors.test.js
@@ -16,6 +16,7 @@ const tempDirs = [];
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+  vi.restoreAllMocks();
 });
 
 describe('sponsor generator safeguards', () => {
@@ -43,27 +44,71 @@ describe('sponsor generator safeguards', () => {
     ).not.toThrow();
   });
 
-  it('fails instead of returning a partial GitHub sponsor list', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({
+  it('fails on GitHub API errors in strict mode and remains fail-soft locally', async () => {
+    const strictFetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 401,
       text: async () => 'bad credentials',
     });
 
-    await expect(fetchGitHubSponsors('token', fetchImpl)).rejects.toThrow(
-      'Failed to fetch GitHub sponsors (401)',
+    await expect(
+      fetchGitHubSponsors('token', { fetchImpl: strictFetch, strict: true }),
+    ).rejects.toThrow('Failed to fetch GitHub sponsors (401)');
+
+    const localFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            user: {
+              sponsorshipsAsMaintainer: {
+                nodes: [
+                  {
+                    sponsorEntity: {
+                      login: 'sponsor',
+                      name: 'Sponsor',
+                      avatarUrl: 'https://example.com/avatar.png',
+                      url: 'https://github.com/sponsor',
+                    },
+                    tier: { monthlyPriceInDollars: 5 },
+                    createdAt: '2026-01-01T00:00:00Z',
+                  },
+                ],
+                pageInfo: { hasNextPage: true, endCursor: 'next' },
+              },
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => 'temporarily unavailable',
+      });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(fetchGitHubSponsors('token', { fetchImpl: localFetch })).resolves.toEqual([
+      expect.objectContaining({ login: 'sponsor' }),
+    ]);
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to fetch GitHub sponsors (503): temporarily unavailable',
     );
   });
 
-  it('fails instead of returning a partial Afdian sponsor list', async () => {
+  it('fails on Afdian API errors in strict mode and remains fail-soft locally', async () => {
     const fetchImpl = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ ec: 403, em: 'invalid signature' }),
     });
 
-    await expect(fetchAfdianSponsors('user', 'token', fetchImpl)).rejects.toThrow(
+    await expect(fetchAfdianSponsors('user', 'token', { fetchImpl, strict: true })).rejects.toThrow(
       'Afdian API error: invalid signature',
     );
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(fetchAfdianSponsors('user', 'token', { fetchImpl })).resolves.toEqual([]);
+    expect(consoleError).toHaveBeenCalledWith('Afdian API error: invalid signature');
   });
 
   it('replaces generated output without leaving a temporary file', async () => {

--- a/scripts/generate-sponsors.test.js
+++ b/scripts/generate-sponsors.test.js
@@ -1,0 +1,87 @@
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  fetchAfdianSponsors,
+  fetchGitHubSponsors,
+  validateCredentials,
+  writeFileAtomic,
+} = require('./generate-sponsors.cjs');
+
+const tempDirs = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+});
+
+describe('sponsor generator safeguards', () => {
+  it('requires every remote credential in strict automation mode', () => {
+    expect(() =>
+      validateCredentials(
+        {
+          githubToken: '',
+          afdianUserId: 'user',
+          afdianToken: '',
+        },
+        true,
+      ),
+    ).toThrow('GITHUB_TOKEN, AFDIAN_TOKEN');
+
+    expect(() =>
+      validateCredentials(
+        {
+          githubToken: '',
+          afdianUserId: '',
+          afdianToken: '',
+        },
+        false,
+      ),
+    ).not.toThrow();
+  });
+
+  it('fails instead of returning a partial GitHub sponsor list', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'bad credentials',
+    });
+
+    await expect(fetchGitHubSponsors('token', fetchImpl)).rejects.toThrow(
+      'Failed to fetch GitHub sponsors (401)',
+    );
+  });
+
+  it('fails instead of returning a partial Afdian sponsor list', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ec: 403, em: 'invalid signature' }),
+    });
+
+    await expect(fetchAfdianSponsors('user', 'token', fetchImpl)).rejects.toThrow(
+      'Afdian API error: invalid signature',
+    );
+  });
+
+  it('replaces generated output without leaving a temporary file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'voyager-sponsors-'));
+    tempDirs.push(dir);
+    const target = join(dir, 'sponsors.svg');
+    await writeFile(target, 'old', 'utf8');
+
+    await writeFileAtomic(target, 'new');
+
+    expect(await readFile(target, 'utf8')).toBe('new');
+    expect(await readdir(dir)).toEqual(['sponsors.svg']);
+  });
+
+  it('keeps the write job scoped to the canonical repository and enables strict mode', async () => {
+    const workflow = await readFile(resolve('.github/workflows/sponsors.yml'), 'utf8');
+
+    expect(workflow).toContain("if: github.repository == 'Nagi-ovo/voyager'");
+    expect(workflow).toContain("SPONSORS_STRICT: '1'");
+  });
+});


### PR DESCRIPTION
### AI-Assisted PR Policy / AI 辅助 PR 政策

- I reviewed the final goal, scope, implementation, diff, and validation results.
- The expected behavior, affected automation paths, and verification plan were agreed before implementation.

---

### Description / 描述

This closes the failure mode where syncing upstream history into a fork can trigger the sponsor workflow and replace the fork roster with an empty SVG when sponsor credentials are unavailable.

- Scope the write job to `Nagi-ovo/voyager`.
- Enable strict automation mode so missing credentials, remote API failures, GraphQL errors, malformed payloads, or an invalid friends list fail the run.
- Write the generated SVG atomically only after every source succeeds.
- Preserve the existing fail-soft behavior for optional local runs outside strict automation.
- Add regression tests for the repository guard, credential checks, remote failures, and atomic output replacement.

### Related Issue / 相关 Issue

Fixes #866

### Sensitive Path / 敏感路径

This PR changes `.github/workflows/sponsors.yml`, a sensitive workflow with `contents: write`. The repository guard is applied at the job level before checkout, generation, or commit steps can run.

### Affected Functionality / 受影响功能

Affected: automated sponsor roster generation and commit behavior only.

Unaffected: extension runtime features, browser builds, manifests, and UI. No browser matrix or visual proof is applicable to this non-UI automation fix.

### Verification / 验证

- ✅ `bun x prettier --check .github/workflows/sponsors.yml scripts/generate-sponsors.cjs scripts/generate-sponsors.test.js`
- ✅ `bun run lint`
- ✅ `bun run typecheck`
- ✅ `bun run test scripts/generate-sponsors.test.js` (5/5)
- ✅ `bun run test` (249 files, 2289 tests)
- ✅ Strict run without credentials exits with an error before generation; `docs/public/assets/sponsors.svg` SHA-256 remained unchanged.
- ⏳ Required CI browser builds will run on this PR; local extension builds are not behaviorally relevant to this workflow-only change.

### Checklist / 检查清单

- [x] I discussed the requirement, affected scope, and verification plan clearly.
- [x] I manually verified the failure path and unchanged output.
- [x] I confirmed the change is limited to sponsor automation.
- [x] This PR focuses on one issue.
- [x] I ran formatting, lint, typecheck, and the full test suite.
- [x] I added regression tests and they pass.
- [ ] Required GitHub CI checks are pending.