### PR TITLE
fix(watermark): handle dark and low-confidence watermark matches

### DIFF
--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -26,6 +26,37 @@ Regression test:
 Commit:
 ```
 
+## Dark watermark restoration must distinguish clipping from severe undershoot
+
+Symptom:
+
+Valid white watermarks on dark backgrounds were left untouched even when the
+template and anchor matched, because correct restoration produced many black
+or channel-clipped pixels.
+
+Root cause:
+
+The removal safety gate treated the number of newly black/clipped pixels as
+proof of damage. It could not distinguish a correct reconstruction near zero
+from an over-strong alpha subtraction that fell far below zero before clipping.
+
+Fix:
+
+When the legacy near-black or clipping limits are exceeded, only roll back if
+at least 10% of watermark-region pixels have a raw reverse-alpha channel below
+`-5`.
+
+Regression test:
+
+`src/pages/content/watermarkRemover/__tests__/watermarkEngine.test.ts`
+(`accepts clipped pixels that reconstruct a dark background without severe
+undershoot` and `rejects a watermark-like pattern when trial removal would clip
+pixels`).
+
+Commit:
+
+`fix(watermark): distinguish dark restoration from clipping damage`
+
 ## Mermaid must honor Gemini explicit light theme
 
 Symptom:

--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -26,6 +26,44 @@ Regression test:
 Commit:
 ```
 
+## Low-confidence watermark matches require isolated trial removal
+
+Symptom:
+
+Gemini watermarks at a known template and anchor could remain untouched when
+image content weakened their spatial and gradient correlations just below the
+trusted detection thresholds.
+
+Root cause:
+
+The anchor chooser returned the historical default when no candidate was
+trusted, and the removal path then rejected that same untrusted signal without
+testing whether one reverse-alpha pass would specifically suppress the known
+watermark pattern.
+
+Fix:
+
+When every known anchor misses the trusted thresholds, trial each preset
+template and allowed snap offset independently against the original pixels.
+Accept only candidates whose spatial and gradient signals both decrease, whose
+combined suppression exceeds `0.08`, and whose severe-undershoot ratio stays
+below `0.1`; restore every trial before applying the strongest candidate once.
+The existing trusted path remains unchanged and keeps priority.
+
+Regression test:
+
+`src/pages/content/watermarkRemover/__tests__/watermarkEngine.test.ts`
+(`accepts a difficult match only when both signals improve and removal stays
+safe`, `selects the strongest difficult candidate without retaining trial
+pixels`, `finds a difficult small watermark at a snapped offset`, and `leaves
+trial pixels unchanged when no difficult candidate qualifies`). The same file
+also verifies that the difficult path applies exactly one pass and never takes
+over after a trusted candidate's safety rollback.
+
+Commit:
+
+`fix(watermark): add difficult-match fallback`
+
 ## Dark watermark restoration must distinguish clipping from severe undershoot
 
 Symptom:

