### PR TITLE
fix: remove nonexistent badges/*.svg from git-auto-commit file_pattern

### DIFF
--- a/.github/workflows/update-readme-badges.yml
+++ b/.github/workflows/update-readme-badges.yml
@@ -25,4 +25,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
         with:
           commit_message: 'chore: update readme badges'
-          file_pattern: 'badges/*.svg docs/public/badges/*.svg'
+          file_pattern: 'docs/public/badges/*.svg'


### PR DESCRIPTION
The `Update README Badges` workflow has been failing every day
([example run](https://github.com/Nagi-ovo/voyager/actions/runs/30237196052))
with:

```
fatal: pathspec 'badges/*.svg' did not match any files
Error: Invalid status code: 128
```

## Root cause

In `85b5166`, the `badges/` directory was removed and the script was
updated to only output to `docs/public/badges/`, but the workflow's
`file_pattern` was not updated accordingly. It still references the
nonexistent `badges/*.svg`, causing `git add` to exit with 128.

## Fix

Remove `badges/*.svg` from `file_pattern`, leaving only
`docs/public/badges/*.svg`.