### PR TITLE
feat(prompt): add independent slash toggle and onboarding coachmark

### DIFF
--- a/src/core/services/SettingsBackupService.ts
+++ b/src/core/services/SettingsBackupService.ts
@@ -74,6 +74,7 @@ export const BACKUPABLE_SYNC_SETTINGS_DEFAULTS = {
   [StorageKeys.PROMPT_INSERT_ON_CLICK]: false,
   [StorageKeys.PROMPT_VIEW_MODE]: 'compact',
   [StorageKeys.PROMPT_PANEL_VIEW]: 'prompts',
+  [StorageKeys.SLASH_PROMPT_ENABLED]: true,
   [StorageKeys.LANGUAGE]: null,
   [StorageKeys.FORMULA_COPY_FORMAT]: 'latex',
   [StorageKeys.WATERMARK_REMOVER_ENABLED]: true,

--- a/src/core/services/__tests__/SettingsBackupService.test.ts
+++ b/src/core/services/__tests__/SettingsBackupService.test.ts
@@ -29,6 +29,7 @@ describe('SettingsBackupService', () => {
         [StorageKeys.DEFAULT_THINKING_LEVEL]: null,
         [StorageKeys.COACHMARKS_SEEN]: [],
         [StorageKeys.EXPORT_IMAGE_WIDTH]: 620,
+        [StorageKeys.SLASH_PROMPT_ENABLED]: true,
       }),
     );
     expect(BACKUPABLE_SYNC_SETTINGS_DEFAULTS).not.toHaveProperty(StorageKeys.PLUGINS_STATE);

--- a/src/core/types/common.ts
+++ b/src/core/types/common.ts
@@ -98,6 +98,7 @@ export const StorageKeys = {
   PROMPT_INSERT_ON_CLICK: 'gvPromptInsertOnClick',
   PROMPT_VIEW_MODE: 'gvPromptViewMode',
   PROMPT_PANEL_VIEW: 'gvPromptPanelView',
+  SLASH_PROMPT_ENABLED: 'gvSlashPromptEnabled',
   // Persisted tag filter for the prompt manager (#729). chrome.storage.local
   // only — the selected tags are a per-device view over this machine's prompt
   // set, not a synced preference; syncing them could restore tags a device

--- a/src/locales/ar/messages.json
+++ b/src/locales/ar/messages.json
@@ -975,6 +975,14 @@
     "message": "إخفاء الزر العائم لمدير المطالبات على الصفحة",
     "description": "Hint for hiding prompt manager feature"
   },