--- a/src/pages/content/watermarkRemover/__tests__/watermarkEngine.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/watermarkEngine.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import { removeWatermark } from '../blendModes';
 import {
+  assessDifficultWatermarkRemovalCandidate,
   getWatermarkSignalStrength,
   hasAcceptableWatermarkRemovalEvidence,
   hasReliableWatermarkSignal,
@@ -11,9 +13,11 @@ import {
   type WatermarkAnchorOption,
   type WatermarkConfig,
   calculateWatermarkPosition,
+  chooseDifficultWatermarkAnchorOption,
   chooseWatermarkAnchorOption,
   detectWatermarkConfig,
   getWatermarkConfigOptions,
+  removeWatermarkFromAnchorOptions,
   removeWatermarkWithResidualCheck,
 } from '../watermarkEngine';
 
@@ -21,21 +25,37 @@ const TEST_ALPHA_MAP = Float32Array.from([
   0.02, 0.15, 0.15, 0.02, 0.15, 0.8, 0.8, 0.15, 0.15, 0.8, 0.8, 0.15, 0.02, 0.15, 0.15, 0.02,
 ]);
 
+const WEAK_DIFFICULT_ALPHA_MAP = Float32Array.from(TEST_ALPHA_MAP, (alpha) => alpha * 0.15);
+const STRONG_DIFFICULT_ALPHA_MAP = Float32Array.from(TEST_ALPHA_MAP, (alpha) => alpha * 0.5);
+const WEAK_DIFFICULT_BASE_PATTERN = [
+  93, 131, 74, 82, 64, 50, 129, 101, 27, 77, 218, 34, 221, 116, 76, 131,
+];
+const STRONG_DIFFICULT_BASE_PATTERN = [
+  24, 102, 48, 226, 59, 235, 28, 58, 65, 64, 103, 204, 33, 179, 216, 173,
+];
+
+function createSolidImageData(value = 80): ImageData {
+  const width = 24;
+  const height = 24;
+  const data = new Uint8ClampedArray(width * height * 4);
+
+  for (let index = 0; index < data.length; index += 4) {
+    data[index] = value;
+    data[index + 1] = value;
+    data[index + 2] = value;
+    data[index + 3] = 255;
+  }
+
+  return { data, width, height } as ImageData;
+}
+
 function createImageDataWithWatermark(
   config: WatermarkConfig,
   layers = 1,
   baseValue = 80,
 ): ImageData {
-  const width = 24;
-  const height = 24;
-  const data = new Uint8ClampedArray(width * height * 4);
-
-  for (let i = 0; i < data.length; i += 4) {
-    data[i] = baseValue;
-    data[i + 1] = baseValue;
-    data[i + 2] = baseValue;
-    data[i + 3] = 255;
-  }
+  const imageData = createSolidImageData(baseValue);
+  const { data, width, height } = imageData;
 
   const position = calculateWatermarkPosition(width, height, config);
   for (let row = 0; row < position.height; row++) {
@@ -52,7 +72,7 @@ function createImageDataWithWatermark(
     }
   }
 
-  return { data, width, height } as ImageData;
+  return imageData;
 }
 
 function createImageDataWithWeakAlphaPattern(config: WatermarkConfig): ImageData {
@@ -97,6 +117,26 @@ function writeGrayscalePattern(
   }
 }
 
+function writeSyntheticWatermark(
+  imageData: ImageData,
+  config: WatermarkConfig,
+  alphaMap: Float32Array,
+  basePattern: number[],
+): void {
+  const position = calculateWatermarkPosition(imageData.width, imageData.height, config);
+  for (let row = 0; row < position.height; row++) {
+    for (let col = 0; col < position.width; col++) {
+      const alphaIndex = row * position.width + col;
+      const alpha = alphaMap[alphaIndex];
+      const value = Math.round(255 * alpha + basePattern[alphaIndex] * (1 - alpha));
+      const imageIndex = ((position.y + row) * imageData.width + position.x + col) * 4;
+      imageData.data[imageIndex] = value;
+      imageData.data[imageIndex + 1] = value;
+      imageData.data[imageIndex + 2] = value;
+    }
+  }
+}
+
 function fillRegionAboveWatermark(
   imageData: ImageData,
   config: WatermarkConfig,
@@ -130,6 +170,208 @@ function expectWatermarkAreaNearBase(imageData: ImageData, config: WatermarkConf
 }
 
 describe('watermarkEngine config detection', () => {
+  it('accepts a difficult match only when both signals improve and removal stays safe', () => {
+    const assessment = assessDifficultWatermarkRemovalCandidate(
+      { spatialScore: 0.25, gradientScore: 0.2 },
+      { spatialScore: -0.1, gradientScore: 0.1 },
+      0.099,
+    );
+
+    expect(assessment.originalStrength).toBeCloseTo(0.185);
+    expect(assessment.finalResidualStrength).toBeCloseTo(0.08);
+    expect(assessment.suppression).toBeCloseTo(0.105);
+    expect(assessment.eligible).toBe(true);
+  });
+
+  it.each([
+    {
+      name: 'suppression equals the strict minimum',
+      originalSignal: { spatialScore: 0.2, gradientScore: 0.1 },
+      finalSignal: { spatialScore: 0.1, gradientScore: 0 },
+      severeUndershootRatio: 0,
+    },
+    {
+      name: 'severe undershoot equals the strict maximum',
+      originalSignal: { spatialScore: 0.25, gradientScore: 0.2 },
+      finalSignal: { spatialScore: -0.1, gradientScore: 0.1 },
+      severeUndershootRatio: 0.1,
+    },
+    {
+      name: 'spatial correlation does not decrease',
+      originalSignal: { spatialScore: 0.2, gradientScore: 0.5 },
+      finalSignal: { spatialScore: -0.2, gradientScore: 0 },
+      severeUndershootRatio: 0,
+    },
+    {
+      name: 'gradient correlation does not decrease',
+      originalSignal: { spatialScore: 0.25, gradientScore: 0.1 },
+      finalSignal: { spatialScore: 0.05, gradientScore: 0.1 },
+      severeUndershootRatio: 0,
+    },
+  ])(
+    'rejects a difficult match when $name',
+    ({ originalSignal, finalSignal, severeUndershootRatio }) => {
+      expect(
+        assessDifficultWatermarkRemovalCandidate(originalSignal, finalSignal, severeUndershootRatio)
+          .eligible,
+      ).toBe(false);
+    },
+  );
+
+  it('selects the strongest difficult candidate without retaining trial pixels', () => {
+    const weakConfig = { logoSize: 4, marginRight: 1, marginBottom: 1 };
+    const strongConfig = {
+      logoSize: 4,
+      marginRight: 9,
+      marginBottom: 9,
+      alphaVariant: '20260520' as const,
+    };
+    const imageData = createSolidImageData();
+    writeSyntheticWatermark(
+      imageData,
+      weakConfig,
+      WEAK_DIFFICULT_ALPHA_MAP,
+      WEAK_DIFFICULT_BASE_PATTERN,
+    );
+    writeSyntheticWatermark(
+      imageData,
+      strongConfig,
+      STRONG_DIFFICULT_ALPHA_MAP,
+      STRONG_DIFFICULT_BASE_PATTERN,
+    );
+    const originalPixels = new Uint8ClampedArray(imageData.data);
+    const weakOption = { config: weakConfig, alphaMap: WEAK_DIFFICULT_ALPHA_MAP };
+    const strongOption = { config: strongConfig, alphaMap: STRONG_DIFFICULT_ALPHA_MAP };
+
+    for (const option of [weakOption, strongOption]) {
+      const position = calculateWatermarkPosition(imageData.width, imageData.height, option.config);
+      expect(
+        hasReliableWatermarkSignal(measureWatermarkSignal(imageData, option.alphaMap, position)),
+      ).toBe(false);
+    }
+
+    expect(chooseDifficultWatermarkAnchorOption(imageData, [weakOption])).toBe(weakOption);
+    expect(chooseDifficultWatermarkAnchorOption(imageData, [strongOption])).toBe(strongOption);
+    expect(chooseDifficultWatermarkAnchorOption(imageData, [weakOption, strongOption])).toBe(
+      strongOption,
+    );
+    expect(imageData.data).toEqual(originalPixels);
+  });
+
+  it('finds a difficult small watermark at a snapped offset', () => {
+    const baseConfig = {
+      logoSize: 4,
+      marginRight: 9,
+      marginBottom: 9,
+      alphaVariant: '20260520-small' as const,
+    };
+    const shiftedConfig = {
+      ...baseConfig,
+      marginRight: 7,
+      marginBottom: 10,
+    };
+    const imageData = createSolidImageData();
+    writeSyntheticWatermark(
+      imageData,
+      shiftedConfig,
+      STRONG_DIFFICULT_ALPHA_MAP,
+      STRONG_DIFFICULT_BASE_PATTERN,
+    );
+    const originalPixels = new Uint8ClampedArray(imageData.data);
+
+    expect(
+      chooseDifficultWatermarkAnchorOption(imageData, [
+        { config: baseConfig, alphaMap: STRONG_DIFFICULT_ALPHA_MAP },
+      ])?.config,
+    ).toEqual(shiftedConfig);
+    expect(imageData.data).toEqual(originalPixels);
+  });
+
+  it('leaves trial pixels unchanged when no difficult candidate qualifies', () => {
+    const config = { logoSize: 4, marginRight: 1, marginBottom: 1 };
+    const imageData = createSolidImageData();
+    const originalPixels = new Uint8ClampedArray(imageData.data);
+
+    expect(
+      chooseDifficultWatermarkAnchorOption(imageData, [
+        { config, alphaMap: STRONG_DIFFICULT_ALPHA_MAP },
+      ]),
+    ).toBeUndefined();
+    expect(imageData.data).toEqual(originalPixels);
+  });
+
+  it('applies an accepted difficult candidate exactly once', () => {
+    const config = {
+      logoSize: 4,
+      marginRight: 9,
+      marginBottom: 9,
+      alphaVariant: '20260520' as const,
+    };
+    const imageData = createSolidImageData();
+    writeSyntheticWatermark(
+      imageData,
+      config,
+      STRONG_DIFFICULT_ALPHA_MAP,
+      STRONG_DIFFICULT_BASE_PATTERN,
+    );
+    const expected = {
+      data: new Uint8ClampedArray(imageData.data),
+      width: imageData.width,
+      height: imageData.height,
+    } as ImageData;
+    const position = calculateWatermarkPosition(imageData.width, imageData.height, config);
+    removeWatermark(expected, STRONG_DIFFICULT_ALPHA_MAP, position);
+
+    removeWatermarkFromAnchorOptions(imageData, [{ config, alphaMap: STRONG_DIFFICULT_ALPHA_MAP }]);
+
+    expect(imageData.data).toEqual(expected.data);
+  });
+
+  it('does not enter the difficult path after a trusted candidate is rolled back', () => {
+    const trustedConfig = { logoSize: 4, marginRight: 1, marginBottom: 1 };
+    const difficultConfig = {
+      logoSize: 4,
+      marginRight: 9,
+      marginBottom: 9,
+      alphaVariant: '20260520' as const,
+    };
+    const imageData = createImageDataWithWeakAlphaPattern(trustedConfig);
+    writeSyntheticWatermark(
+      imageData,
+      difficultConfig,
+      STRONG_DIFFICULT_ALPHA_MAP,
+      STRONG_DIFFICULT_BASE_PATTERN,
+    );
+    const originalPixels = new Uint8ClampedArray(imageData.data);
+    const trustedPosition = calculateWatermarkPosition(
+      imageData.width,
+      imageData.height,
+      trustedConfig,
+    );
+    const difficultPosition = calculateWatermarkPosition(
+      imageData.width,
+      imageData.height,
+      difficultConfig,
+    );
+    expect(
+      hasReliableWatermarkSignal(
+        measureWatermarkSignal(imageData, TEST_ALPHA_MAP, trustedPosition),
+      ),
+    ).toBe(true);
+    expect(
+      hasReliableWatermarkSignal(
+        measureWatermarkSignal(imageData, STRONG_DIFFICULT_ALPHA_MAP, difficultPosition),
+      ),
+    ).toBe(false);
+
+    removeWatermarkFromAnchorOptions(imageData, [
+      { config: trustedConfig, alphaMap: TEST_ALPHA_MAP },
+      { config: difficultConfig, alphaMap: STRONG_DIFFICULT_ALPHA_MAP },
+    ]);
+
+    expect(imageData.data).toEqual(originalPixels);
+  });
+
   it('accepts a safely suppressed residual measured from a real moved-anchor output', () => {
     const candidateSignal = {
       spatialScore: 0.2143191174,

--- a/src/pages/content/watermarkRemover/__tests__/watermarkEngine.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/watermarkEngine.test.ts
@@ -4,6 +4,7 @@ import {
   getWatermarkSignalStrength,
   hasAcceptableWatermarkRemovalEvidence,
   hasReliableWatermarkSignal,
+  measureSevereUndershootRatio,
   measureWatermarkSignal,
 } from '../watermarkDetector';
 import {
@@ -20,15 +21,19 @@ const TEST_ALPHA_MAP = Float32Array.from([
   0.02, 0.15, 0.15, 0.02, 0.15, 0.8, 0.8, 0.15, 0.15, 0.8, 0.8, 0.15, 0.02, 0.15, 0.15, 0.02,
 ]);
 
-function createImageDataWithWatermark(config: WatermarkConfig, layers = 1): ImageData {
+function createImageDataWithWatermark(
+  config: WatermarkConfig,
+  layers = 1,
+  baseValue = 80,
+): ImageData {
   const width = 24;
   const height = 24;
   const data = new Uint8ClampedArray(width * height * 4);
 
   for (let i = 0; i < data.length; i += 4) {
-    data[i] = 80;
-    data[i + 1] = 80;
-    data[i + 2] = 80;
+    data[i] = baseValue;
+    data[i + 1] = baseValue;
+    data[i + 2] = baseValue;
     data[i + 3] = 255;
   }
 
@@ -36,7 +41,7 @@ function createImageDataWithWatermark(config: WatermarkConfig, layers = 1): Imag
   for (let row = 0; row < position.height; row++) {
     for (let col = 0; col < position.width; col++) {
       const alpha = TEST_ALPHA_MAP[row * position.width + col];
-      let value = 80;
+      let value = baseValue;
       for (let layer = 0; layer < layers; layer++) {
         value = Math.round(255 * alpha + value * (1 - alpha));
       }
@@ -420,6 +425,26 @@ describe('watermarkEngine config detection', () => {
     expect(imageData.data).toEqual(originalPixels);
   });
 
+  it('accepts clipped pixels that reconstruct a dark background without severe undershoot', () => {
+    const config = { logoSize: 4, marginRight: 1, marginBottom: 1 };
+    const imageData = createImageDataWithWatermark(config, 1, 0);
+    const position = calculateWatermarkPosition(imageData.width, imageData.height, config);
+
+    expect(measureSevereUndershootRatio(imageData, TEST_ALPHA_MAP, position)).toBeLessThan(0.1);
+
+    const passes = removeWatermarkWithResidualCheck(imageData, TEST_ALPHA_MAP, position);
+
+    expect(passes).toBe(1);
+    for (let row = 0; row < position.height; row++) {
+      for (let col = 0; col < position.width; col++) {
+        const index = ((position.y + row) * imageData.width + position.x + col) * 4;
+        expect(imageData.data[index]).toBe(0);
+        expect(imageData.data[index + 1]).toBe(0);
+        expect(imageData.data[index + 2]).toBe(0);
+      }
+    }
+  });
+
   it('rejects a watermark-like pattern when trial removal would clip pixels', () => {
     const config = { logoSize: 4, marginRight: 1, marginBottom: 1 };
     const imageData = createImageDataWithWeakAlphaPattern(config);
@@ -429,6 +454,9 @@ describe('watermarkEngine config detection', () => {
     expect(
       hasReliableWatermarkSignal(measureWatermarkSignal(imageData, TEST_ALPHA_MAP, position)),
     ).toBe(true);
+    expect(
+      measureSevereUndershootRatio(imageData, TEST_ALPHA_MAP, position),
+    ).toBeGreaterThanOrEqual(0.1);
 
     const passes = removeWatermarkWithResidualCheck(imageData, TEST_ALPHA_MAP, position);
 

--- a/src/pages/content/watermarkRemover/watermarkDetector.ts
+++ b/src/pages/content/watermarkRemover/watermarkDetector.ts
@@ -25,6 +25,11 @@ const MAX_NEAR_BLACK_INCREASE = 0.05;
 const CLIP_ORIGINAL_THRESHOLD = 5;
 const CLIP_CANDIDATE_THRESHOLD = 0;
 const MAX_NEWLY_CLIPPED_RATIO = 0.03;
+const ALPHA_THRESHOLD = 0.002;
+const MAX_ALPHA = 0.99;
+const LOGO_VALUE = 255;
+const SEVERE_UNDERSHOOT_THRESHOLD = -5;
+const MAX_SEVERE_UNDERSHOOT_RATIO = 0.1;
 
 export interface WatermarkSignal {
   spatialScore: number;
@@ -38,6 +43,7 @@ export interface WatermarkRemovalAssessment {
   suppressionGain: number;
   nearBlackIncrease: number;
   newlyClippedRatio: number;
+  severeUndershootRatio: number;
 }
 
 function calculateLuminance(data: Uint8ClampedArray, index: number): number {
@@ -193,12 +199,51 @@ function hasStrongWatermarkRemovalEvidence(
   );
 }
 
+export function measureSevereUndershootRatio(
+  imageData: ImageData,
+  alphaMap: Float32Array,
+  position: WatermarkPosition,
+): number {
+  if (
+    !isRegionInBounds(imageData, position) ||
+    alphaMap.length !== position.width * position.height
+  ) {
+    return 0;
+  }
+
+  let severeUndershoot = 0;
+  for (let row = 0; row < position.height; row++) {
+    for (let col = 0; col < position.width; col++) {
+      const alphaIndex = row * position.width + col;
+      let alpha = alphaMap[alphaIndex];
+      if (alpha < ALPHA_THRESHOLD) continue;
+
+      alpha = Math.min(alpha, MAX_ALPHA);
+      const oneMinusAlpha = 1 - alpha;
+      const imageIndex = ((position.y + row) * imageData.width + position.x + col) * 4;
+      let severePixel = false;
+      for (let channel = 0; channel < 3; channel++) {
+        const watermarked = imageData.data[imageIndex + channel];
+        const rawOriginal = (watermarked - alpha * LOGO_VALUE) / oneMinusAlpha;
+        if (rawOriginal < SEVERE_UNDERSHOOT_THRESHOLD) {
+          severePixel = true;
+          break;
+        }
+      }
+      if (severePixel) severeUndershoot++;
+    }
+  }
+
+  return severeUndershoot / Math.max(1, position.width * position.height);
+}
+
 export function assessWatermarkRemovalCandidate(
   originalImageData: ImageData,
   candidateImageData: ImageData,
   alphaMap: Float32Array,
   position: WatermarkPosition,
   originalSignal = measureWatermarkSignal(originalImageData, alphaMap, position),
+  severeUndershootRatio = measureSevereUndershootRatio(originalImageData, alphaMap, position),
 ): WatermarkRemovalAssessment {
   const candidateSignal = measureWatermarkSignal(candidateImageData, alphaMap, position);
   const totalPixels = position.width * position.height;
@@ -244,8 +289,10 @@ export function assessWatermarkRemovalCandidate(
   const nearBlackIncrease = Math.max(0, candidateNearBlack - originalNearBlack) / ratioDenominator;
   const newlyClippedRatio = newlyClipped / ratioDenominator;
   const evidenceSafe = hasAcceptableWatermarkRemovalEvidence(candidateSignal, suppressionGain);
+  const exceedsLegacyDamageLimits =
+    nearBlackIncrease > MAX_NEAR_BLACK_INCREASE || newlyClippedRatio > MAX_NEWLY_CLIPPED_RATIO;
   const damageSafe =
-    nearBlackIncrease <= MAX_NEAR_BLACK_INCREASE && newlyClippedRatio <= MAX_NEWLY_CLIPPED_RATIO;
+    !exceedsLegacyDamageLimits || severeUndershootRatio < MAX_SEVERE_UNDERSHOOT_RATIO;
 
   return {
     safe: hasReliableWatermarkSignal(originalSignal) && evidenceSafe && damageSafe,
@@ -254,5 +301,6 @@ export function assessWatermarkRemovalCandidate(
     suppressionGain,
     nearBlackIncrease,
     newlyClippedRatio,
+    severeUndershootRatio,
   };
 }

--- a/src/pages/content/watermarkRemover/watermarkDetector.ts
+++ b/src/pages/content/watermarkRemover/watermarkDetector.ts
@@ -20,6 +20,7 @@ const MAX_RESIDUAL_GRADIENT_SCORE = 0.18;
 const MIN_SUPPRESSION_GAIN = 0.25;
 const MIN_RELIABILITY_TRANSITION_GAIN = 0.2;
 const MIN_RELIABILITY_TRANSITION_RATIO = 0.4;
+const MIN_DIFFICULT_SUPPRESSION = 0.08;
 const NEAR_BLACK_THRESHOLD = 5;
 const MAX_NEAR_BLACK_INCREASE = 0.05;
 const CLIP_ORIGINAL_THRESHOLD = 5;
@@ -43,6 +44,14 @@ export interface WatermarkRemovalAssessment {
   suppressionGain: number;
   nearBlackIncrease: number;
   newlyClippedRatio: number;
+  severeUndershootRatio: number;
+}
+
+export interface DifficultWatermarkRemovalAssessment {
+  eligible: boolean;
+  originalStrength: number;
+  finalResidualStrength: number;
+  suppression: number;
   severeUndershootRatio: number;
 }
 
@@ -162,6 +171,32 @@ export function hasReliableWatermarkSignal(signal: WatermarkSignal): boolean {
 
 export function getWatermarkSignalStrength(signal: WatermarkSignal): number {
   return Math.max(0, signal.spatialScore) * 0.5 + Math.max(0, signal.gradientScore) * 0.3;
+}
+
+export function assessDifficultWatermarkRemovalCandidate(
+  originalSignal: WatermarkSignal,
+  finalSignal: WatermarkSignal,
+  severeUndershootRatio: number,
+): DifficultWatermarkRemovalAssessment {
+  const originalStrength = getWatermarkSignalStrength(originalSignal);
+  const finalResidualStrength =
+    Math.abs(finalSignal.spatialScore) * 0.5 + Math.max(0, finalSignal.gradientScore) * 0.3;
+  const suppression = originalStrength - finalResidualStrength;
+  const spatialReduced = Math.abs(finalSignal.spatialScore) < originalSignal.spatialScore;
+  const gradientReduced = finalSignal.gradientScore < originalSignal.gradientScore;
+  const eligible =
+    spatialReduced &&
+    gradientReduced &&
+    suppression > MIN_DIFFICULT_SUPPRESSION &&
+    severeUndershootRatio < MAX_SEVERE_UNDERSHOOT_RATIO;
+
+  return {
+    eligible,
+    originalStrength,
+    finalResidualStrength,
+    suppression,
+    severeUndershootRatio,
+  };
 }
 
 export function hasResidualWatermarkEdges(signal: WatermarkSignal): boolean {

--- a/src/pages/content/watermarkRemover/watermarkEngine.ts
+++ b/src/pages/content/watermarkRemover/watermarkEngine.ts
@@ -17,6 +17,7 @@ import BG_96_IMPORT from './assets/bg_96.png';
 import BG_96_20260520_IMPORT from './assets/bg_96_20260520.png';
 import { type WatermarkPosition, removeWatermark } from './blendModes';
 import {
+  assessDifficultWatermarkRemovalCandidate,
   assessWatermarkRemovalCandidate,
   getWatermarkSignalStrength,
   hasReliableWatermarkSignal,
@@ -246,6 +247,123 @@ function restoreWatermarkRegion(
       targetStart,
     );
   }
+}
+
+function isWatermarkPositionInBounds(imageData: ImageData, position: WatermarkPosition): boolean {
+  return (
+    position.width > 0 &&
+    position.height > 0 &&
+    position.x >= 0 &&
+    position.y >= 0 &&
+    position.x + position.width <= imageData.width &&
+    position.y + position.height <= imageData.height
+  );
+}
+
+function getDifficultWatermarkAnchorOptions(
+  options: WatermarkAnchorOption[],
+): WatermarkAnchorOption[] {
+  return options.flatMap((option) => {
+    const snapOffsets =
+      option.config.alphaVariant === '20260520-small' ? [-3, -2, -1, 0, 1, 2, 3] : [0];
+
+    return snapOffsets.flatMap((offsetX) =>
+      snapOffsets.map((offsetY) =>
+        offsetX === 0 && offsetY === 0
+          ? option
+          : {
+              ...option,
+              config: {
+                ...option.config,
+                marginRight: option.config.marginRight - offsetX,
+                marginBottom: option.config.marginBottom - offsetY,
+              },
+            },
+      ),
+    );
+  });
+}
+
+export function chooseDifficultWatermarkAnchorOption(
+  imageData: ImageData,
+  options: WatermarkAnchorOption[],
+): WatermarkAnchorOption | undefined {
+  let best:
+    | {
+        option: WatermarkAnchorOption;
+        suppression: number;
+      }
+    | undefined;
+
+  for (const option of getDifficultWatermarkAnchorOptions(options)) {
+    const position = calculateWatermarkPosition(imageData.width, imageData.height, option.config);
+    if (!isWatermarkPositionInBounds(imageData, position)) continue;
+
+    const originalSignal = measureWatermarkSignal(imageData, option.alphaMap, position);
+    const severeUndershootRatio = measureSevereUndershootRatio(
+      imageData,
+      option.alphaMap,
+      position,
+    );
+    const snapshot = snapshotWatermarkRegion(imageData, position);
+    let finalSignal: ReturnType<typeof measureWatermarkSignal>;
+
+    try {
+      removeWatermark(imageData, option.alphaMap, position);
+      finalSignal = measureWatermarkSignal(imageData, option.alphaMap, position);
+    } finally {
+      restoreWatermarkRegion(imageData, position, snapshot);
+    }
+
+    const assessment = assessDifficultWatermarkRemovalCandidate(
+      originalSignal,
+      finalSignal,
+      severeUndershootRatio,
+    );
+    if (!assessment.eligible) continue;
+    if (!best || assessment.suppression > best.suppression) {
+      best = {
+        option,
+        suppression: assessment.suppression,
+      };
+    }
+  }
+
+  return best?.option;
+}
+
+export function removeWatermarkFromAnchorOptions(
+  imageData: ImageData,
+  anchorOptions: WatermarkAnchorOption[],
+): void {
+  const trustedOption = chooseWatermarkAnchorOption(imageData, anchorOptions);
+  const trustedPosition = calculateWatermarkPosition(
+    imageData.width,
+    imageData.height,
+    trustedOption.config,
+  );
+  const trustedSignal = measureWatermarkSignal(imageData, trustedOption.alphaMap, trustedPosition);
+
+  if (hasReliableWatermarkSignal(trustedSignal)) {
+    // Keep the established trusted path unchanged. Gemini can stack multiple
+    // transparent marks after iterative edits, so this path may remove more
+    // than one layer and retains its existing safety rollback.
+    removeWatermarkWithResidualCheck(imageData, trustedOption.alphaMap, trustedPosition);
+    return;
+  }
+
+  // Only fall back after every known anchor misses the trusted thresholds.
+  // Each difficult candidate is trialed against, and restored to, the same
+  // original pixels before the strongest safe suppression is applied once.
+  const difficultOption = chooseDifficultWatermarkAnchorOption(imageData, anchorOptions);
+  if (!difficultOption) return;
+
+  const difficultPosition = calculateWatermarkPosition(
+    imageData.width,
+    imageData.height,
+    difficultOption.config,
+  );
+  removeWatermark(imageData, difficultOption.alphaMap, difficultPosition);
 }
 
 function createGaussianKernel(radius: number, sigma: number): Float32Array {
@@ -607,13 +725,7 @@ export class WatermarkEngine {
         alphaMap: await this.getAlphaMap(this.getAlphaMapKey(config)),
       })),
     );
-    const { config, alphaMap } = chooseWatermarkAnchorOption(imageData, anchorOptions);
-    const position = calculateWatermarkPosition(canvas.width, canvas.height, config);
-
-    // Remove watermark from image data. Gemini can stack multiple transparent
-    // marks after iterative image edits, so repeat only while the known alpha
-    // pattern is still clearly present at the selected anchor.
-    removeWatermarkWithResidualCheck(imageData, alphaMap, position);
+    removeWatermarkFromAnchorOptions(imageData, anchorOptions);
 
     // Write processed image data back to canvas
     ctx.putImageData(imageData, 0, 0);

--- a/src/pages/content/watermarkRemover/watermarkEngine.ts
+++ b/src/pages/content/watermarkRemover/watermarkEngine.ts
@@ -21,6 +21,7 @@ import {
   getWatermarkSignalStrength,
   hasReliableWatermarkSignal,
   hasResidualWatermarkEdges,
+  measureSevereUndershootRatio,
   measureWatermarkSignal,
 } from './watermarkDetector';
 
@@ -407,6 +408,7 @@ export function removeWatermarkWithResidualCheck(
 
   while (passes < WATERMARK_MAX_REMOVAL_PASSES) {
     const previousRegion = snapshotWatermarkRegion(imageData, position);
+    const severeUndershootRatio = measureSevereUndershootRatio(imageData, alphaMap, position);
     removeWatermark(imageData, alphaMap, position);
     const assessment = assessWatermarkRemovalCandidate(
       originalImageData,
@@ -414,6 +416,7 @@ export function removeWatermarkWithResidualCheck(
       alphaMap,
       position,
       currentSignal,
+      severeUndershootRatio,
     );
     if (!assessment.safe) {
       restoreWatermarkRegion(imageData, position, previousRegion);


### PR DESCRIPTION
### Description

Fixes two false-negative paths in Gemini image watermark removal:

1. **Dark-background restoration was mistaken for clipping damage.**
   The existing safety check rolled back a removal when too many pixels became near-black or clipped to zero. On legitimately dark backgrounds, correct reverse-alpha reconstruction can naturally land near zero, so valid removals were rejected.

   This change keeps the existing safety limits, but distinguishes harmless near-zero restoration from severe over-subtraction by measuring the raw reverse-alpha result. When the legacy damage limits are exceeded, removal is rolled back only when at least 10% of the watermark region is severely undershot.

2. **Known watermark anchors could fall just below the trusted detection thresholds.**
   Some current 96 px Gemini watermarks are positioned at the expected 192 px margin but receive low spatial/gradient scores on difficult backgrounds. The detector therefore found no trusted candidate and returned the image unchanged.

   This change adds an independent difficult-match fallback that runs only when the existing trusted-candidate set is empty. It trial-removes each known anchor/template/offset combination, restores the original pixels after every trial, and accepts a candidate only when:

   ```text
   originalSpatial > abs(finalSpatial)
   originalGradient > finalGradient
   suppression > 0.08
   severeUndershoot < 0.10
   ```

   where:

   ```text
   originalStrength =
     max(0, originalSpatial) × 0.5 +
     max(0, originalGradient) × 0.3
   
   finalResidualStrength =
     abs(finalSpatial) × 0.5 +
     max(0, finalGradient) × 0.3
   
   suppression = originalStrength - finalResidualStrength
   ```

The existing trusted-candidate path remains unchanged and retains priority. In particular, the fallback does not take over when a trusted match is found but later rejected by its existing safety validation.

Regression tests and regression notes are included for both failure modes.

### Related Issue

Fixes #870

- [x] N/A — #870 is not labeled `community-only` and is assigned to @gunnlace.

### Visual Proof

#### Group A — manual validation across resolutions, aspect ratios, and backgrounds

All ten generated images were successfully processed by this branch. Each comparison shows a magnified crop from the bottom-right corner before and after removal.

| Case | Resolution | Requested ratio | Scene | Result |
|---|---:|---:|---|---|
| 01 | 2048×2048 | 1:1 | Near-black smooth background | Clean |
| 02 | 2048×2048 | 1:1 | Dark wet-stone texture | Clean |
| 03 | 2048×2048 | 1:1 | Bright low-contrast control | Clean |
| 04 | 1856×2304 | 4:5 | Dark underwater scene | Clean |
| 05 | 2304×1856 | 5:4 | Dense forest texture | Clean |
| 06 | 1536×2752 | 9:16 | Dark portrait city scene | Clean |
| 07 | 2752×1536 | 16:9 | Snow and dark rocks | Clean |
| 08 | 928×4640 | 1:5 | Dark extreme portrait | Clean |
| 09 | 4640×928 | 5:1 | Dark extreme landscape | Clean |
| 10 | 2048×2048 | 1:1 | Iteratively edited dark scene | Clean |

<details>
<summary>Show all 10 before/after crop comparisons</summary>

##### Case 01

<img width="1680" height="820" alt="01-comparison" src="https://github.com/user-attachments/assets/412cc6e4-c42c-4783-8e82-2f17c79a4868" />

##### Case 02

<img width="1680" height="820" alt="02-comparison" src="https://github.com/user-attachments/assets/a58a0c16-c2dc-483b-802b-23a37cca5a9b" />

##### Case 03

<img width="1680" height="820" alt="03-comparison" src="https://github.com/user-attachments/assets/a38d7bc1-cd6e-4517-b47e-29c17bad335b" />

##### Case 04

<img width="1680" height="820" alt="04-comparison" src="https://github.com/user-attachments/assets/c5c1822b-f282-41f5-b05b-556bd90b8852" />

##### Case 05

<img width="1680" height="820" alt="05-comparison" src="https://github.com/user-attachments/assets/66aa68c7-c29a-4547-b05c-42665f590bef" />

##### Case 06

<img width="1680" height="820" alt="06-comparison" src="https://github.com/user-attachments/assets/595f990c-8718-4424-a6a6-ebed7fe529a0" />

##### Case 07

<img width="1680" height="820" alt="07-comparison" src="https://github.com/user-attachments/assets/ec1d1a5f-6668-4338-8e40-796307de197d" />

##### Case 08

<img width="1680" height="820" alt="08-comparison" src="https://github.com/user-attachments/assets/c92223fd-5742-4e2e-beb9-6f08595f7bb2" />

##### Case 09

<img width="1680" height="820" alt="09-comparison" src="https://github.com/user-attachments/assets/bfef0fff-88c3-4ae7-8368-0fa6ead6e6a1" />

##### Case 10

<img width="1680" height="820" alt="10-comparison" src="https://github.com/user-attachments/assets/44f7f807-c1f2-41d6-899d-1c630b3fc0d3" />

</details>

<details>
<summary>Part-of-resolution samples</summary>

<img width="2048" height="2048" alt="03-fixed" src="https://github.com/user-attachments/assets/eb57ba0b-a913-4407-adf9-e5fcabd06526" />
<img width="2048" height="2048" alt="03-origin" src="https://github.com/user-attachments/assets/d00742a1-df3b-4481-a39f-6abfa488b45d" />
<img width="928" height="4640" alt="08-fixed" src="https://github.com/user-attachments/assets/62ac1e1d-9f6f-4262-be0d-22ceb4f25173" />
<img width="928" height="4640" alt="08-origin" src="https://github.com/user-attachments/assets/040ffc2f-b090-4f08-8c4a-8c8d73ee5f1d" />
<img width="4640" height="928" alt="09-fixed" src="https://github.com/user-attachments/assets/38abf97f-46a0-4610-b212-4c3bc2ba4044" />
<img width="4640" height="928" alt="09-origin" src="https://github.com/user-attachments/assets/1db5b93c-fe72-48c3-a91c-bef043c200e4" />

</details>


#### Group B — six previously failing samples

The current `main` implementation left all six samples unchanged. This branch removed the watermark from all six while limiting changes to the expected 96×96 watermark region.

The upstream `gemini-watermark-remover` output is included only as a same-sample reference, not as a general benchmark.

| Case | `main` | This branch | Upstream reference |
|---|---|---|---|
| 01 | Watermark remains | Clean | Clean |
| 03 | Watermark remains | Clean | Clean |
| 04 | Watermark remains | Clean | Clean |
| 05 | Watermark remains | Clean | Clean |
| 08 | Watermark remains | Clean | Visible residual/repair artifact |
| 09 | Watermark remains | Clean | Visible gray repair artifact |

Comparison revisions:

- Voyager `main`: `94d7edef`
- This branch: `a559ff89`
- `gemini-watermark-remover`: `6fab72e`

<details>
<summary>Show all 6 four-way crop comparisons</summary>

##### Case 01

<img width="2380" height="820" alt="01-comparison" src="https://github.com/user-attachments/assets/c337c864-f97e-4bc4-978f-cef8f79bb0a4" />

##### Case 03

<img width="2380" height="820" alt="03-comparison" src="https://github.com/user-attachments/assets/c2501f21-a67f-4101-820c-a67ce2d4ad1d" />

##### Case 04

<img width="2380" height="820" alt="04-comparison" src="https://github.com/user-attachments/assets/9cc6ed78-4558-428f-8046-d37a13315591" />

##### Case 05

<img width="2380" height="820" alt="05-comparison" src="https://github.com/user-attachments/assets/16511e51-f6e4-4b30-8244-52e170bae54c" />

##### Case 08

<img width="2380" height="820" alt="08-comparison" src="https://github.com/user-attachments/assets/e82a92a9-68a2-4e5c-b822-bbe5bd16eaac" />

##### Case 09

<img width="2380" height="820" alt="09-comparison" src="https://github.com/user-attachments/assets/ff223e04-f48b-4773-9d23-ea1fa7065d40" />

</details>

<details>
<summary>Part-of-resolution samples</summary>

<img width="2752" height="1536" alt="04-origin" src="https://github.com/user-attachments/assets/23b799ac-7742-40e6-a688-5556614d627d" />
<img width="2752" height="1536" alt="04-fix-a559ff89" src="https://github.com/user-attachments/assets/e97b0778-d19d-4249-bfce-57476d7500e5" />

<img width="2048" height="2048" alt="08-origin" src="https://github.com/user-attachments/assets/3de0cb4a-b288-4c94-a030-4849e3e88886" />
<img width="2048" height="2048" alt="08-fix-a559ff89" src="https://github.com/user-attachments/assets/a729219e-e52e-4396-916c-15cee306acf8" />


</details>


### Browser Testing

- [x] **Chrome / Edge (Chromium)** — manually tested in Chrome with the unpacked development build.
- [x] **Firefox (mandatory)** — tested cases 01, 05, and 08 with the temporary development add-on; all watermarks were removed without visible damage.
- [ ] **Safari (optional)** — not tested.

### Automated Verification

- [x] `bun run typecheck`
- [x] `bun run test` — 249 files, 2300 tests passed
- [x] `bun run build:chrome`
- [x] `bun run lint`
- [x] `bun run format`

Test coverage added for:

- accepting valid dark, near-zero restoration;
- rejecting genuine severe over-subtraction;
- difficult-match eligibility and strict threshold boundaries;
- selecting the highest-suppression difficult candidate;
- restoring pixels after each trial so candidates cannot contaminate one another;
- small anchor offsets;
- preserving the input when no candidate qualifies;
- applying the selected fallback exactly once; and
- preventing fallback takeover after a trusted candidate is rejected.

### Checklist

- [x] I discussed the implementation and edge cases with an agent before coding.
- [x] I manually verified the change with generated images.
- [x] I spent more than 15 minutes using the affected workflow.
- [x] I attached the visual proof referenced above.
- [x] The change is focused on #870 and preserves the existing trusted-match path.
- [x] Existing automated tests pass.
- [x] I ran the repository's lint and format commands and reviewed their changes.
- [x] I completed mandatory Firefox verification.
