### PR TITLE
test(ci): docs-only change to verify path routing (#843)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -146,3 +146,5 @@ features:
 <p align="center">
   <img src="https://count.getloli.com/@gemini-voyager?name=gemini-voyager&theme=rule34&padding=7&offset=0&align=top&scale=1&pixelated=1&darkmode=auto" width="400">
 </p>
+
+<!-- CI path-routing verification (#843): docs-only change, PR will be closed without merging. -->


### PR DESCRIPTION
Docs-only PR to verify the new path-based CI routing: browser builds and the macOS native job should be **skipped**; Format, Docs Build, and CI Summary should run. Will be closed without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)