+  "slashPromptEnabled": {
+    "message": "تمكين الإدراج السريع للمطالبات باستخدام /",
+    "description": "Enable slash prompt quick insertion toggle"
+  },
+  "slashPromptEnabledHint": {
+    "message": "اكتب / في مربع كتابة Gemini لإدراج مطالبة محفوظة بسرعة.",
+    "description": "Hint for slash prompt quick insertion"
+  },
   "promptInsertOnClick": {
     "message": "إدراج المطالبة عند النقر",
     "description": "Enable direct prompt insertion instead of copying"
@@ -2363,6 +2371,18 @@
   "timelineCoachmarkToggle": {
     "message": "استخدام المخطط الزمني المضغوط",
     "description": "Inline toggle label in the compact-timeline coachmark"
+  },
+  "slashPromptCoachmarkTitle": {
+    "message": "جديد: إدراج المطالبات باستخدام /",
+    "description": "Coachmark title introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkBody": {
+    "message": "اكتب / في مربع كتابة Gemini لإدراج مطالبة محفوظة بسرعة.",
+    "description": "Coachmark body text introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkToggle": {
+    "message": "تمكين إدراج المطالبات باستخدام /",
+    "description": "Inline toggle label in the slash-prompt coachmark"
   },
   "coachmarkDismiss": {
     "message": "تم",

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -975,6 +975,14 @@
     "message": "Hide the Prompt Manager floating ball on the page",
     "description": "Hint for hiding prompt manager feature"
   },
+  "slashPromptEnabled": {
+    "message": "Enable slash prompt quick insertion",
+    "description": "Enable slash prompt quick insertion toggle"
+  },
+  "slashPromptEnabledHint": {
+    "message": "Type / in the Gemini composer to quickly insert a saved Prompt.",
+    "description": "Hint for slash prompt quick insertion"
+  },
   "promptInsertOnClick": {
     "message": "Insert prompt on click",
     "description": "Enable direct prompt insertion instead of copying"
@@ -2363,6 +2371,18 @@
   "timelineCoachmarkToggle": {
     "message": "Use compact timeline",
     "description": "Inline toggle label in the compact-timeline coachmark"
+  },
+  "slashPromptCoachmarkTitle": {
+    "message": "New: slash prompt insertion",
+    "description": "Coachmark title introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkBody": {
+    "message": "Type / in the Gemini composer to quickly insert a saved Prompt.",
+    "description": "Coachmark body text introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkToggle": {
+    "message": "Enable slash prompt insertion",
+    "description": "Inline toggle label in the slash-prompt coachmark"
   },
   "coachmarkDismiss": {
     "message": "Done",

--- a/src/locales/es/messages.json
+++ b/src/locales/es/messages.json
@@ -975,6 +975,14 @@
     "message": "Ocultar el botón flotante del Gestor de Prompts en la página",
     "description": "Hint for hiding prompt manager feature"
   },
+  "slashPromptEnabled": {
+    "message": "Activar la inserción rápida de prompts con /",
+    "description": "Enable slash prompt quick insertion toggle"
+  },
+  "slashPromptEnabledHint": {
+    "message": "Escribe / en el cuadro de texto de Gemini para insertar rápidamente un prompt guardado.",
+    "description": "Hint for slash prompt quick insertion"
+  },
   "promptInsertOnClick": {
     "message": "Insertar prompt al hacer clic",
     "description": "Enable direct prompt insertion instead of copying"
@@ -2363,6 +2371,18 @@
   "timelineCoachmarkToggle": {
     "message": "Usar cronología compacta",
     "description": "Inline toggle label in the compact-timeline coachmark"
+  },
+  "slashPromptCoachmarkTitle": {
+    "message": "Novedad: inserción de prompts con /",
+    "description": "Coachmark title introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkBody": {
+    "message": "Escribe / en el cuadro de texto de Gemini para insertar rápidamente un prompt guardado.",
+    "description": "Coachmark body text introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkToggle": {
+    "message": "Activar la inserción de prompts con /",
+    "description": "Inline toggle label in the slash-prompt coachmark"
   },
   "coachmarkDismiss": {
     "message": "Listo",

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -975,6 +975,14 @@
     "message": "Masquer le bouton flottant du gestionnaire",
     "description": "Hint for hiding prompt manager feature"
   },
+  "slashPromptEnabled": {
+    "message": "Activer l’insertion rapide de prompts avec /",
+    "description": "Enable slash prompt quick insertion toggle"
+  },
+  "slashPromptEnabledHint": {
+    "message": "Saisissez / dans la zone de saisie de Gemini pour insérer rapidement un prompt enregistré.",
+    "description": "Hint for slash prompt quick insertion"
+  },
   "promptInsertOnClick": {
     "message": "Inserer le prompt au clic",
     "description": "Enable direct prompt insertion instead of copying"
@@ -2365,6 +2373,18 @@
   "timelineCoachmarkToggle": {
     "message": "Utiliser la chronologie compacte",
     "description": "Inline toggle label in the compact-timeline coachmark"
+  },
+  "slashPromptCoachmarkTitle": {
+    "message": "Nouveau : insertion de prompts avec /",
+    "description": "Coachmark title introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkBody": {
+    "message": "Saisissez / dans la zone de saisie de Gemini pour insérer rapidement un prompt enregistré.",
+    "description": "Coachmark body text introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkToggle": {
+    "message": "Activer l’insertion de prompts avec /",
+    "description": "Inline toggle label in the slash-prompt coachmark"
   },
   "coachmarkDismiss": {
     "message": "Terminé",

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -975,6 +975,14 @@
     "message": "ページ上のプロンプトマネージャーのフローティングアイコンを非表示にします",
     "description": "Hint for hiding prompt manager feature"
   },
+  "slashPromptEnabled": {
+    "message": "スラッシュでプロンプトをすばやく挿入",
+    "description": "Enable slash prompt quick insertion toggle"
+  },
+  "slashPromptEnabledHint": {
+    "message": "Gemini の入力欄で / を入力すると、保存済みのプロンプトをすばやく挿入できます。",
+    "description": "Hint for slash prompt quick insertion"
+  },
   "promptInsertOnClick": {
     "message": "クリック時にプロンプトを直接挿入",
     "description": "Enable direct prompt insertion instead of copying"
@@ -2363,6 +2371,18 @@
   "timelineCoachmarkToggle": {
     "message": "コンパクト表示を使う",
     "description": "Inline toggle label in the compact-timeline coachmark"
+  },
+  "slashPromptCoachmarkTitle": {
+    "message": "新機能：スラッシュでプロンプトを挿入",
+    "description": "Coachmark title introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkBody": {
+    "message": "Gemini の入力欄で / を入力すると、保存済みのプロンプトをすばやく挿入できます。",
+    "description": "Coachmark body text introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkToggle": {
+    "message": "スラッシュでプロンプトを挿入",
+    "description": "Inline toggle label in the slash-prompt coachmark"
   },
   "coachmarkDismiss": {
     "message": "完了",

--- a/src/locales/ko/messages.json
+++ b/src/locales/ko/messages.json
@@ -975,6 +975,14 @@
     "message": "페이지의 프롬프트 관리자 플로팅 볼을 숨깁니다",
     "description": "Hint for hiding prompt manager feature"
   },
+  "slashPromptEnabled": {
+    "message": "슬래시로 프롬프트 빠르게 삽입",
+    "description": "Enable slash prompt quick insertion toggle"
+  },
+  "slashPromptEnabledHint": {
+    "message": "Gemini 입력창에 /를 입력하여 저장된 프롬프트를 빠르게 삽입합니다.",
+    "description": "Hint for slash prompt quick insertion"
+  },
   "promptInsertOnClick": {
     "message": "클릭 시 프롬프트 바로 삽입",
     "description": "Enable direct prompt insertion instead of copying"
@@ -2363,6 +2371,18 @@
   "timelineCoachmarkToggle": {
     "message": "컴팩트 타임라인 사용",
     "description": "Inline toggle label in the compact-timeline coachmark"
+  },
+  "slashPromptCoachmarkTitle": {
+    "message": "새 기능: 슬래시 프롬프트 삽입",
+    "description": "Coachmark title introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkBody": {
+    "message": "Gemini 입력창에 /를 입력하여 저장된 프롬프트를 빠르게 삽입합니다.",
+    "description": "Coachmark body text introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkToggle": {
+    "message": "슬래시 프롬프트 삽입 사용",
+    "description": "Inline toggle label in the slash-prompt coachmark"
   },
   "coachmarkDismiss": {
     "message": "완료",

--- a/src/locales/pt/messages.json
+++ b/src/locales/pt/messages.json
@@ -975,6 +975,14 @@
     "message": "Ocultar o botão flutuante do Gerenciador de Prompts na página",
     "description": "Hint for hiding prompt manager feature"
   },
+  "slashPromptEnabled": {
+    "message": "Ativar inserção rápida de prompts com /",
+    "description": "Enable slash prompt quick insertion toggle"
+  },
+  "slashPromptEnabledHint": {
+    "message": "Digite / no campo de texto do Gemini para inserir rapidamente um prompt salvo.",
+    "description": "Hint for slash prompt quick insertion"
+  },
   "promptInsertOnClick": {
     "message": "Inserir prompt ao clicar",
     "description": "Enable direct prompt insertion instead of copying"
@@ -2363,6 +2371,18 @@
   "timelineCoachmarkToggle": {
     "message": "Usar linha do tempo compacta",
     "description": "Inline toggle label in the compact-timeline coachmark"
+  },
+  "slashPromptCoachmarkTitle": {
+    "message": "Novidade: inserção de prompts com /",
+    "description": "Coachmark title introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkBody": {
+    "message": "Digite / no campo de texto do Gemini para inserir rapidamente um prompt salvo.",
+    "description": "Coachmark body text introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkToggle": {
+    "message": "Ativar inserção de prompts com /",
+    "description": "Inline toggle label in the slash-prompt coachmark"
   },
   "coachmarkDismiss": {
     "message": "Concluir",

--- a/src/locales/ru/messages.json
+++ b/src/locales/ru/messages.json
@@ -975,6 +975,14 @@
     "message": "Скрыть плавающую кнопку Менеджера промптов на странице",
     "description": "Hint for hiding prompt manager feature"
   },
+  "slashPromptEnabled": {
+    "message": "Включить быструю вставку промптов через /",
+    "description": "Enable slash prompt quick insertion toggle"
+  },
+  "slashPromptEnabledHint": {
+    "message": "Введите / в поле Gemini, чтобы быстро вставить сохранённый промпт.",
+    "description": "Hint for slash prompt quick insertion"
+  },
   "promptInsertOnClick": {
     "message": "Вставлять промпт по клику",
     "description": "Enable direct prompt insertion instead of copying"
@@ -2363,6 +2371,18 @@
   "timelineCoachmarkToggle": {
     "message": "Использовать компактную шкалу",
     "description": "Inline toggle label in the compact-timeline coachmark"
+  },
+  "slashPromptCoachmarkTitle": {
+    "message": "Новое: вставка промптов через /",
+    "description": "Coachmark title introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkBody": {
+    "message": "Введите / в поле Gemini, чтобы быстро вставить сохранённый промпт.",
+    "description": "Coachmark body text introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkToggle": {
+    "message": "Включить вставку промптов через /",
+    "description": "Inline toggle label in the slash-prompt coachmark"
   },
   "coachmarkDismiss": {
     "message": "Готово",

--- a/src/locales/zh/messages.json
+++ b/src/locales/zh/messages.json
@@ -975,6 +975,14 @@
     "message": "隐藏页面上的提示词管理器悬浮球",
     "description": "隐藏提示词管理器功能提示"
   },
+  "slashPromptEnabled": {
+    "message": "启用斜杠快速插入提示词",
+    "description": "启用斜杠快速插入提示词开关"
+  },
+  "slashPromptEnabledHint": {
+    "message": "在 Gemini 输入框中输入 /，即可快速插入已保存的提示词。",
+    "description": "斜杠快速插入提示词说明"
+  },
   "promptInsertOnClick": {
     "message": "点击时直接插入提示词",
     "description": "启用后点击提示词时直接插入而不是复制"
@@ -2361,6 +2369,18 @@
   "timelineCoachmarkToggle": {
     "message": "使用紧凑索引",
     "description": "Inline toggle label in the compact-timeline coachmark"
+  },
+  "slashPromptCoachmarkTitle": {
+    "message": "新功能：斜杠提示词插入",
+    "description": "Coachmark title introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkBody": {
+    "message": "在 Gemini 输入框中输入 /，即可快速插入已保存的提示词。",
+    "description": "Coachmark body text introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkToggle": {
+    "message": "启用斜杠提示词插入",
+    "description": "Inline toggle label in the slash-prompt coachmark"
   },
   "coachmarkDismiss": {
     "message": "完成",

--- a/src/locales/zh_TW/messages.json
+++ b/src/locales/zh_TW/messages.json
@@ -935,6 +935,14 @@
     "message": "隱藏頁面上的提示詞管理器懸浮球",
     "description": "隱藏提示詞管理器功能提示"
   },
+  "slashPromptEnabled": {
+    "message": "啟用斜線快速插入提示詞",
+    "description": "啟用斜線快速插入提示詞開關"
+  },
+  "slashPromptEnabledHint": {
+    "message": "在 Gemini 輸入框中輸入 /，即可快速插入已儲存的提示詞。",
+    "description": "斜線快速插入提示詞說明"
+  },
   "promptInsertOnClick": {
     "message": "點擊時直接插入提示詞",
     "description": "啟用後點擊提示詞時直接插入而不是複製"
@@ -2361,6 +2369,18 @@
   "timelineCoachmarkToggle": {
     "message": "使用精簡索引",
     "description": "Inline toggle label in the compact-timeline coachmark"
+  },
+  "slashPromptCoachmarkTitle": {
+    "message": "新功能：斜線提示詞插入",
+    "description": "Coachmark title introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkBody": {
+    "message": "在 Gemini 輸入框中輸入 /，即可快速插入已儲存的提示詞。",
+    "description": "Coachmark body text introducing slash prompt insertion"
+  },
+  "slashPromptCoachmarkToggle": {
+    "message": "啟用斜線提示詞插入",
+    "description": "Inline toggle label in the slash-prompt coachmark"
   },
   "coachmarkDismiss": {
     "message": "完成",

--- a/src/pages/content/coachmark/__tests__/coachmark.test.ts
+++ b/src/pages/content/coachmark/__tests__/coachmark.test.ts
@@ -227,6 +227,19 @@ describe('showCoachmark', () => {
     expect(document.querySelector('.gv-coach')).toBeNull();
   });
 
+  it('skips a missing anchor without leaving DOM or marking the guide as seen', async () => {
+    const result = await showCoachmark({
+      id: 'missing-anchor',
+      anchor: () => null,
+      body: 'intro',
+    });
+
+    expect(result).toBe('skipped');
+    expect(document.querySelector('.gv-coach')).toBeNull();
+    expect(document.querySelector('.gv-coach-scrim')).toBeNull();
+    expect(await hasSeenCoachmark('missing-anchor')).toBe(false);
+  });
+
   it('keeps the guide open while switching and confirms the selected state with Done', async () => {
     const anchor = document.createElement('div');
     document.body.appendChild(anchor);
@@ -410,7 +423,7 @@ describe('showCoachmark', () => {
     expect(document.querySelector('.partial-preview')).toBeNull();
   });
 
-  it('labels the dialog, focuses its action, and restores focus after explicit close', async () => {
+  it('labels the dialog, focuses its action by default, and restores focus after close', async () => {
     const anchor = document.createElement('button');
     document.body.appendChild(anchor);
     anchor.focus();
@@ -440,6 +453,33 @@ describe('showCoachmark', () => {
     close?.click();
     await pending;
     expect(document.activeElement).toBe(anchor);
+  });
+
+  it('leaves page focus untouched on open and cleanup when focusOnOpen is false', async () => {
+    const composer = document.createElement('textarea');
+    const nextFocus = document.createElement('button');
+    document.body.append(composer, nextFocus);
+    composer.focus();
+
+    const pending = showCoachmark({
+      id: 'non-focusing-guide',
+      anchor: () => composer,
+      body: 'Feature explanation',
+      dismissLabel: 'Done',
+      focusOnOpen: false,
+    });
+    await flush();
+    await flush();
+
+    expect(document.activeElement).toBe(composer);
+
+    nextFocus.focus();
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+    );
+
+    expect(await pending).toBe('dismissed');
+    expect(document.activeElement).toBe(nextFocus);
   });
 
   it('does not show twice when once is left default (second call skips)', async () => {

--- a/src/pages/content/coachmark/index.ts
+++ b/src/pages/content/coachmark/index.ts
@@ -80,6 +80,8 @@ export interface CoachmarkConfig {
   placement?: 'top' | 'bottom';
   /** Dim the page behind the coachmark. Default true. */
   scrim?: boolean;
+  /** Move focus into the coachmark on open and restore it on close. Default true. */
+  focusOnOpen?: boolean;
   /** Set false to always show (ignores + does not record seen state). */
   once?: boolean;
 }
@@ -217,6 +219,7 @@ function positionBubble(bubble: HTMLElement, anchor: HTMLElement, prefer: 'top' 
 
 export async function showCoachmark(cfg: CoachmarkConfig): Promise<CoachmarkResult> {
   const once = cfg.once !== false;
+  const focusOnOpen = cfg.focusOnOpen !== false;
   if (activeId) return 'skipped';
   if (once && (await hasSeenCoachmark(cfg.id))) return 'skipped';
 
@@ -351,7 +354,7 @@ export async function showCoachmark(cfg: CoachmarkConfig): Promise<CoachmarkResu
             /* gone */
           }
         }
-        if (restoreFocus && previouslyFocused?.isConnected) {
+        if (restoreFocus && focusOnOpen && previouslyFocused?.isConnected) {
           try {
             previouslyFocused.focus({ preventScroll: true });
           } catch {
@@ -435,8 +438,10 @@ export async function showCoachmark(cfg: CoachmarkConfig): Promise<CoachmarkResu
       window.addEventListener('click', onOutside, true);
       window.addEventListener('keydown', onKey, true);
       window.addEventListener('resize', onReflow);
-      const initialFocus = bubble.querySelector<HTMLElement>('.gv-coach-dismiss') ?? close;
-      initialFocus.focus({ preventScroll: true });
+      if (focusOnOpen) {
+        const initialFocus = bubble.querySelector<HTMLElement>('.gv-coach-dismiss') ?? close;
+        initialFocus.focus({ preventScroll: true });
+      }
     }, 0);
   });
 }

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -54,6 +54,8 @@ import { startMermaid } from './mermaid/index';
 import { startBrandTheme } from './platformTheme';
 import { startPreventAutoScroll } from './preventAutoScroll/index';
 import { startPromptManager } from './prompt/index';
+import { slashPromptCoachmarkStep } from './prompt/slashPromptCoachmark';
+import { startSlashPromptFeature } from './prompt/slashPromptFeature';
 import { startQuoteReply } from './quoteReply/index';
 import { startRemoteAnnouncements } from './remoteAnnouncements/index';
 import { startResponseCompleteNotification } from './responseNotification/index';
@@ -101,6 +103,7 @@ let initializationTimer: number | null = null;
 let folderManagerInstance: Awaited<ReturnType<typeof startFolderManager>> | null = null;
 
 let promptManagerInstance: Awaited<ReturnType<typeof startPromptManager>> | null = null;
+let slashPromptFeatureInstance: Awaited<ReturnType<typeof startSlashPromptFeature>> | null = null;
 let quoteReplyCleanup: (() => void) | null = null;
 let inputVimModeCleanup: (() => void) | null = null;
 let sendBehaviorCleanup: (() => void) | null = null;
@@ -143,6 +146,7 @@ function showOnboardingCoachmarksWhenChangelogIsIdle(): void {
     usageCoachmarkStep,
     folderSearchCoachmarkStep,
     conversationSortCoachmarkStep,
+    slashPromptCoachmarkStep,
   ])
     .then((result) => {
       if (result !== 'skipped') onboardingCoachmarkShownThisPage = true;
@@ -193,6 +197,8 @@ async function initializeFeatures(): Promise<void> {
     if (!hasValidExtensionContext()) {
       return;
     }
+
+    slashPromptFeatureInstance = await startSlashPromptFeature();
 
     // Yield between features instead of sleeping a fixed amount. On an idle main
     // thread (the common foreground case) requestIdleCallback fires on the next
@@ -636,6 +642,10 @@ function handleVisibilityChange(): void {
         if (promptManagerInstance) {
           promptManagerInstance.destroy();
           promptManagerInstance = null;
+        }
+        if (slashPromptFeatureInstance) {
+          slashPromptFeatureInstance.destroy();
+          slashPromptFeatureInstance = null;
         }
         if (quoteReplyCleanup) {
           quoteReplyCleanup();

--- a/src/pages/content/prompt/__tests__/lifecycle.test.ts
+++ b/src/pages/content/prompt/__tests__/lifecycle.test.ts
@@ -5,14 +5,21 @@ import { describe, expect, it, vi } from 'vitest';
 import { createSlashPromptLifecycle } from '../slashPrompt';
 
 describe('prompt manager lifecycle', () => {
-  it('reconciles slash completion when the runtime hide setting changes', () => {
-    const code = readFileSync(resolve(process.cwd(), 'src/pages/content/prompt/index.ts'), 'utf8');
-    const hideSettingBranch =
-      code.match(
-        /if \(area === 'sync' && changes\?\.gvHidePromptManager\) \{[\s\S]*?\n      \}/,
-      )?.[0] ?? '';
+  it('drives slash completion only from its independent sync setting', () => {
+    const slashFeatureCode = readFileSync(
+      resolve(process.cwd(), 'src/pages/content/prompt/slashPromptFeature.ts'),
+      'utf8',
+    );
+    const promptManagerCode = readFileSync(
+      resolve(process.cwd(), 'src/pages/content/prompt/index.ts'),
+      'utf8',
+    );
 
-    expect(hideSettingBranch).toContain('void setSlashPromptEnabled(!shouldHide);');
+    expect(slashFeatureCode).toContain('StorageKeys.SLASH_PROMPT_ENABLED');
+    expect(slashFeatureCode).not.toContain('gvHidePromptManager');
+    expect(slashFeatureCode).not.toContain('HIDE_PROMPT_MANAGER');
+    expect(promptManagerCode).not.toContain('SLASH_PROMPT_ENABLED');
+    expect(promptManagerCode).not.toContain('setSlashPromptEnabled');
   });
 
   it('marks duplicate-name prompts with a persistent non-blocking badge', () => {

--- a/src/pages/content/prompt/__tests__/slashPrompt.test.ts
+++ b/src/pages/content/prompt/__tests__/slashPrompt.test.ts
@@ -5,6 +5,7 @@ import { StorageKeys } from '@/core/types/common';
 import type { PromptItem } from '@/core/types/sync';
 
 import {
+  hasSlashEligiblePrompts,
   isGeminiSlashPromptSurface,
   matchSlashPrompts,
   startPromptSlashCommand,
@@ -115,6 +116,25 @@ describe('matchSlashPrompts', () => {
 
     expect(matchSlashPrompts(items, 'translator').map((item) => item.id)).toEqual(['first']);
     expect(matchSlashPrompts(items, 'editor').map((item) => item.id)).toEqual(['second']);
+  });
+});
+
+describe('hasSlashEligiblePrompts', () => {
+  it('requires a non-empty name that is not part of a normalized conflict group', () => {
+    const duplicateNames: PromptItem[] = [
+      { id: 'first', name: 'Translator', text: 'First body', tags: [], createdAt: 1 },
+      { id: 'second', name: 'ＴＲＡＮＳＬＡＴＯＲ', text: 'Second body', tags: [], createdAt: 2 },
+      { id: 'legacy', text: 'Legacy body', tags: [], createdAt: 3 },
+      { id: 'blank', name: '  ', text: 'Blank name', tags: [], createdAt: 4 },
+    ];
+
+    expect(hasSlashEligiblePrompts(duplicateNames)).toBe(false);
+    expect(
+      hasSlashEligiblePrompts([
+        ...duplicateNames,
+        { id: 'unique', name: 'Summarizer', text: 'Unique body', tags: [], createdAt: 5 },
+      ]),
+    ).toBe(true);
   });
 });
 

--- a/src/pages/content/prompt/__tests__/slashPromptCoachmark.test.ts
+++ b/src/pages/content/prompt/__tests__/slashPromptCoachmark.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findChatInput: vi.fn<() => HTMLElement | null>(),
+  getTranslationSync: vi.fn((key: string) => key),
+  hasSlashEligiblePrompts: vi.fn((items: unknown[]) => items.length > 0),
+  initI18n: vi.fn(async () => undefined),
+  isGeminiSlashPromptSurface: vi.fn(() => true),
+  promptStorageGet: vi.fn(),
+  showCoachmark: vi.fn(async (_config: unknown) => 'dismissed'),
+  storageGet: vi.fn(async (defaults?: Record<string, unknown>) => defaults ?? {}),
+  storageSet: vi.fn(async () => undefined),
+}));
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    storage: {
+      sync: {
+        get: mocks.storageGet,
+        set: mocks.storageSet,
+      },
+    },
+  },
+}));
+
+vi.mock('@/core/services/StorageService', () => ({
+  promptStorageService: {
+    get: mocks.promptStorageGet,
+  },
+}));
+
+vi.mock('@/utils/i18n', () => ({
+  getTranslationSync: mocks.getTranslationSync,
+  initI18n: mocks.initI18n,
+}));
+
+vi.mock('../../chatInput', () => ({
+  findChatInput: mocks.findChatInput,
+}));
+
+vi.mock('../../coachmark', () => ({
+  showCoachmark: mocks.showCoachmark,
+}));
+
+vi.mock('../slashPrompt', () => ({
+  hasSlashEligiblePrompts: mocks.hasSlashEligiblePrompts,
+  isGeminiSlashPromptSurface: mocks.isGeminiSlashPromptSurface,
+}));
+
+interface CapturedCoachmarkConfig {
+  anchor: () => HTMLElement | null;
+  focusOnOpen?: boolean;
+  id: string;
+  toggle: {
+    initial: boolean;
+    onChange: (enabled: boolean) => Promise<void>;
+  };
+}
+
+describe('slash prompt coachmark', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+    mocks.isGeminiSlashPromptSurface.mockReturnValue(true);
+    mocks.storageGet.mockImplementation(
+      async (defaults?: Record<string, unknown>) => defaults ?? {},
+    );
+    mocks.promptStorageGet.mockResolvedValue({ success: true, data: [] });
+    mocks.hasSlashEligiblePrompts.mockImplementation((items: unknown[]) => items.length > 0);
+  });
+
+  it('is eligible only when the setting is enabled and a usable Prompt exists', async () => {
+    const { isSlashPromptCoachmarkEligible } = await import('../slashPromptCoachmark');
+
+    expect(await isSlashPromptCoachmarkEligible()).toBe(false);
+
+    mocks.promptStorageGet.mockResolvedValue({
+      success: true,
+      data: [{ id: 'prompt-1', name: 'Review', text: 'Review this', tags: [], createdAt: 1 }],
+    });
+    expect(await isSlashPromptCoachmarkEligible()).toBe(true);
+
+    mocks.storageGet.mockResolvedValue({ gvSlashPromptEnabled: false });
+    expect(await isSlashPromptCoachmarkEligible()).toBe(false);
+  });
+
+  it('anchors without changing the composer draft or focus', async () => {
+    const composer = document.createElement('div');
+    composer.contentEditable = 'true';
+    composer.tabIndex = 0;
+    composer.textContent = 'unfinished draft';
+    document.body.appendChild(composer);
+    composer.focus();
+    mocks.findChatInput.mockReturnValue(composer);
+    mocks.promptStorageGet.mockResolvedValue({
+      success: true,
+      data: [{ id: 'prompt-1', name: 'Review', text: 'Review this', tags: [], createdAt: 1 }],
+    });
+
+    const { maybeShowSlashPromptCoachmark } = await import('../slashPromptCoachmark');
+    await maybeShowSlashPromptCoachmark();
+
+    const config = mocks.showCoachmark.mock.calls[0]![0] as CapturedCoachmarkConfig;
+    expect(config.id).toBe('slash-prompt-insertion-intro');
+    expect(config.focusOnOpen).toBe(false);
+    expect(config.anchor()).toBe(composer);
+    expect(composer.textContent).toBe('unfinished draft');
+    expect(document.activeElement).toBe(composer);
+  });
+
+  it('keeps the inline switch synchronized through the slash setting key', async () => {
+    mocks.promptStorageGet.mockResolvedValue({
+      success: true,
+      data: [{ id: 'prompt-1', name: 'Review', text: 'Review this', tags: [], createdAt: 1 }],
+    });
+    const { maybeShowSlashPromptCoachmark } = await import('../slashPromptCoachmark');
+    await maybeShowSlashPromptCoachmark();
+
+    const config = mocks.showCoachmark.mock.calls[0]![0] as CapturedCoachmarkConfig;
+    expect(config.toggle.initial).toBe(true);
+    await config.toggle.onChange(false);
+    expect(mocks.storageSet).toHaveBeenCalledWith({ gvSlashPromptEnabled: false });
+  });
+
+  it('can be forced by the debug event without an eligible Prompt', async () => {
+    const { SLASH_PROMPT_COACHMARK_DEBUG_EVENT } = await import('../slashPromptCoachmark');
+
+    document.dispatchEvent(new Event(SLASH_PROMPT_COACHMARK_DEBUG_EVENT));
+
+    await vi.waitFor(() => expect(mocks.showCoachmark).toHaveBeenCalled());
+  });
+
+  it('skips outside Gemini without mounting or marking anything', async () => {
+    mocks.isGeminiSlashPromptSurface.mockReturnValue(false);
+    const { maybeShowSlashPromptCoachmark } = await import('../slashPromptCoachmark');
+
+    expect(await maybeShowSlashPromptCoachmark({ force: true })).toBe('skipped');
+    expect(mocks.showCoachmark).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/content/prompt/__tests__/slashPromptFeature.test.ts
+++ b/src/pages/content/prompt/__tests__/slashPromptFeature.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { StorageKeys } from '@/core/types/common';
+
+import { startSlashPromptFeature } from '../slashPromptFeature';
+
+type StorageChangeListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: string,
+) => void;
+
+const storageMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+}));
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    storage: {
+      sync: {
+        get: storageMocks.get,
+      },
+      onChanged: {
+        addListener: storageMocks.addListener,
+        removeListener: storageMocks.removeListener,
+      },
+    },
+  },
+}));
+
+function getStorageListener(): StorageChangeListener {
+  const listener = storageMocks.addListener.mock.calls.at(-1)?.[0] as
+    | StorageChangeListener
+    | undefined;
+  expect(listener).toBeTypeOf('function');
+  return listener!;
+}
+
+async function flushRuntimeChange(): Promise<void> {
+  await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+}
+
+describe('slash prompt feature lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storageMocks.get.mockResolvedValue({ [StorageKeys.SLASH_PROMPT_ENABLED]: true });
+  });
+
+  it('stays inert on surfaces that do not support Gemini slash completion', async () => {
+    const start = vi.fn();
+
+    const feature = await startSlashPromptFeature({
+      pageUrl: 'https://aistudio.google.com/prompts/new_chat',
+      start,
+    });
+    feature.destroy();
+
+    expect(start).not.toHaveBeenCalled();
+    expect(storageMocks.get).not.toHaveBeenCalled();
+    expect(storageMocks.addListener).not.toHaveBeenCalled();
+    expect(storageMocks.removeListener).not.toHaveBeenCalled();
+  });
+
+  it('defaults to enabled and tears down its listener and controller exactly once', async () => {
+    storageMocks.get.mockResolvedValue({});
+    const destroyController = vi.fn();
+    const start = vi.fn().mockResolvedValue({ destroy: destroyController });
+
+    const feature = await startSlashPromptFeature({
+      pageUrl: 'https://gemini.google.com/app',
+      start,
+    });
+    const listener = getStorageListener();
+
+    expect(storageMocks.get).toHaveBeenCalledWith({
+      [StorageKeys.SLASH_PROMPT_ENABLED]: true,
+    });
+    expect(start).toHaveBeenCalledTimes(1);
+
+    feature.destroy();
+    feature.destroy();
+
+    expect(storageMocks.removeListener).toHaveBeenCalledTimes(1);
+    expect(storageMocks.removeListener).toHaveBeenCalledWith(listener);
+    expect(destroyController).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { hidePromptManager: false, slashPromptEnabled: true, expectedStarts: 1 },
+    { hidePromptManager: true, slashPromptEnabled: true, expectedStarts: 1 },
+    { hidePromptManager: false, slashPromptEnabled: false, expectedStarts: 0 },
+    { hidePromptManager: true, slashPromptEnabled: false, expectedStarts: 0 },
+  ])(
+    'uses only the slash setting when hide=$hidePromptManager and slash=$slashPromptEnabled',
+    async ({ hidePromptManager, slashPromptEnabled, expectedStarts }) => {
+      storageMocks.get.mockResolvedValue({
+        [StorageKeys.HIDE_PROMPT_MANAGER]: hidePromptManager,
+        [StorageKeys.SLASH_PROMPT_ENABLED]: slashPromptEnabled,
+      });
+      const start = vi.fn().mockResolvedValue({ destroy: vi.fn() });
+
+      const feature = await startSlashPromptFeature({
+        pageUrl: 'https://gemini.google.com/app',
+        start,
+      });
+
+      expect(start).toHaveBeenCalledTimes(expectedStarts);
+      feature.destroy();
+    },
+  );
+
+  it('starts and destroys completion immediately as the sync setting changes', async () => {
+    storageMocks.get.mockResolvedValue({ [StorageKeys.SLASH_PROMPT_ENABLED]: false });
+    const destroyController = vi.fn();
+    const start = vi.fn().mockResolvedValue({ destroy: destroyController });
+    const feature = await startSlashPromptFeature({
+      pageUrl: 'https://business.gemini.google/app',
+      start,
+    });
+    const listener = getStorageListener();
+
+    expect(start).not.toHaveBeenCalled();
+
+    listener({ [StorageKeys.SLASH_PROMPT_ENABLED]: { oldValue: false, newValue: true } }, 'sync');
+    await flushRuntimeChange();
+    expect(start).toHaveBeenCalledTimes(1);
+
+    listener({ [StorageKeys.SLASH_PROMPT_ENABLED]: { oldValue: true, newValue: false } }, 'sync');
+    await flushRuntimeChange();
+    expect(destroyController).toHaveBeenCalledTimes(1);
+
+    listener({ [StorageKeys.SLASH_PROMPT_ENABLED]: { oldValue: false, newValue: true } }, 'local');
+    listener({ unrelated: { oldValue: false, newValue: true } }, 'sync');
+    await flushRuntimeChange();
+    expect(start).toHaveBeenCalledTimes(1);
+
+    feature.destroy();
+  });
+
+  it('treats removing the setting as restoring the enabled default', async () => {
+    storageMocks.get.mockResolvedValue({ [StorageKeys.SLASH_PROMPT_ENABLED]: false });
+    const destroyController = vi.fn();
+    const start = vi.fn().mockResolvedValue({ destroy: destroyController });
+    const feature = await startSlashPromptFeature({
+      pageUrl: 'https://gemini.google.com/app',
+      start,
+    });
+
+    getStorageListener()(
+      { [StorageKeys.SLASH_PROMPT_ENABLED]: { oldValue: false, newValue: undefined } },
+      'sync',
+    );
+    await flushRuntimeChange();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    feature.destroy();
+    expect(destroyController).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a stale initial read overwrite a newer runtime setting', async () => {
+    let resolveInitialRead!: (value: Record<string, unknown>) => void;
+    storageMocks.get.mockImplementation(
+      () =>
+        new Promise<Record<string, unknown>>((resolve) => {
+          resolveInitialRead = resolve;
+        }),
+    );
+    const start = vi.fn().mockResolvedValue({ destroy: vi.fn() });
+
+    const initializing = startSlashPromptFeature({
+      pageUrl: 'https://gemini.google.com/app',
+      start,
+    });
+    await vi.waitFor(() => expect(storageMocks.get).toHaveBeenCalledTimes(1));
+
+    getStorageListener()(
+      { [StorageKeys.SLASH_PROMPT_ENABLED]: { oldValue: true, newValue: false } },
+      'sync',
+    );
+    resolveInitialRead({ [StorageKeys.SLASH_PROMPT_ENABLED]: true });
+    const feature = await initializing;
+
+    expect(start).not.toHaveBeenCalled();
+    feature.destroy();
+  });
+
+  it('destroys a controller whose runtime start finishes after feature teardown', async () => {
+    storageMocks.get.mockResolvedValue({ [StorageKeys.SLASH_PROMPT_ENABLED]: false });
+    let resolveStart!: (controller: { destroy: () => void }) => void;
+    const pendingStart = new Promise<{ destroy: () => void }>((resolve) => {
+      resolveStart = resolve;
+    });
+    const destroyController = vi.fn();
+    const start = vi.fn(() => pendingStart);
+    const feature = await startSlashPromptFeature({
+      pageUrl: 'https://gemini.google.com/app',
+      start,
+    });
+
+    getStorageListener()(
+      { [StorageKeys.SLASH_PROMPT_ENABLED]: { oldValue: false, newValue: true } },
+      'sync',
+    );
+    feature.destroy();
+    resolveStart({ destroy: destroyController });
+    await flushRuntimeChange();
+
+    expect(destroyController).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/content/prompt/index.ts
+++ b/src/pages/content/prompt/index.ts
@@ -51,11 +51,6 @@ import { extractPlainTitle } from './compactTitle';
 import { activatePromptText } from './promptClickAction';
 import { getPromptNameConflictIds, isPromptNameTaken, normalizePromptName } from './promptName';
 import { getScrollHintState } from './scrollHint';
-import {
-  createSlashPromptLifecycle,
-  isGeminiSlashPromptSurface,
-  startStoredPromptSlashCommand,
-} from './slashPrompt';
 import { formatStarredMessageTime } from './starredLibrary';
 import { sanitizeSelectedTags } from './tagFilterState';
 
@@ -429,18 +424,6 @@ function computeAnchoredPosition(
 }
 
 export async function startPromptManager(): Promise<{ destroy: () => void }> {
-  const slashPromptLifecycle = isGeminiSlashPromptSurface()
-    ? createSlashPromptLifecycle(startStoredPromptSlashCommand)
-    : null;
-  const setSlashPromptEnabled = async (enabled: boolean): Promise<void> => {
-    if (!slashPromptLifecycle) return;
-    try {
-      await slashPromptLifecycle.setEnabled(enabled);
-    } catch (error) {
-      pmLogger.warn('Failed to update slash prompt completion state', { enabled, error });
-    }
-  };
-
   let marked!: typeof MarkedFn;
   let DOMPurify!: typeof import('dompurify').default;
 
@@ -528,13 +511,6 @@ export async function startPromptManager(): Promise<{ destroy: () => void }> {
       // Ignore errors
     }
 
-    await setSlashPromptEnabled(!pmHiddenByUser);
-
-    if (pmHiddenByUser && !changelogBadgeActive) {
-      pmLogger.info('Prompt Manager is hidden by user settings');
-      return { destroy: () => {} };
-    }
-
     // Monkey patch console.warn to suppress KaTeX quirks mode warning in content script
     const originalWarn = console.warn;
     console.warn = function (...args) {
@@ -586,7 +562,7 @@ export async function startPromptManager(): Promise<{ destroy: () => void }> {
 
     // Prevent duplicate injection
     if (document.getElementById(ID.trigger)) {
-      return { destroy: () => slashPromptLifecycle?.destroy() };
+      return { destroy: () => {} };
     }
 
     // Trigger button
@@ -610,6 +586,9 @@ export async function startPromptManager(): Promise<{ destroy: () => void }> {
     trigger.appendChild(img);
     if (changelogBadgeActive) {
       trigger.classList.add('gv-pm-trigger-new');
+    }
+    if (pmHiddenByUser && !changelogBadgeActive) {
+      trigger.style.display = 'none';
     }
     document.body.appendChild(trigger);
     // Helper: place trigger near a target element (e.g. Gemini FAB touch target)
@@ -2163,7 +2142,6 @@ export async function startPromptManager(): Promise<{ destroy: () => void }> {
         const shouldHide = changes.gvHidePromptManager.newValue === true;
         pmHiddenByUser = shouldHide;
         pmLogger.info('Hide prompt manager setting changed', { shouldHide });
-        void setSlashPromptEnabled(!shouldHide);
         if (shouldHide && !changelogBadgeActive) {
           // Hide trigger and panel
           trigger.style.display = 'none';
@@ -2400,7 +2378,6 @@ export async function startPromptManager(): Promise<{ destroy: () => void }> {
     return {
       destroy: () => {
         try {
-          slashPromptLifecycle?.destroy();
           window.removeEventListener('resize', onWindowResize);
           window.removeEventListener('scroll', onReposition);
           window.removeEventListener('pointerdown', onWindowPointerDown, { capture: true });
@@ -2438,7 +2415,6 @@ export async function startPromptManager(): Promise<{ destroy: () => void }> {
       },
     };
   } catch (err) {
-    slashPromptLifecycle?.destroy();
     try {
       if (isExtensionContextInvalidatedError(err)) {
         return { destroy: () => {} };

--- a/src/pages/content/prompt/slashPrompt.ts
+++ b/src/pages/content/prompt/slashPrompt.ts
@@ -135,6 +135,11 @@ function usablePrompts(items: PromptItem[]): PromptItem[] {
   );
 }
 
+/** Returns whether at least one saved Prompt can be addressed unambiguously by slash completion. */
+export function hasSlashEligiblePrompts(items: PromptItem[]): boolean {
+  return usablePrompts(items).length > 0;
+}
+
 /** Matches names only. Prompt body and tags are deliberately excluded. */
 export function matchSlashPrompts(items: PromptItem[], query: string): PromptItem[] {
   const normalizedQuery = getPromptNameComparisonKey(query);

--- a/src/pages/content/prompt/slashPromptCoachmark.ts
+++ b/src/pages/content/prompt/slashPromptCoachmark.ts
@@ -1,0 +1,119 @@
+import browser from 'webextension-polyfill';
+
+import { promptStorageService } from '@/core/services/StorageService';
+import { StorageKeys } from '@/core/types/common';
+import type { PromptItem } from '@/core/types/sync';
+import { getTranslationSync, initI18n } from '@/utils/i18n';
+import type { TranslationKey } from '@/utils/translations';
+
+import { findChatInput } from '../chatInput';
+import {
+  type CoachmarkProgress,
+  type CoachmarkResult,
+  type CoachmarkSequenceStep,
+  showCoachmark,
+} from '../coachmark';
+import { hasSlashEligiblePrompts, isGeminiSlashPromptSurface } from './slashPrompt';
+
+export const SLASH_PROMPT_COACHMARK_ID = 'slash-prompt-insertion-intro';
+export const SLASH_PROMPT_COACHMARK_DEBUG_EVENT = 'gv:debug:slashPromptCoachmark';
+
+const t = (key: TranslationKey, fallback: string): string => {
+  try {
+    const value = getTranslationSync(key);
+    return value && value !== key ? value : fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+interface SlashPromptCoachmarkState {
+  enabled: boolean;
+  prompts: PromptItem[];
+}
+
+async function loadSlashPromptCoachmarkState(): Promise<SlashPromptCoachmarkState> {
+  const [setting, storedPrompts] = await Promise.all([
+    browser.storage.sync
+      .get({ [StorageKeys.SLASH_PROMPT_ENABLED]: true })
+      .catch(() => ({ [StorageKeys.SLASH_PROMPT_ENABLED]: true })),
+    promptStorageService.get<PromptItem[]>(StorageKeys.PROMPT_ITEMS),
+  ]);
+
+  return {
+    enabled: setting[StorageKeys.SLASH_PROMPT_ENABLED] !== false,
+    prompts: storedPrompts.success && Array.isArray(storedPrompts.data) ? storedPrompts.data : [],
+  };
+}
+
+async function setSlashPromptEnabled(enabled: boolean): Promise<void> {
+  try {
+    await browser.storage.sync.set({ [StorageKeys.SLASH_PROMPT_ENABLED]: enabled });
+  } catch {
+    /* non-critical */
+  }
+}
+
+export async function isSlashPromptCoachmarkEligible(): Promise<boolean> {
+  if (!isGeminiSlashPromptSurface()) return false;
+  const state = await loadSlashPromptCoachmarkState();
+  return state.enabled && hasSlashEligiblePrompts(state.prompts);
+}
+
+export async function maybeShowSlashPromptCoachmark(
+  options: { force?: boolean; progress?: CoachmarkProgress } = {},
+): Promise<CoachmarkResult> {
+  if (!isGeminiSlashPromptSurface()) return 'skipped';
+
+  const state = await loadSlashPromptCoachmarkState();
+  if (!options.force && (!state.enabled || !hasSlashEligiblePrompts(state.prompts))) {
+    return 'skipped';
+  }
+
+  try {
+    await initI18n();
+  } catch {
+    /* fall back to literals */
+  }
+
+  return showCoachmark({
+    id: SLASH_PROMPT_COACHMARK_ID,
+    once: !options.force,
+    scrim: true,
+    title: t('slashPromptCoachmarkTitle', 'New: slash prompt insertion'),
+    body: t(
+      'slashPromptCoachmarkBody',
+      'Type / in the Gemini composer to quickly insert a saved Prompt.',
+    ),
+    placement: 'top',
+    anchor: () => findChatInput(),
+    toggle: {
+      label: t('slashPromptCoachmarkToggle', 'Enable slash prompt insertion'),
+      initial: state.enabled,
+      onChange: setSlashPromptEnabled,
+    },
+    dismissLabel: t('coachmarkDismiss', 'Done'),
+    nextLabel: t('coachmarkNext', 'Next'),
+    closeLabel: t('coachmarkClose', 'Close'),
+    progress: options.progress,
+    focusOnOpen: false,
+  });
+}
+
+export const slashPromptCoachmarkStep: CoachmarkSequenceStep = {
+  id: SLASH_PROMPT_COACHMARK_ID,
+  isEligible: isSlashPromptCoachmarkEligible,
+  show: (progress) => maybeShowSlashPromptCoachmark({ progress }),
+};
+
+const showDebugSlashPromptCoachmark = () => void maybeShowSlashPromptCoachmark({ force: true });
+
+// Debug from the page console:
+// document.dispatchEvent(new Event('gv:debug:slashPromptCoachmark'))
+try {
+  (window as unknown as Record<string, unknown>).__gvSlashPromptCoachmark =
+    showDebugSlashPromptCoachmark;
+  document.addEventListener(SLASH_PROMPT_COACHMARK_DEBUG_EVENT, showDebugSlashPromptCoachmark);
+} catch {
+  /* ignore */
+}

--- a/src/pages/content/prompt/slashPromptFeature.ts
+++ b/src/pages/content/prompt/slashPromptFeature.ts
@@ -1,0 +1,90 @@
+import browser from 'webextension-polyfill';
+
+import { logger } from '@/core/services/LoggerService';
+import { StorageKeys } from '@/core/types/common';
+
+import {
+  type SlashPromptController,
+  createSlashPromptLifecycle,
+  isGeminiSlashPromptSurface,
+  startStoredPromptSlashCommand,
+} from './slashPrompt';
+
+const slashPromptFeatureLogger = logger.createChild('SlashPromptFeature');
+
+export interface SlashPromptFeatureOptions {
+  pageUrl?: string;
+  start?: () => Promise<SlashPromptController>;
+}
+
+/**
+ * Owns slash completion independently from the Prompt Manager UI.
+ *
+ * Unsupported surfaces return an inert controller without touching storage.
+ */
+export async function startSlashPromptFeature(
+  options: SlashPromptFeatureOptions = {},
+): Promise<SlashPromptController> {
+  if (!isGeminiSlashPromptSurface(options.pageUrl)) {
+    return { destroy: () => {} };
+  }
+
+  const lifecycle = createSlashPromptLifecycle(options.start ?? startStoredPromptSlashCommand);
+  let destroyed = false;
+  let receivedRuntimeSetting = false;
+  let latestReconciliation = Promise.resolve();
+
+  const reconcile = (enabled: boolean): Promise<void> => {
+    const reconciliation = lifecycle.setEnabled(enabled).catch((error: unknown) => {
+      slashPromptFeatureLogger.warn('Failed to update slash prompt completion state', {
+        enabled,
+        error,
+      });
+    });
+    latestReconciliation = reconciliation;
+    return reconciliation;
+  };
+
+  const onStorageChanged = (
+    changes: Record<string, browser.Storage.StorageChange>,
+    areaName: string,
+  ): void => {
+    if (destroyed || areaName !== 'sync') return;
+    const settingChange = changes[StorageKeys.SLASH_PROMPT_ENABLED];
+    if (!settingChange) return;
+
+    receivedRuntimeSetting = true;
+    void reconcile(settingChange.newValue !== false);
+  };
+
+  browser.storage.onChanged.addListener(onStorageChanged);
+
+  let initiallyEnabled = true;
+  try {
+    const stored = await browser.storage.sync.get({
+      [StorageKeys.SLASH_PROMPT_ENABLED]: true,
+    });
+    initiallyEnabled = stored[StorageKeys.SLASH_PROMPT_ENABLED] !== false;
+  } catch (error) {
+    slashPromptFeatureLogger.warn(
+      'Failed to read slash prompt setting, continuing with the enabled default',
+      { error },
+    );
+  }
+
+  if (!receivedRuntimeSetting) {
+    await reconcile(initiallyEnabled);
+  } else {
+    // A live change that arrived during the initial read is authoritative.
+    await latestReconciliation;
+  }
+
+  return {
+    destroy: () => {
+      if (destroyed) return;
+      destroyed = true;
+      browser.storage.onChanged.removeListener(onStorageChanged);
+      lifecycle.destroy();
+    },
+  };
+}

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -396,6 +396,12 @@ const POPUP_SETTINGS_SEARCH_ITEMS = [
     'hidePromptManager',
     'hidePromptManagerHint',
   ]),
+  popupSearchTarget(
+    'promptManager',
+    'slashPromptEnabled',
+    ['slashPromptEnabled', 'slashPromptEnabledHint'],
+    ['slash autocomplete quick insert 斜杠 快速插入'],
+  ),
   popupSearchTarget('promptManager', 'promptInsertOnClick', [
     'promptInsertOnClick',
     'promptInsertOnClickHint',
@@ -745,6 +751,7 @@ interface SettingsUpdate {
   watermarkDownloadEnabled?: boolean;
   watermarkPreviewEnabled?: boolean;
   hidePromptManager?: boolean;
+  slashPromptEnabled?: boolean;
   promptInsertOnClickEnabled?: boolean;
   inputCollapseEnabled?: boolean;
   inputCollapseWhenNotEmpty?: boolean;
@@ -944,6 +951,7 @@ export default function Popup({ sourceTabId }: PopupProps = {}) {
   const [watermarkDownloadEnabled, setWatermarkDownloadEnabled] = useState<boolean>(true);
   const [watermarkPreviewEnabled, setWatermarkPreviewEnabled] = useState<boolean>(true);
   const [hidePromptManager, setHidePromptManager] = useState<boolean>(false);
+  const [slashPromptEnabled, setSlashPromptEnabled] = useState<boolean>(true);
   const [promptInsertOnClickEnabled, setPromptInsertOnClickEnabled] = useState<boolean>(false);
   const [promptMigrationStatus, setPromptMigrationStatus] = useState<{
     kind: 'ok' | 'warn' | 'err';
@@ -1276,6 +1284,8 @@ export default function Popup({ sourceTabId }: PopupProps = {}) {
       }
       if (typeof settings.hidePromptManager === 'boolean')
         payload.gvHidePromptManager = settings.hidePromptManager;
+      if (typeof settings.slashPromptEnabled === 'boolean')
+        payload[StorageKeys.SLASH_PROMPT_ENABLED] = settings.slashPromptEnabled;
       if (typeof settings.promptInsertOnClickEnabled === 'boolean')
         payload[StorageKeys.PROMPT_INSERT_ON_CLICK] = settings.promptInsertOnClickEnabled;
       if (typeof settings.inputCollapseEnabled === 'boolean')
@@ -1850,6 +1860,7 @@ export default function Popup({ sourceTabId }: PopupProps = {}) {
           [StorageKeys.WATERMARK_DOWNLOAD_ENABLED]: null,
           [StorageKeys.WATERMARK_PREVIEW_ENABLED]: null,
           gvHidePromptManager: false,
+          [StorageKeys.SLASH_PROMPT_ENABLED]: true,
           [StorageKeys.PROMPT_INSERT_ON_CLICK]: false,
           gvInputCollapseEnabled: false,
           gvInputCollapseWhenNotEmpty: false,
@@ -1938,6 +1949,7 @@ export default function Popup({ sourceTabId }: PopupProps = {}) {
             setWatermarkPreviewEnabled(watermarkSettings.preview);
           }
           setHidePromptManager(!!res?.gvHidePromptManager);
+          setSlashPromptEnabled(res?.[StorageKeys.SLASH_PROMPT_ENABLED] !== false);
           setPromptInsertOnClickEnabled(res?.[StorageKeys.PROMPT_INSERT_ON_CLICK] === true);
           setInputCollapseEnabled(res?.gvInputCollapseEnabled !== false);
           setInputCollapseWhenNotEmpty(res?.gvInputCollapseWhenNotEmpty === true);
@@ -3911,6 +3923,31 @@ export default function Popup({ sourceTabId }: PopupProps = {}) {
                     onChange={(e) => {
                       setHidePromptManager(e.target.checked);
                       apply({ hidePromptManager: e.target.checked });
+                    }}
+                  />
+                </div>,
+              )}
+              {renderSetting(
+                'promptManager',
+                'slashPromptEnabled',
+                <div className="group flex items-center justify-between">
+                  <div className="flex-1">
+                    <Label
+                      htmlFor="slash-prompt-enabled"
+                      className="group-hover:text-primary cursor-pointer text-sm font-medium transition-colors"
+                    >
+                      {t('slashPromptEnabled')}
+                    </Label>
+                    <p className="text-muted-foreground mt-1 text-xs">
+                      {t('slashPromptEnabledHint')}
+                    </p>
+                  </div>
+                  <Switch
+                    id="slash-prompt-enabled"
+                    checked={slashPromptEnabled}
+                    onChange={(e) => {
+                      setSlashPromptEnabled(e.target.checked);
+                      apply({ slashPromptEnabled: e.target.checked });
                     }}
                   />
                 </div>,

--- a/src/pages/popup/utils/settingsSearch.test.ts
+++ b/src/pages/popup/utils/settingsSearch.test.ts
@@ -54,6 +54,20 @@ describe('settings search', () => {
     expect(matches.has('general:section')).toBe(false);
   });
 
+  it('finds the slash prompt toggle through its localized copy', () => {
+    const matches = getSettingsSearchMatches(
+      [
+        {
+          id: 'promptManager:slashPromptEnabled',
+          keys: ['slashPromptEnabled', 'slashPromptEnabledHint'],
+        },
+      ],
+      '斜杠',
+    );
+
+    expect(matches.has('promptManager:slashPromptEnabled')).toBe(true);
+  });
+
   it('does not match unrelated words', () => {
     const matches = getSettingsSearchMatches(
       [{ id: 'general', keys: ['responseCompleteNotification'] }],


### PR DESCRIPTION
### AI-Assisted PR Policy / AI 辅助 PR 政策

- AI-assisted PRs are welcome, but they must be manually reviewed and verified by the contributor. / 欢迎使用 AI 辅助提交 PR，但贡献者必须亲自复核和验证。
- You are responsible for the PR's goal, scope, behavior, and verification results. You do not need to fully understand every line generated by an agent, but you should be able to explain what the PR is trying to solve and why the approach is reasonable. / 你需要为 PR 的目标、范围、行为变化和验证结果负责。你不必完全读懂 Agent 生成的每一行代码，但应该能说明这个 PR 要解决什么，以及为什么这个方案是合理的。
- Before coding, discuss the requirement with your agent clearly: expected behavior, affected pages/features, and how to verify it. / 开始改代码前，请先和 Agent 讨论清楚需求：预期行为、影响范围，以及如何验证。
- Keep the PR focused: one PR should fix one issue or make one coherent change. / 保持 PR 聚焦：一个 PR 只修一个问题，或只做一个清晰完整的改动。
- After changing code, manually use the feature yourself. For UI/behavior changes, please spend about 15 minutes trying the real workflow when possible. / 改完后请亲自手动体验。涉及 UI 或行为变化时，条件允许的话请用真实流程体验约 15 分钟。
- Provide visual proof after verification: screenshots, screen recordings, or before/after clips. / 验证后请提供可视化证据：截图、录屏或前后对比。

---

### Description / 描述

This PR separates Slash Prompt insertion from Prompt Manager visibility and adds an independent, default-enabled setting plus a one-time onboarding coachmark.

#### Root cause

Slash Prompt initialization previously lived inside the Prompt Manager visibility path. Hiding Prompt Manager therefore disabled slash insertion as a side effect, and users had no independent setting or guided introduction for slash insertion.

#### Changes

- add the sync-backed `gvSlashPromptEnabled` setting to the Popup, settings search, backup defaults, and all 10 locales
- give Slash Prompt an explicit start/destroy lifecycle with live storage updates and initialization race protection
- keep Slash Prompt independent from `Hide Prompt Manager`
- keep Prompt Manager hide/unhide live by constructing its UI even when hidden at startup
- add the `slash-prompt-insertion-intro` coachmark with the shared setting, eligibility checks, synced seen state, debug trigger, and no composer focus mutation
- add focused lifecycle, eligibility, localization, backup, and coachmark tests

#### Expected behavior matrix

| Hide Prompt Manager | Slash Prompt | Expected result |
| --- | --- | --- |
| off | on | Prompt Manager trigger visible; slash insertion active |
| on | on | Prompt Manager trigger hidden; slash insertion remains active |
| off | off | Prompt Manager trigger visible; slash listeners and UI destroyed |
| on | off | Neither surface active |

#### Verification

Tested code SHA: `4ffbb31b168d366e883da1ffa7753d6042f5cd4d`

Automated verification:

- `bun run typecheck` — passed
- focused Vitest suite — 7 files / 115 tests passed
- formatting and lint checks — passed
- Chrome, Edge, Firefox, and Safari builds — passed
- GitHub Actions Test, Typecheck, Format, Lint, i18n, browser builds, and Native Swift/Xcode checks — passed

Contributor manual verification on Windows 11 24H2 — Chrome 150.0.7871.187 and Firefox 153.0:

- created, searched, edited, copied, and deleted a temporary Prompt
- matched the temporary Prompt with `/` and inserted a Slash Prompt token
- verified Slash Prompt on/off changes take effect without a page reload
- verified `Hide Prompt Manager = on` + `Slash Prompt = on` keeps `/` insertion working
- verified `Hide Prompt Manager = off` + `Slash Prompt = off` keeps Prompt Manager available while slash completion remains absent
- with Slash Prompt disabled and **Insert prompt on click** enabled, clicking a saved Prompt inserted its body into the Gemini composer, and slash completion remained absent
- cleared the Gemini draft and removed the temporary Prompt; no Gemini message was sent

### Related Issue / 相关 Issue

Closes #864

- [x] If the issue is labeled `community-only`, I was assigned after maintainer approval before starting. / 如果 Issue 带有 `community-only` 标签，我已在开始前获得维护者确认并被分配。 *(N/A: the issue is not labeled `community-only`; it is claimed and assigned to @ivaris03.)*

### Visual Proof / 可视化证据

<!-- REQUIRED for UI/behavior changes: Provide screenshots, screen recordings, or before/after clips after manual verification. -->
<!-- UI/行为修改必填：请在手动验证后提供截图、录屏或前后对比。 -->

<img width="2560" height="1440" alt="3a1bc5409d3429c936fd26a94363d649" src="https://github.com/user-attachments/assets/00de4c2e-4f95-4f57-867a-1bbf86c13694" />

This is Chrome using a light theme, while Firefox uses a dark theme. Opening both confirms this: if there was a prompt earlier, it will initiate a guide.
这个是 Chrome 用亮色主题，然后 Firefox 用暗色主题，打开都证明了这一点：如果你之前有提示词的情况下，它会进行一次引导。

---

<img width="320" height="603" alt="b81c03874015017f5d899c8928dd077e" src="https://github.com/user-attachments/assets/4967cb50-9f57-4b20-b08c-1b5902d752bf" />

This is in the manager, specifically the toggle for the quick insert prompt feature.
这个是在 manager 里面，就是这个快速插入提示这个功能的开关

---

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/583058d9-f5fe-4882-9fe4-a19062967878" />

Screenshot of the toggle for the quick prompt insertion feature in Firefox's Voyager in dark mode.
这个在 firefox 的 voyager 在暗色状态下，快速插入提示词功能的开关的截图

---

https://github.com/user-attachments/assets/5d4001c4-5814-4c7f-9ca3-8ac3a368d7a9

This is a complete demonstration of the feature: when turned on, it can match stickers normally; when turned off, the function is properly disabled.
这个是这个功能的一个完整的演示：在打开状态下，这个是能正常匹配贴纸的；然后关闭状态下，这个功能是正常关闭的。

---

https://github.com/user-attachments/assets/362f34f0-f933-4f56-880e-65657cb8a1b0

This is the result of a complete test on Firefox: when hidden prompts are used but the "quick insert prompt words" feature is enabled, it works normally. When "prompt word management" is enabled but the "quick insert prompt words" feature is disabled, it is not possible to quickly insert prompt words. Moreover, the CRUD functions of this prompt management are all working properly.
这是在 Firefox 上面完整测试的结果：在隐藏提示词但开启“快速插入提示词”功能下，表现是正常的。在开启“提示词管理”但关闭“快速插入提示词”功能时，是无法快速插入提示词的。并且，这个提示管理的增删改查功能都是正常的。

### Browser Testing / 浏览器测试

- [x] **Chrome / Edge (Chromium)**: Tested / 已测试
- [x] **Firefox**: Tested (Mandatory) / 已测试（必填）
- [ ] **Safari**: Tested (Optional) or labeled as unsupported / 已测试（可选）或已标注为不支持

### Checklist / 检查清单

- [x] If I used an agent, I discussed the requirement, affected scope, and verification plan clearly. / 如果使用了 Agent，我已讨论清楚需求、影响范围和验证方式。
- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] For UI/behavior changes, I have tried the real workflow for about 15 minutes when possible. / 对于 UI/行为改动，条件允许时我已用真实流程体验约 15 分钟。
- [x] For UI/behavior changes, I have included visual proof after verification. / 对于 UI/行为改动，我已在验证后提供可视化证据。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] This PR focuses on one issue or one coherent change. / 此 PR 只聚焦一个问题或一个清晰完整的改动。
- [x] I have run `bun run lint`, `bun run typecheck`, `bun run format` and `bun run build`. / 我已运行代码校验、类型检查、格式化及构建。
- [x] I have added/updated necessary tests and they pass (`bun run test`). / 我已添加/更新了必要的测试并确保通过（`bun run test`).