### PR TITLE
feat(export): customize speaker names in conversation exports

### DIFF
--- a/public/contentStyle.css
+++ b/public/contentStyle.css
@@ -8054,6 +8054,108 @@ body.gv-rtl .gv-export-prompt-heading-switch[aria-checked='true'] .gv-coach-knob
   transform: translateX(-18px);
 }
 
+.gv-export-speakers-section {
+  margin-bottom: 16px;
+  padding: 16px;
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  background: #f8f9fa;
+}
+
+.gv-export-speakers-title {
+  margin-bottom: 12px;
+  color: #202124;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.gv-export-speakers-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.gv-export-speaker-field {
+  min-width: 0;
+}
+
+.gv-export-speaker-label {
+  display: block;
+  margin-bottom: 8px;
+  color: #5f6368;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.gv-export-speaker-input {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 10px;
+  border: 1px solid #bdc1c6;
+  border-radius: 6px;
+  outline: none;
+  background: #fff;
+  color: #202124;
+  font: inherit;
+  font-size: 14px;
+}
+
+.gv-export-speaker-input:focus-visible {
+  border-color: #1a73e8;
+  box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.2);
+}
+
+html.dark .gv-export-speakers-section,
+.theme-host.dark-theme ~ .gv-export-dialog-overlay .gv-export-speakers-section,
+[data-theme='dark'] .gv-export-speakers-section,
+[data-color-scheme='dark'] .gv-export-speakers-section,
+html.dark-theme .gv-export-speakers-section,
+body.dark-theme .gv-export-speakers-section,
+body[data-theme='dark'] .gv-export-speakers-section,
+body[data-color-scheme='dark'] .gv-export-speakers-section {
+  border-color: #3c4043;
+  background: #2d2e30;
+}
+
+html.dark .gv-export-speakers-title,
+html.dark .gv-export-speaker-label,
+.theme-host.dark-theme ~ .gv-export-dialog-overlay .gv-export-speakers-title,
+.theme-host.dark-theme ~ .gv-export-dialog-overlay .gv-export-speaker-label,
+[data-theme='dark'] .gv-export-speakers-title,
+[data-theme='dark'] .gv-export-speaker-label,
+[data-color-scheme='dark'] .gv-export-speakers-title,
+[data-color-scheme='dark'] .gv-export-speaker-label,
+html.dark-theme .gv-export-speakers-title,
+html.dark-theme .gv-export-speaker-label,
+body.dark-theme .gv-export-speakers-title,
+body.dark-theme .gv-export-speaker-label,
+body[data-theme='dark'] .gv-export-speakers-title,
+body[data-theme='dark'] .gv-export-speaker-label,
+body[data-color-scheme='dark'] .gv-export-speakers-title,
+body[data-color-scheme='dark'] .gv-export-speaker-label {
+  color: #e8eaed;
+}
+
+html.dark .gv-export-speaker-input,
+.theme-host.dark-theme ~ .gv-export-dialog-overlay .gv-export-speaker-input,
+[data-theme='dark'] .gv-export-speaker-input,
+[data-color-scheme='dark'] .gv-export-speaker-input,
+html.dark-theme .gv-export-speaker-input,
+body.dark-theme .gv-export-speaker-input,
+body[data-theme='dark'] .gv-export-speaker-input,
+body[data-color-scheme='dark'] .gv-export-speaker-input {
+  border-color: #5f6368;
+  background: #202124;
+  color: #e8eaed;
+}
+
+@media (max-width: 520px) {
+  .gv-export-speakers-fields {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Font size control section in export dialog */
 .gv-export-fontsize-section {
   margin-bottom: 20px;

--- a/src/core/services/SettingsBackupService.ts
+++ b/src/core/services/SettingsBackupService.ts
@@ -119,6 +119,7 @@ export const BACKUPABLE_SYNC_SETTINGS_DEFAULTS = {
   [StorageKeys.GV_VISUAL_EFFECT]: 'off',
   [StorageKeys.FORK_ENABLED]: false,
   [StorageKeys.EXPORT_IMAGE_WIDTH]: 620,
+  [StorageKeys.EXPORT_SPEAKER_LABELS]: {},
   [StorageKeys.PERSISTENT_EXPORT_TOOLBAR_ENABLED]: true,
   [StorageKeys.GV_AISTUDIO_ENABLED]: true,
   [StorageKeys.GV_SHOW_MESSAGE_TIMESTAMPS]: false,

--- a/src/core/services/__tests__/SettingsBackupService.test.ts
+++ b/src/core/services/__tests__/SettingsBackupService.test.ts
@@ -30,6 +30,7 @@ describe('SettingsBackupService', () => {
         [StorageKeys.COACHMARKS_SEEN]: [],
         [StorageKeys.EXPORT_IMAGE_WIDTH]: 620,
         [StorageKeys.SLASH_PROMPT_ENABLED]: true,
+        [StorageKeys.EXPORT_SPEAKER_LABELS]: {},
       }),
     );
     expect(BACKUPABLE_SYNC_SETTINGS_DEFAULTS).not.toHaveProperty(StorageKeys.PLUGINS_STATE);

--- a/src/core/types/common.ts
+++ b/src/core/types/common.ts
@@ -250,6 +250,7 @@ export const StorageKeys = {
 
   // Export
   EXPORT_IMAGE_WIDTH: 'gvExportImageWidth',
+  EXPORT_SPEAKER_LABELS: 'gvExportSpeakerLabels',
   // Fallback top-right export toolbar shown when Gemini's logo (the normal
   // inline injection point) is absent. Defaults to true. When false, the
   // toolbar is suppressed even if the logo is missing — users keep the menu

--- a/src/features/export/services/ConversationExportService.ts
+++ b/src/features/export/services/ConversationExportService.ts
@@ -6,6 +6,7 @@
 import { fetchImageViaExtensionRuntime } from '@/core/utils/runtimeImageFetch';
 
 import { IMAGE_RENDER_EVENT_ERROR_CODE, isEventLikeImageRenderError } from '../types/errors';
+import { DEFAULT_EXPORT_SPEAKER_LABELS } from '../types/export';
 import type {
   ChatTurn,
   ConversationMetadata,
@@ -43,18 +44,23 @@ export class ConversationExportService {
         return await this.exportDocument(turns, metadata, options);
       }
 
-      switch (options.format) {
+      const conversationOptions: ExportOptions = {
+        ...options,
+        speakerLabels: options.speakerLabels ?? DEFAULT_EXPORT_SPEAKER_LABELS,
+      };
+
+      switch (conversationOptions.format) {
         case 'json':
-          return this.exportJSON(turns, metadata, options);
+          return this.exportJSON(turns, metadata, conversationOptions);
 
         case 'markdown':
-          return await this.exportMarkdown(turns, metadata, options);
+          return await this.exportMarkdown(turns, metadata, conversationOptions);
 
         case 'pdf':
-          return await this.exportPDF(turns, metadata, options);
+          return await this.exportPDF(turns, metadata, conversationOptions);
 
         case 'image':
-          return await this.exportImage(turns, metadata, options);
+          return await this.exportImage(turns, metadata, conversationOptions);
 
         default:
           return {
@@ -183,6 +189,7 @@ export class ConversationExportService {
     // First create a clean markdown (no inlining)
     let markdown = MarkdownFormatter.format(turns, metadata, {
       usePromptAsTurnHeading: options.usePromptAsTurnHeading,
+      speakerLabels: options.speakerLabels,
     });
 
     // Strip image source attribution lines if user opted out
@@ -203,7 +210,10 @@ export class ConversationExportService {
     metadata: ConversationMetadata,
     options: ExportOptions,
   ): Promise<ExportResult> {
-    await PDFPrintService.export(turns, metadata, { fontSize: options.fontSize });
+    await PDFPrintService.export(turns, metadata, {
+      fontSize: options.fontSize,
+      speakerLabels: options.speakerLabels,
+    });
 
     // Note: We can't get the actual filename from print dialog
     // User chooses filename in Save as PDF dialog
@@ -227,6 +237,7 @@ export class ConversationExportService {
       filename,
       fontSize: options.fontSize,
       imageWidth: options.imageWidth,
+      speakerLabels: options.speakerLabels,
     });
     return { success: true, format: 'image' as ExportFormat, filename };
   }

--- a/src/features/export/services/ImageExportService.ts
+++ b/src/features/export/services/ImageExportService.ts
@@ -11,7 +11,9 @@ import { isEventLikeImageRenderError } from '../types/errors';
 import {
   type ChatTurn,
   type ConversationMetadata,
+  DEFAULT_EXPORT_SPEAKER_LABELS,
   DEFAULT_IMAGE_EXPORT_WIDTH,
+  type ExportSpeakerLabels,
 } from '../types/export';
 import { DOMContentExtractor } from './DOMContentExtractor';
 import { renderElementToImageBlob } from './ImageRenderService';
@@ -35,7 +37,12 @@ export class ImageExportService {
   static async export(
     turns: ChatTurn[],
     metadata: ConversationMetadata,
-    options: { filename: string; fontSize?: number; imageWidth?: number },
+    options: {
+      filename: string;
+      fontSize?: number;
+      imageWidth?: number;
+      speakerLabels?: ExportSpeakerLabels;
+    },
   ): Promise<void> {
     const filename = options.filename.toLowerCase().endsWith('.png')
       ? options.filename
@@ -60,13 +67,18 @@ export class ImageExportService {
   static async renderConversationBlob(
     turns: ChatTurn[],
     metadata: ConversationMetadata,
-    options: { fontSize?: number; imageWidth?: number },
+    options: {
+      fontSize?: number;
+      imageWidth?: number;
+      speakerLabels?: ExportSpeakerLabels;
+    },
   ): Promise<Blob> {
     const container = this.createRenderContainer(
       turns,
       metadata,
       options.fontSize,
       options.imageWidth,
+      options.speakerLabels,
     );
     return await this.renderContainerToBlob(container);
   }
@@ -85,6 +97,7 @@ export class ImageExportService {
     metadata: ConversationMetadata,
     fontSize?: number,
     imageWidth?: number,
+    speakerLabels: ExportSpeakerLabels = DEFAULT_EXPORT_SPEAKER_LABELS,
   ): HTMLElement {
     const outer = document.createElement('div');
     outer.className = 'gv-image-export-container';
@@ -128,11 +141,11 @@ export class ImageExportService {
           <article class="gv-image-export-turn">
             <div class="gv-image-export-turn-header">Turn ${turnIndex}${starred}</div>
             <section class="gv-image-export-block">
-              <div class="gv-image-export-label">User</div>
+              <div class="gv-image-export-label">${this.escapeHTML(speakerLabels.user)}</div>
               <div class="gv-image-export-content">${userHtml || '<em>No content</em>'}</div>
             </section>
             <section class="gv-image-export-block">
-              <div class="gv-image-export-label">Assistant</div>
+              <div class="gv-image-export-label">${this.escapeHTML(speakerLabels.assistant)}</div>
               <div class="gv-image-export-content">${assistantHtml || '<em>No content</em>'}</div>
             </section>
           </article>
@@ -149,7 +162,7 @@ export class ImageExportService {
               hasUser
                 ? `
             <section class="gv-image-export-block">
-              <div class="gv-image-export-label">User</div>
+              <div class="gv-image-export-label">${this.escapeHTML(speakerLabels.user)}</div>
               <div class="gv-image-export-content">${userHtml || '<em>No content</em>'}</div>
             </section>
             `
@@ -159,7 +172,7 @@ export class ImageExportService {
               hasAssistant
                 ? `
             <section class="gv-image-export-block">
-              <div class="gv-image-export-label">Assistant</div>
+              <div class="gv-image-export-label">${this.escapeHTML(speakerLabels.assistant)}</div>
               <div class="gv-image-export-content">${assistantHtml || '<em>No content</em>'}</div>
             </section>
             `

--- a/src/features/export/services/MarkdownFormatter.ts
+++ b/src/features/export/services/MarkdownFormatter.ts
@@ -3,7 +3,12 @@
  * Converts conversation to clean, standard Markdown format
  * Following the "paper book" philosophy - content over design
  */
-import type { ChatTurn, ConversationMetadata, MarkdownFormatOptions } from '../types/export';
+import {
+  type ChatTurn,
+  type ConversationMetadata,
+  DEFAULT_EXPORT_SPEAKER_LABELS,
+  type MarkdownFormatOptions,
+} from '../types/export';
 import { DOMContentExtractor } from './DOMContentExtractor';
 
 /**
@@ -126,6 +131,7 @@ export class MarkdownFormatter {
    */
   private static formatTurn(turn: ChatTurn, index: number, options: MarkdownFormatOptions): string {
     const lines: string[] = [];
+    const speakerLabels = options.speakerLabels ?? DEFAULT_EXPORT_SPEAKER_LABELS;
     const promptHeadingContent = options.usePromptAsTurnHeading
       ? this.formatPromptHeading(turn)
       : { hasMedia: false, text: '' };
@@ -142,7 +148,7 @@ export class MarkdownFormatter {
 
     if (!turn.omitEmptySections) {
       if (!omitUserSection) {
-        lines.push('### 👤 User');
+        lines.push(`### 👤 ${this.escapeMarkdownLabel(speakerLabels.user)}`);
         lines.push('');
 
         if (turn.userElement) {
@@ -159,7 +165,7 @@ export class MarkdownFormatter {
         lines.push('');
       }
 
-      lines.push('### 🤖 Assistant');
+      lines.push(`### 🤖 ${this.escapeMarkdownLabel(speakerLabels.assistant)}`);
       lines.push('');
 
       if (turn.assistantElement) {
@@ -178,7 +184,7 @@ export class MarkdownFormatter {
     const userFallback = this.formatContent(turn.user);
     const hasUser = !!turn.userElement || !!userFallback;
     if (hasUser && !omitUserSection) {
-      lines.push('### 👤 User');
+      lines.push(`### 👤 ${this.escapeMarkdownLabel(speakerLabels.user)}`);
       lines.push('');
 
       if (turn.userElement) {
@@ -199,7 +205,7 @@ export class MarkdownFormatter {
     const assistantFallback = this.formatContent(turn.assistant);
     const hasAssistant = !!turn.assistantElement || !!assistantFallback;
     if (hasAssistant) {
-      lines.push('### 🤖 Assistant');
+      lines.push(`### 🤖 ${this.escapeMarkdownLabel(speakerLabels.assistant)}`);
       lines.push('');
 
       if (turn.assistantElement) {
@@ -314,6 +320,11 @@ export class MarkdownFormatter {
   private static escapeMarkdown(text: string): string {
     // Escape special characters that could break Markdown
     return text.replace(/([\\`*_{}[\]()#+\-.!])/g, '\\$1');
+  }
+
+  private static escapeMarkdownLabel(text: string): string {
+    const escapedHtml = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return this.escapeMarkdown(escapedHtml);
   }
 
   /**

--- a/src/features/export/services/PDFPrintService.ts
+++ b/src/features/export/services/PDFPrintService.ts
@@ -5,7 +5,12 @@
  */
 import { isSafari } from '@/core/utils/browser';
 
-import type { ChatTurn, ConversationMetadata } from '../types/export';
+import {
+  type ChatTurn,
+  type ConversationMetadata,
+  DEFAULT_EXPORT_SPEAKER_LABELS,
+  type ExportSpeakerLabels,
+} from '../types/export';
 import { DOMContentExtractor } from './DOMContentExtractor';
 import { buildKatexExportStyles } from './katexExportStyles';
 import { buildMermaidExportStyles } from './mermaidExportStyles';
@@ -39,9 +44,9 @@ export class PDFPrintService {
   static async export(
     turns: ChatTurn[],
     metadata: ConversationMetadata,
-    options?: { fontSize?: number },
+    options?: { fontSize?: number; speakerLabels?: ExportSpeakerLabels },
   ): Promise<void> {
-    await this.exportInternal(turns, metadata, false, options?.fontSize);
+    await this.exportInternal(turns, metadata, false, options?.fontSize, options?.speakerLabels);
   }
 
   static async exportDocument(content: PrintableDocumentContent): Promise<void> {
@@ -74,6 +79,7 @@ export class PDFPrintService {
     metadata: ConversationMetadata,
     preferMetadataTitle: boolean,
     fontSize?: number,
+    speakerLabels: ExportSpeakerLabels = DEFAULT_EXPORT_SPEAKER_LABELS,
   ): Promise<void> {
     // Ensure we don't leave a previous export container around (e.g. if a prior export failed)
     this.cleanup();
@@ -81,7 +87,12 @@ export class PDFPrintService {
     const safari = isSafari();
 
     // Create print container
-    const container = this.createPrintContainer(turns, metadata, preferMetadataTitle);
+    const container = this.createPrintContainer(
+      turns,
+      metadata,
+      preferMetadataTitle,
+      speakerLabels,
+    );
     if (safari) {
       isolateMermaidSvgImages(container);
     } else {
@@ -190,6 +201,7 @@ export class PDFPrintService {
     turns: ChatTurn[],
     metadata: ConversationMetadata,
     preferMetadataTitle: boolean,
+    speakerLabels: ExportSpeakerLabels,
   ): HTMLElement {
     const container = document.createElement('div');
     container.id = this.PRINT_CONTAINER_ID;
@@ -199,7 +211,7 @@ export class PDFPrintService {
     container.innerHTML = `
       <div class="gv-print-document">
         ${this.renderHeader(metadata, preferMetadataTitle)}
-        ${this.renderContent(turns)}
+        ${this.renderContent(turns, speakerLabels)}
         ${this.renderFooter(metadata)}
       </div>
     `;
@@ -528,10 +540,10 @@ export class PDFPrintService {
   /**
    * Render conversation content
    */
-  private static renderContent(turns: ChatTurn[]): string {
+  private static renderContent(turns: ChatTurn[], speakerLabels: ExportSpeakerLabels): string {
     return `
       <div class="gv-print-content">
-        ${turns.map((turn, index) => this.renderTurn(turn, index + 1)).join('\n')}
+        ${turns.map((turn, index) => this.renderTurn(turn, index + 1, speakerLabels)).join('\n')}
       </div>
     `;
   }
@@ -539,7 +551,11 @@ export class PDFPrintService {
   /**
    * Render a single turn
    */
-  private static renderTurn(turn: ChatTurn, index: number): string {
+  private static renderTurn(
+    turn: ChatTurn,
+    index: number,
+    speakerLabels: ExportSpeakerLabels,
+  ): string {
     const starredClass = turn.starred ? 'gv-print-turn-starred' : '';
 
     const userContent = turn.userElement
@@ -560,12 +576,12 @@ export class PDFPrintService {
         </div>
 
         <div class="gv-print-turn-user">
-          <div class="gv-print-turn-label">👤 User</div>
+          <div class="gv-print-turn-label">👤 ${this.escapeHTML(speakerLabels.user)}</div>
           <div class="gv-print-turn-text">${userContent}</div>
         </div>
 
         <div class="gv-print-turn-assistant">
-          <div class="gv-print-turn-label">🤖 Assistant</div>
+          <div class="gv-print-turn-label">🤖 ${this.escapeHTML(speakerLabels.assistant)}</div>
           <div class="gv-print-turn-text">${assistantContent}</div>
         </div>
       </div>
@@ -586,7 +602,7 @@ export class PDFPrintService {
           hasUser
             ? `
         <div class="gv-print-turn-user">
-          <div class="gv-print-turn-label">👤 User</div>
+          <div class="gv-print-turn-label">👤 ${this.escapeHTML(speakerLabels.user)}</div>
           <div class="gv-print-turn-text">${userContent}</div>
         </div>
         `
@@ -597,7 +613,7 @@ export class PDFPrintService {
           hasAssistant
             ? `
           <div class="gv-print-turn-assistant">
-            <div class="gv-print-turn-label">🤖 Assistant</div>
+            <div class="gv-print-turn-label">🤖 ${this.escapeHTML(speakerLabels.assistant)}</div>
             <div class="gv-print-turn-text">${assistantContent}</div>
           </div>
         `

--- a/src/features/export/services/SpeakerLabelPreferenceService.ts
+++ b/src/features/export/services/SpeakerLabelPreferenceService.ts
@@ -1,0 +1,41 @@
+import { storageService } from '@/core/services/StorageService';
+import { StorageKeys } from '@/core/types/common';
+
+import {
+  type ExportSpeakerLabelOverrides,
+  type ExportSpeakerLabels,
+  normalizeSpeakerLabelOverrides,
+} from '../types/export';
+
+export { normalizeSpeakerLabelOverrides, resolveExportSpeakerLabels } from '../types/export';
+
+export async function getSavedSpeakerLabelOverrides(
+  defaults: ExportSpeakerLabels,
+): Promise<ExportSpeakerLabelOverrides> {
+  try {
+    const result = await storageService.get<unknown>(StorageKeys.EXPORT_SPEAKER_LABELS);
+    if (!result.success) return {};
+    return normalizeSpeakerLabelOverrides(result.data, defaults);
+  } catch {
+    return {};
+  }
+}
+
+export async function saveSpeakerLabelOverrides(
+  value: unknown,
+  defaults: ExportSpeakerLabels,
+): Promise<boolean> {
+  const overrides = normalizeSpeakerLabelOverrides(value, defaults);
+
+  try {
+    if (!overrides.user && !overrides.assistant) {
+      const result = await storageService.remove(StorageKeys.EXPORT_SPEAKER_LABELS);
+      return result.success;
+    }
+
+    const result = await storageService.set(StorageKeys.EXPORT_SPEAKER_LABELS, overrides);
+    return result.success;
+  } catch {
+    return false;
+  }
+}

--- a/src/features/export/services/SpeakerLabelPreferenceService.ts
+++ b/src/features/export/services/SpeakerLabelPreferenceService.ts
@@ -1,34 +1,25 @@
 import { storageService } from '@/core/services/StorageService';
 import { StorageKeys } from '@/core/types/common';
 
-import {
-  type ExportSpeakerLabelOverrides,
-  type ExportSpeakerLabels,
-  normalizeSpeakerLabelOverrides,
-} from '../types/export';
+import { type ExportSpeakerLabelOverrides, normalizeSpeakerLabelOverrides } from '../types/export';
 
 export { normalizeSpeakerLabelOverrides, resolveExportSpeakerLabels } from '../types/export';
 
-export async function getSavedSpeakerLabelOverrides(
-  defaults: ExportSpeakerLabels,
-): Promise<ExportSpeakerLabelOverrides> {
+export async function getSavedSpeakerLabelOverrides(): Promise<ExportSpeakerLabelOverrides> {
   try {
     const result = await storageService.get<unknown>(StorageKeys.EXPORT_SPEAKER_LABELS);
     if (!result.success) return {};
-    return normalizeSpeakerLabelOverrides(result.data, defaults);
+    return normalizeSpeakerLabelOverrides(result.data);
   } catch {
     return {};
   }
 }
 
-export async function saveSpeakerLabelOverrides(
-  value: unknown,
-  defaults: ExportSpeakerLabels,
-): Promise<boolean> {
-  const overrides = normalizeSpeakerLabelOverrides(value, defaults);
+export async function saveSpeakerLabelOverrides(value: unknown): Promise<boolean> {
+  const overrides = normalizeSpeakerLabelOverrides(value);
 
   try {
-    if (!overrides.user && !overrides.assistant) {
+    if (Object.keys(overrides).length === 0) {
       const result = await storageService.remove(StorageKeys.EXPORT_SPEAKER_LABELS);
       return result.success;
     }

--- a/src/features/export/services/__tests__/ConversationExportService.test.ts
+++ b/src/features/export/services/__tests__/ConversationExportService.test.ts
@@ -118,6 +118,21 @@ describe('ConversationExportService', () => {
       expect(markdown).not.toContain('### 👤 User');
     });
 
+    it('passes custom speaker labels to Markdown formatting', async () => {
+      const formatSpy = vi.spyOn(MarkdownFormatter, 'format');
+      const speakerLabels = { user: 'Erik', assistant: 'Nova' };
+
+      await ConversationExportService.export(mockTurns, mockMetadata, {
+        format: ExportFormat.MARKDOWN,
+        speakerLabels,
+      });
+
+      expect(formatSpy).toHaveBeenCalledWith(mockTurns, mockMetadata, {
+        usePromptAsTurnHeading: undefined,
+        speakerLabels,
+      });
+    });
+
     it('should export as PDF', async () => {
       const result = await ConversationExportService.export(mockTurns, mockMetadata, {
         format: ExportFormat.PDF,
@@ -139,6 +154,22 @@ describe('ConversationExportService', () => {
       expect((global.window as Window & { print: () => void }).print).toHaveBeenCalled();
     });
 
+    it('passes custom speaker labels to PDF export', async () => {
+      const exportSpy = vi.spyOn(PDFPrintService, 'export').mockResolvedValue(undefined);
+      const speakerLabels = { user: 'Erik', assistant: 'Nova' };
+
+      await ConversationExportService.export(mockTurns, mockMetadata, {
+        format: ExportFormat.PDF,
+        fontSize: 14,
+        speakerLabels,
+      });
+
+      expect(exportSpy).toHaveBeenCalledWith(mockTurns, mockMetadata, {
+        fontSize: 14,
+        speakerLabels,
+      });
+    });
+
     it('should export as Image', async () => {
       (toBlob as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
         new Blob(['x'], { type: 'image/png' }),
@@ -151,6 +182,25 @@ describe('ConversationExportService', () => {
       expect(result.success).toBe(true);
       expect(result.format).toBe('image');
       expect(result.filename).toBe('Premier-League-Fantasy.png');
+    });
+
+    it('passes custom speaker labels to image export', async () => {
+      const exportSpy = vi.spyOn(ImageExportService, 'export').mockResolvedValue(undefined);
+      const speakerLabels = { user: 'Erik', assistant: 'Nova' };
+
+      await ConversationExportService.export(mockTurns, mockMetadata, {
+        format: ExportFormat.IMAGE,
+        fontSize: 22,
+        imageWidth: 960,
+        speakerLabels,
+      });
+
+      expect(exportSpy).toHaveBeenCalledWith(mockTurns, mockMetadata, {
+        filename: 'Premier-League-Fantasy.png',
+        fontSize: 22,
+        imageWidth: 960,
+        speakerLabels,
+      });
     });
 
     it('should export report markdown without turn wrappers in document layout', async () => {
@@ -257,6 +307,7 @@ describe('ConversationExportService', () => {
         format: ExportFormat.PDF,
         layout: 'document' as ExportLayout,
         fontSize: 15,
+        speakerLabels: { user: 'Erik', assistant: 'Nova' },
       });
 
       expect(result.success).toBe(true);
@@ -285,6 +336,7 @@ describe('ConversationExportService', () => {
         layout: 'document' as ExportLayout,
         fontSize: 24,
         imageWidth: 1360,
+        speakerLabels: { user: 'Erik', assistant: 'Nova' },
       });
 
       expect(result.success).toBe(true);
@@ -420,6 +472,28 @@ describe('ConversationExportService', () => {
       expect(items[0].assistant).toBe('Plain text assistant');
 
       expect(items[0].userElement).toBeUndefined();
+    });
+
+    it('keeps JSON roles and object shape unchanged when speaker labels are provided', async () => {
+      const downloadSpy = vi.spyOn(
+        ConversationExportService as unknown as { downloadJSON: (...args: unknown[]) => unknown },
+        'downloadJSON',
+      );
+
+      await ConversationExportService.export(mockTurns, mockMetadata, {
+        format: ExportFormat.JSON,
+        speakerLabels: { user: 'Erik', assistant: 'Nova' },
+      });
+
+      const payload = downloadSpy.mock.calls[0][0] as {
+        items: Array<Record<string, unknown>>;
+      };
+      expect(payload.items[0]).toEqual({
+        user: 'Test question',
+        assistant: 'Test answer',
+        starred: false,
+      });
+      expect(payload.items[0]).not.toHaveProperty('speakerLabels');
     });
 
     it('includes structured attachment metadata without serializing DOM elements', async () => {

--- a/src/features/export/services/__tests__/ImageExportService.test.ts
+++ b/src/features/export/services/__tests__/ImageExportService.test.ts
@@ -83,13 +83,25 @@ describe('ImageExportService', () => {
 
   it('renders conversation to blob without downloading', async () => {
     const blob = new Blob(['blob'], { type: 'image/png' });
-    (toBlob as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(blob);
+    let renderedTarget: HTMLElement | null = null;
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (node: HTMLElement) => {
+        renderedTarget = node;
+        return blob;
+      },
+    );
 
     const result = await ImageExportService.renderConversationBlob(mockTurns, mockMetadata, {});
 
     expect(result).toBe(blob);
     expect(toBlob).toHaveBeenCalled();
     expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+    const target = renderedTarget as HTMLElement | null;
+    expect(
+      Array.from(target?.querySelectorAll('.gv-image-export-label') ?? []).map(
+        (label) => label.textContent,
+      ),
+    ).toEqual(['User', 'Assistant']);
   });
 
   it('renders custom speaker labels as escaped text', async () => {

--- a/src/features/export/services/__tests__/ImageExportService.test.ts
+++ b/src/features/export/services/__tests__/ImageExportService.test.ts
@@ -92,6 +92,32 @@ describe('ImageExportService', () => {
     expect(global.URL.createObjectURL).not.toHaveBeenCalled();
   });
 
+  it('renders custom speaker labels as escaped text', async () => {
+    let renderedTarget: HTMLElement | null = null;
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (node: HTMLElement) => {
+        renderedTarget = node;
+        return new Blob(['x'], { type: 'image/png' });
+      },
+    );
+
+    await ImageExportService.renderConversationBlob(mockTurns, mockMetadata, {
+      speakerLabels: {
+        user: '<img src=x onerror=alert(1)>',
+        assistant: 'Nova & Co.',
+      },
+    });
+
+    const target = renderedTarget as HTMLElement | null;
+    expect(target).not.toBeNull();
+    const labels = Array.from(target?.querySelectorAll('.gv-image-export-label') ?? []);
+    expect(labels.map((label) => label.textContent)).toEqual([
+      '<img src=x onerror=alert(1)>',
+      'Nova & Co.',
+    ]);
+    expect(target?.querySelector('.gv-image-export-label img')).toBeNull();
+  });
+
   it('renders uploaded file placeholders in image exports', async () => {
     let renderedAttachmentText = '';
     let renderedStyles = '';

--- a/src/features/export/services/__tests__/MarkdownFormatter.test.ts
+++ b/src/features/export/services/__tests__/MarkdownFormatter.test.ts
@@ -182,6 +182,56 @@ describe('MarkdownFormatter', () => {
       // Should escape special characters in title but not in content
       expect(markdown).toBeTruthy();
     });
+
+    it('uses custom speaker labels without escaping conversation content', () => {
+      const markdown = MarkdownFormatter.format(mockTurns, mockMetadata, {
+        speakerLabels: {
+          user: 'Erik',
+          assistant: 'Nova',
+        },
+      });
+
+      expect(markdown).toContain('### 👤 Erik');
+      expect(markdown).toContain('### 🤖 Nova');
+      expect(markdown).toContain('Of course! TypeScript is a superset of JavaScript...');
+    });
+
+    it('escapes Markdown-special characters in speaker labels only', () => {
+      const markdown = MarkdownFormatter.format(
+        [
+          {
+            user: '**content stays formatted**',
+            assistant: '`code stays formatted`',
+            starred: false,
+          },
+        ],
+        mockMetadata,
+        {
+          speakerLabels: {
+            user: '# **[User](url)** `root` \\',
+            assistant: '[Assistant](url)',
+          },
+        },
+      );
+
+      expect(markdown).toContain('### 👤 \\# \\*\\*\\[User\\]\\(url\\)\\*\\* \\`root\\` \\\\');
+      expect(markdown).toContain('### 🤖 \\[Assistant\\]\\(url\\)');
+      expect(markdown).toContain('**content stays formatted**');
+      expect(markdown).toContain('`code stays formatted`');
+    });
+
+    it('neutralizes raw HTML in speaker labels', () => {
+      const markdown = MarkdownFormatter.format(mockTurns, mockMetadata, {
+        speakerLabels: {
+          user: '<img src=x onerror="alert(1)">',
+          assistant: 'R&D > Support',
+        },
+      });
+
+      expect(markdown).toContain('### 👤 &lt;img src=x onerror="alert\\(1\\)"&gt;');
+      expect(markdown).toContain('### 🤖 R&amp;D &gt; Support');
+      expect(markdown).not.toContain('<img src=x');
+    });
   });
 
   describe('generateFilename', () => {

--- a/src/features/export/services/__tests__/PDFPrintService.test.ts
+++ b/src/features/export/services/__tests__/PDFPrintService.test.ts
@@ -46,6 +46,33 @@ describe('PDFPrintService', () => {
     expect(document.getElementById('gv-pdf-print-container')).toBeNull();
   });
 
+  it('renders custom speaker labels as escaped text', async () => {
+    window.print = vi.fn();
+
+    await PDFPrintService.export(
+      [{ user: 'u', assistant: 'a', starred: false }],
+      {
+        url: 'https://gemini.google.com/app/x',
+        exportedAt: new Date().toISOString(),
+        count: 1,
+        title: 'Safe labels',
+      },
+      {
+        speakerLabels: {
+          user: '<img src=x onerror=alert(1)>',
+          assistant: 'Nova & Co.',
+        },
+      },
+    );
+
+    const labels = Array.from(document.querySelectorAll('.gv-print-turn-label'));
+    expect(labels.map((label) => label.textContent)).toEqual([
+      '👤 <img src=x onerror=alert(1)>',
+      '🤖 Nova & Co.',
+    ]);
+    expect(document.querySelector('.gv-print-turn-label img')).toBeNull();
+  });
+
   it('injects print rules scoped by pdf printing class with white page reset', async () => {
     window.print = vi.fn();
 

--- a/src/features/export/services/__tests__/SpeakerLabelPreferenceService.test.ts
+++ b/src/features/export/services/__tests__/SpeakerLabelPreferenceService.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { StorageKeys } from '@/core/types/common';
+
+import type { ExportSpeakerLabels } from '../../types/export';
+import {
+  getSavedSpeakerLabelOverrides,
+  normalizeSpeakerLabelOverrides,
+  resolveExportSpeakerLabels,
+  saveSpeakerLabelOverrides,
+} from '../SpeakerLabelPreferenceService';
+
+const { getMock, removeMock, setMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  removeMock: vi.fn(),
+  setMock: vi.fn(),
+}));
+
+vi.mock('@/core/services/StorageService', () => ({
+  storageService: {
+    get: getMock,
+    remove: removeMock,
+    set: setMock,
+  },
+}));
+
+describe('SpeakerLabelPreferenceService', () => {
+  const defaults: ExportSpeakerLabels = {
+    user: 'User',
+    assistant: 'Assistant',
+  };
+
+  beforeEach(() => {
+    getMock.mockReset();
+    removeMock.mockReset();
+    setMock.mockReset();
+  });
+
+  it.each([
+    [{ user: '', assistant: '   ' }, {}],
+    [{ user: ' User ', assistant: 'Assistant' }, {}],
+    [
+      { user: ' Erik ', assistant: '  Nova  ' },
+      { user: 'Erik', assistant: 'Nova' },
+    ],
+    [{ user: 'Erik' }, { user: 'Erik' }],
+    [null, {}],
+    ['invalid', {}],
+    [{ user: 42, assistant: ['Nova'] }, {}],
+  ])('normalizes stored overrides defensively', (value, expected) => {
+    expect(normalizeSpeakerLabelOverrides(value, defaults)).toEqual(expected);
+  });
+
+  it('resolves blank and whitespace-only values to localized defaults', () => {
+    expect(resolveExportSpeakerLabels({ user: '', assistant: '   ' }, defaults)).toEqual(defaults);
+  });
+
+  it('restores valid saved overrides and ignores malformed fields', async () => {
+    getMock.mockResolvedValue({
+      success: true,
+      data: { user: 'Erik', assistant: 42 },
+    });
+
+    await expect(getSavedSpeakerLabelOverrides(defaults)).resolves.toEqual({ user: 'Erik' });
+    expect(getMock).toHaveBeenCalledWith(StorageKeys.EXPORT_SPEAKER_LABELS);
+  });
+
+  it('falls back safely when reading storage fails or throws', async () => {
+    getMock.mockResolvedValueOnce({ success: false, error: new Error('read failed') });
+    await expect(getSavedSpeakerLabelOverrides(defaults)).resolves.toEqual({});
+
+    getMock.mockRejectedValueOnce(new Error('context invalidated'));
+    await expect(getSavedSpeakerLabelOverrides(defaults)).resolves.toEqual({});
+  });
+
+  it('stores only normalized custom overrides', async () => {
+    setMock.mockResolvedValue({ success: true, data: undefined });
+
+    await expect(
+      saveSpeakerLabelOverrides({ user: ' Erik ', assistant: 'Nova' }, defaults),
+    ).resolves.toBe(true);
+
+    expect(setMock).toHaveBeenCalledWith(StorageKeys.EXPORT_SPEAKER_LABELS, {
+      user: 'Erik',
+      assistant: 'Nova',
+    });
+  });
+
+  it('removes saved overrides when both fields return to defaults', async () => {
+    removeMock.mockResolvedValue({ success: true, data: undefined });
+
+    await expect(
+      saveSpeakerLabelOverrides({ user: ' ', assistant: 'Assistant' }, defaults),
+    ).resolves.toBe(true);
+
+    expect(removeMock).toHaveBeenCalledWith(StorageKeys.EXPORT_SPEAKER_LABELS);
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it('reports failed writes without throwing', async () => {
+    setMock.mockResolvedValue({ success: false, error: new Error('write failed') });
+
+    await expect(
+      saveSpeakerLabelOverrides({ user: 'Erik', assistant: 'Nova' }, defaults),
+    ).resolves.toBe(false);
+  });
+
+  it('reports failed removals without throwing', async () => {
+    removeMock.mockResolvedValue({ success: false, error: new Error('remove failed') });
+
+    await expect(saveSpeakerLabelOverrides({}, defaults)).resolves.toBe(false);
+  });
+
+  it('contains thrown storage failures and keeps export callers unblocked', async () => {
+    setMock.mockRejectedValue(new Error('context invalidated'));
+
+    await expect(saveSpeakerLabelOverrides({ user: 'Erik' }, defaults)).resolves.toBe(false);
+  });
+});

--- a/src/features/export/services/__tests__/SpeakerLabelPreferenceService.test.ts
+++ b/src/features/export/services/__tests__/SpeakerLabelPreferenceService.test.ts
@@ -38,7 +38,10 @@ describe('SpeakerLabelPreferenceService', () => {
 
   it.each([
     [{ user: '', assistant: '   ' }, {}],
-    [{ user: ' User ', assistant: 'Assistant' }, {}],
+    [
+      { user: ' User ', assistant: 'Assistant' },
+      { user: 'User', assistant: 'Assistant' },
+    ],
     [
       { user: ' Erik ', assistant: '  Nova  ' },
       { user: 'Erik', assistant: 'Nova' },
@@ -48,7 +51,7 @@ describe('SpeakerLabelPreferenceService', () => {
     ['invalid', {}],
     [{ user: 42, assistant: ['Nova'] }, {}],
   ])('normalizes stored overrides defensively', (value, expected) => {
-    expect(normalizeSpeakerLabelOverrides(value, defaults)).toEqual(expected);
+    expect(normalizeSpeakerLabelOverrides(value)).toEqual(expected);
   });
 
   it('resolves blank and whitespace-only values to localized defaults', () => {
@@ -61,24 +64,24 @@ describe('SpeakerLabelPreferenceService', () => {
       data: { user: 'Erik', assistant: 42 },
     });
 
-    await expect(getSavedSpeakerLabelOverrides(defaults)).resolves.toEqual({ user: 'Erik' });
+    await expect(getSavedSpeakerLabelOverrides()).resolves.toEqual({ user: 'Erik' });
     expect(getMock).toHaveBeenCalledWith(StorageKeys.EXPORT_SPEAKER_LABELS);
   });
 
   it('falls back safely when reading storage fails or throws', async () => {
     getMock.mockResolvedValueOnce({ success: false, error: new Error('read failed') });
-    await expect(getSavedSpeakerLabelOverrides(defaults)).resolves.toEqual({});
+    await expect(getSavedSpeakerLabelOverrides()).resolves.toEqual({});
 
     getMock.mockRejectedValueOnce(new Error('context invalidated'));
-    await expect(getSavedSpeakerLabelOverrides(defaults)).resolves.toEqual({});
+    await expect(getSavedSpeakerLabelOverrides()).resolves.toEqual({});
   });
 
   it('stores only normalized custom overrides', async () => {
     setMock.mockResolvedValue({ success: true, data: undefined });
 
-    await expect(
-      saveSpeakerLabelOverrides({ user: ' Erik ', assistant: 'Nova' }, defaults),
-    ).resolves.toBe(true);
+    await expect(saveSpeakerLabelOverrides({ user: ' Erik ', assistant: 'Nova' })).resolves.toBe(
+      true,
+    );
 
     expect(setMock).toHaveBeenCalledWith(StorageKeys.EXPORT_SPEAKER_LABELS, {
       user: 'Erik',
@@ -86,12 +89,51 @@ describe('SpeakerLabelPreferenceService', () => {
     });
   });
 
-  it('removes saved overrides when both fields return to defaults', async () => {
+  it('preserves an explicit override through a locale-default collision', async () => {
+    const englishDefaults: ExportSpeakerLabels = {
+      user: 'User',
+      assistant: 'Assistant',
+    };
+    const frenchDefaults: ExportSpeakerLabels = {
+      user: 'Utilisateur',
+      assistant: 'Utilisateur',
+    };
+    let storedValue: unknown;
+
+    getMock.mockImplementation(async () => ({ success: true, data: storedValue }));
+    setMock.mockImplementation(async (_key: string, value: unknown) => {
+      storedValue = value;
+      return { success: true, data: undefined };
+    });
+    removeMock.mockImplementation(async () => {
+      storedValue = undefined;
+      return { success: true, data: undefined };
+    });
+
+    await expect(saveSpeakerLabelOverrides({ assistant: 'Utilisateur' })).resolves.toBe(true);
+
+    const frenchOverrides = await getSavedSpeakerLabelOverrides();
+    expect(frenchOverrides).toEqual({ assistant: 'Utilisateur' });
+    expect(resolveExportSpeakerLabels(frenchOverrides, frenchDefaults)).toEqual({
+      user: 'Utilisateur',
+      assistant: 'Utilisateur',
+    });
+
+    await expect(saveSpeakerLabelOverrides(frenchOverrides)).resolves.toBe(true);
+    expect(removeMock).not.toHaveBeenCalled();
+
+    const restoredEnglishOverrides = await getSavedSpeakerLabelOverrides();
+    expect(restoredEnglishOverrides).toEqual({ assistant: 'Utilisateur' });
+    expect(resolveExportSpeakerLabels(restoredEnglishOverrides, englishDefaults)).toEqual({
+      user: 'User',
+      assistant: 'Utilisateur',
+    });
+  });
+
+  it('removes saved overrides when both explicit fields are cleared', async () => {
     removeMock.mockResolvedValue({ success: true, data: undefined });
 
-    await expect(
-      saveSpeakerLabelOverrides({ user: ' ', assistant: 'Assistant' }, defaults),
-    ).resolves.toBe(true);
+    await expect(saveSpeakerLabelOverrides({ user: ' ', assistant: '' })).resolves.toBe(true);
 
     expect(removeMock).toHaveBeenCalledWith(StorageKeys.EXPORT_SPEAKER_LABELS);
     expect(setMock).not.toHaveBeenCalled();
@@ -100,20 +142,20 @@ describe('SpeakerLabelPreferenceService', () => {
   it('reports failed writes without throwing', async () => {
     setMock.mockResolvedValue({ success: false, error: new Error('write failed') });
 
-    await expect(
-      saveSpeakerLabelOverrides({ user: 'Erik', assistant: 'Nova' }, defaults),
-    ).resolves.toBe(false);
+    await expect(saveSpeakerLabelOverrides({ user: 'Erik', assistant: 'Nova' })).resolves.toBe(
+      false,
+    );
   });
 
   it('reports failed removals without throwing', async () => {
     removeMock.mockResolvedValue({ success: false, error: new Error('remove failed') });
 
-    await expect(saveSpeakerLabelOverrides({}, defaults)).resolves.toBe(false);
+    await expect(saveSpeakerLabelOverrides({})).resolves.toBe(false);
   });
 
   it('contains thrown storage failures and keeps export callers unblocked', async () => {
     setMock.mockRejectedValue(new Error('context invalidated'));
 
-    await expect(saveSpeakerLabelOverrides({ user: 'Erik' }, defaults)).resolves.toBe(false);
+    await expect(saveSpeakerLabelOverrides({ user: 'Erik' })).resolves.toBe(false);
   });
 });

--- a/src/features/export/types/export.ts
+++ b/src/features/export/types/export.ts
@@ -59,6 +59,53 @@ export enum ExportFormat {
 export type ExportLayout = 'conversation' | 'document';
 export type ImageExportWidth = 620 | 960 | 1360;
 
+export interface ExportSpeakerLabels {
+  user: string;
+  assistant: string;
+}
+
+export type ExportSpeakerLabelOverrides = Partial<ExportSpeakerLabels>;
+
+export const DEFAULT_EXPORT_SPEAKER_LABELS: Readonly<ExportSpeakerLabels> = {
+  user: 'User',
+  assistant: 'Assistant',
+};
+
+function normalizeSpeakerLabel(value: unknown, defaultValue: string): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  const normalized = value.trim();
+  if (!normalized || normalized === defaultValue) return undefined;
+  return normalized;
+}
+
+export function normalizeSpeakerLabelOverrides(
+  value: unknown,
+  defaults: ExportSpeakerLabels,
+): ExportSpeakerLabelOverrides {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+
+  const candidate = value as Record<string, unknown>;
+  const user = normalizeSpeakerLabel(candidate.user, defaults.user);
+  const assistant = normalizeSpeakerLabel(candidate.assistant, defaults.assistant);
+
+  return {
+    ...(user ? { user } : {}),
+    ...(assistant ? { assistant } : {}),
+  };
+}
+
+export function resolveExportSpeakerLabels(
+  value: unknown,
+  defaults: ExportSpeakerLabels,
+): ExportSpeakerLabels {
+  const overrides = normalizeSpeakerLabelOverrides(value, defaults);
+  return {
+    user: overrides.user ?? defaults.user,
+    assistant: overrides.assistant ?? defaults.assistant,
+  };
+}
+
 export const IMAGE_EXPORT_WIDTH_NARROW: ImageExportWidth = 620;
 export const IMAGE_EXPORT_WIDTH_MEDIUM: ImageExportWidth = 960;
 export const IMAGE_EXPORT_WIDTH_WIDE: ImageExportWidth = 1360;
@@ -109,10 +156,13 @@ export interface ExportOptions {
   includeImageSource?: boolean;
   /** Put each user prompt in its turn heading and omit the duplicate User section. */
   usePromptAsTurnHeading?: boolean;
+  /** Human-readable labels used by conversation exports; ignored by JSON and document layouts. */
+  speakerLabels?: ExportSpeakerLabels;
 }
 
 export interface MarkdownFormatOptions {
   usePromptAsTurnHeading?: boolean;
+  speakerLabels?: ExportSpeakerLabels;
 }
 
 /**

--- a/src/features/export/types/export.ts
+++ b/src/features/export/types/export.ts
@@ -71,23 +71,19 @@ export const DEFAULT_EXPORT_SPEAKER_LABELS: Readonly<ExportSpeakerLabels> = {
   assistant: 'Assistant',
 };
 
-function normalizeSpeakerLabel(value: unknown, defaultValue: string): string | undefined {
+function normalizeSpeakerLabel(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
 
   const normalized = value.trim();
-  if (!normalized || normalized === defaultValue) return undefined;
-  return normalized;
+  return normalized || undefined;
 }
 
-export function normalizeSpeakerLabelOverrides(
-  value: unknown,
-  defaults: ExportSpeakerLabels,
-): ExportSpeakerLabelOverrides {
+export function normalizeSpeakerLabelOverrides(value: unknown): ExportSpeakerLabelOverrides {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
 
   const candidate = value as Record<string, unknown>;
-  const user = normalizeSpeakerLabel(candidate.user, defaults.user);
-  const assistant = normalizeSpeakerLabel(candidate.assistant, defaults.assistant);
+  const user = normalizeSpeakerLabel(candidate.user);
+  const assistant = normalizeSpeakerLabel(candidate.assistant);
 
   return {
     ...(user ? { user } : {}),
@@ -99,7 +95,7 @@ export function resolveExportSpeakerLabels(
   value: unknown,
   defaults: ExportSpeakerLabels,
 ): ExportSpeakerLabels {
-  const overrides = normalizeSpeakerLabelOverrides(value, defaults);
+  const overrides = normalizeSpeakerLabelOverrides(value);
   return {
     user: overrides.user ?? defaults.user,
     assistant: overrides.assistant ?? defaults.assistant,

--- a/src/features/export/ui/ExportDialog.ts
+++ b/src/features/export/ui/ExportDialog.ts
@@ -8,13 +8,14 @@ import { ConversationExportService } from '../services/ConversationExportService
 import {
   DEFAULT_IMAGE_EXPORT_WIDTH,
   type ExportFormat,
+  type ExportSpeakerLabelOverrides,
   type ExportSpeakerLabels,
   IMAGE_EXPORT_WIDTH_MEDIUM,
   IMAGE_EXPORT_WIDTH_NARROW,
   IMAGE_EXPORT_WIDTH_WIDE,
   type ImageExportWidth,
   normalizeImageExportWidth,
-  resolveExportSpeakerLabels,
+  normalizeSpeakerLabelOverrides,
 } from '../types/export';
 
 export interface ExportDialogOptions {
@@ -24,11 +25,12 @@ export interface ExportDialogOptions {
     imageWidth?: number,
     usePromptAsTurnHeading?: boolean,
     speakerLabels?: ExportSpeakerLabels,
+    speakerLabelOverrides?: ExportSpeakerLabelOverrides,
   ) => void;
   onCancel: () => void;
   initialImageWidth?: ImageExportWidth;
   showPromptHeadingOption?: boolean;
-  initialSpeakerLabels?: ExportSpeakerLabels;
+  initialSpeakerLabelOverrides?: ExportSpeakerLabelOverrides;
   speakerLabelsEnabled?: boolean;
   speakerNames?: {
     title: string;
@@ -74,7 +76,7 @@ export class ExportDialog {
   private fontSize: number = PDF_DEFAULT_FONT_SIZE;
   private imageWidth: ImageExportWidth = DEFAULT_IMAGE_EXPORT_WIDTH;
   private usePromptAsTurnHeading = false;
-  private speakerLabels: ExportSpeakerLabels | null = null;
+  private speakerLabelOverrides: ExportSpeakerLabelOverrides | null = null;
 
   /**
    * Show export dialog
@@ -83,13 +85,11 @@ export class ExportDialog {
     this.imageWidth = normalizeImageExportWidth(options.initialImageWidth);
     this.usePromptAsTurnHeading = false;
     if (options.speakerNames && options.speakerLabelsEnabled !== false) {
-      const defaults = {
-        user: options.speakerNames.userDefault,
-        assistant: options.speakerNames.assistantDefault,
-      };
-      this.speakerLabels = resolveExportSpeakerLabels(options.initialSpeakerLabels, defaults);
+      this.speakerLabelOverrides = normalizeSpeakerLabelOverrides(
+        options.initialSpeakerLabelOverrides,
+      );
     } else {
-      this.speakerLabels = null;
+      this.speakerLabelOverrides = null;
     }
     this.overlay = this.createDialog(options);
     document.body.appendChild(this.overlay);
@@ -183,19 +183,21 @@ export class ExportDialog {
       const usePromptAsTurnHeading = isMarkdown ? this.usePromptAsTurnHeading : undefined;
       if (
         this.selectedFormat !== ('json' as ExportFormat) &&
-        this.speakerLabels &&
+        this.speakerLabelOverrides &&
         options.speakerNames
       ) {
-        const defaults = {
-          user: options.speakerNames.userDefault,
-          assistant: options.speakerNames.assistantDefault,
+        const speakerLabelOverrides = { ...this.speakerLabelOverrides };
+        const speakerLabels: ExportSpeakerLabels = {
+          user: speakerLabelOverrides.user ?? options.speakerNames.userDefault,
+          assistant: speakerLabelOverrides.assistant ?? options.speakerNames.assistantDefault,
         };
         options.onExport(
           this.selectedFormat,
           fontSize,
           imageWidth,
           usePromptAsTurnHeading,
-          resolveExportSpeakerLabels(this.speakerLabels, defaults),
+          speakerLabels,
+          speakerLabelOverrides,
         );
       } else {
         options.onExport(this.selectedFormat, fontSize, imageWidth, usePromptAsTurnHeading);
@@ -247,7 +249,9 @@ export class ExportDialog {
   }
 
   private createSpeakerNamesSection(options: ExportDialogOptions): HTMLElement | null {
-    if (!options.speakerNames || options.speakerLabelsEnabled === false || !this.speakerLabels) {
+    const speakerNames = options.speakerNames;
+    const speakerLabelOverrides = this.speakerLabelOverrides;
+    if (!speakerNames || options.speakerLabelsEnabled === false || !speakerLabelOverrides) {
       return null;
     }
 
@@ -256,7 +260,7 @@ export class ExportDialog {
 
     const title = document.createElement('div');
     title.className = 'gv-export-speakers-title';
-    title.textContent = options.speakerNames.title;
+    title.textContent = speakerNames.title;
 
     const fields = document.createElement('div');
     fields.className = 'gv-export-speakers-fields';
@@ -279,10 +283,15 @@ export class ExportDialog {
       input.type = 'text';
       input.className = 'gv-export-speaker-input';
       input.autocomplete = 'off';
-      input.value = this.speakerLabels?.[key] ?? '';
+      const defaultValue =
+        key === 'user' ? speakerNames.userDefault : speakerNames.assistantDefault;
+      input.value = speakerLabelOverrides[key] ?? defaultValue;
       input.addEventListener('input', () => {
-        if (this.speakerLabels) {
-          this.speakerLabels[key] = input.value;
+        const normalized = input.value.trim();
+        if (!normalized || normalized === defaultValue) {
+          delete speakerLabelOverrides[key];
+        } else {
+          speakerLabelOverrides[key] = normalized;
         }
       });
 
@@ -292,10 +301,10 @@ export class ExportDialog {
     };
 
     fields.appendChild(
-      createField('gv-export-speaker-user', options.speakerNames.userLabel, 'user'),
+      createField('gv-export-speaker-user', speakerNames.userLabel, 'user'),
     );
     fields.appendChild(
-      createField('gv-export-speaker-assistant', options.speakerNames.assistantLabel, 'assistant'),
+      createField('gv-export-speaker-assistant', speakerNames.assistantLabel, 'assistant'),
     );
 
     section.appendChild(title);

--- a/src/features/export/ui/ExportDialog.ts
+++ b/src/features/export/ui/ExportDialog.ts
@@ -8,11 +8,13 @@ import { ConversationExportService } from '../services/ConversationExportService
 import {
   DEFAULT_IMAGE_EXPORT_WIDTH,
   type ExportFormat,
+  type ExportSpeakerLabels,
   IMAGE_EXPORT_WIDTH_MEDIUM,
   IMAGE_EXPORT_WIDTH_NARROW,
   IMAGE_EXPORT_WIDTH_WIDE,
   type ImageExportWidth,
   normalizeImageExportWidth,
+  resolveExportSpeakerLabels,
 } from '../types/export';
 
 export interface ExportDialogOptions {
@@ -21,10 +23,20 @@ export interface ExportDialogOptions {
     fontSize?: number,
     imageWidth?: number,
     usePromptAsTurnHeading?: boolean,
+    speakerLabels?: ExportSpeakerLabels,
   ) => void;
   onCancel: () => void;
   initialImageWidth?: ImageExportWidth;
   showPromptHeadingOption?: boolean;
+  initialSpeakerLabels?: ExportSpeakerLabels;
+  speakerLabelsEnabled?: boolean;
+  speakerNames?: {
+    title: string;
+    userLabel: string;
+    assistantLabel: string;
+    userDefault: string;
+    assistantDefault: string;
+  };
   translations: {
     title: string;
     selectFormat: string;
@@ -62,6 +74,7 @@ export class ExportDialog {
   private fontSize: number = PDF_DEFAULT_FONT_SIZE;
   private imageWidth: ImageExportWidth = DEFAULT_IMAGE_EXPORT_WIDTH;
   private usePromptAsTurnHeading = false;
+  private speakerLabels: ExportSpeakerLabels | null = null;
 
   /**
    * Show export dialog
@@ -69,6 +82,15 @@ export class ExportDialog {
   show(options: ExportDialogOptions): void {
     this.imageWidth = normalizeImageExportWidth(options.initialImageWidth);
     this.usePromptAsTurnHeading = false;
+    if (options.speakerNames && options.speakerLabelsEnabled !== false) {
+      const defaults = {
+        user: options.speakerNames.userDefault,
+        assistant: options.speakerNames.assistantDefault,
+      };
+      this.speakerLabels = resolveExportSpeakerLabels(options.initialSpeakerLabels, defaults);
+    } else {
+      this.speakerLabels = null;
+    }
     this.overlay = this.createDialog(options);
     document.body.appendChild(this.overlay);
 
@@ -133,6 +155,7 @@ export class ExportDialog {
 
     // Prompt heading section (visible only for chat Markdown exports)
     const promptHeadingSection = this.createPromptHeadingSection(options);
+    const speakerNamesSection = this.createSpeakerNamesSection(options);
 
     // Buttons
     const buttons = document.createElement('div');
@@ -155,12 +178,28 @@ export class ExportDialog {
       const isPdf = this.selectedFormat === ('pdf' as ExportFormat);
       const isImage = this.selectedFormat === ('image' as ExportFormat);
       const isMarkdown = this.selectedFormat === ('markdown' as ExportFormat);
-      options.onExport(
-        this.selectedFormat,
-        isPdf || isImage ? this.fontSize : undefined,
-        isImage ? this.imageWidth : undefined,
-        isMarkdown ? this.usePromptAsTurnHeading : undefined,
-      );
+      const fontSize = isPdf || isImage ? this.fontSize : undefined;
+      const imageWidth = isImage ? this.imageWidth : undefined;
+      const usePromptAsTurnHeading = isMarkdown ? this.usePromptAsTurnHeading : undefined;
+      if (
+        this.selectedFormat !== ('json' as ExportFormat) &&
+        this.speakerLabels &&
+        options.speakerNames
+      ) {
+        const defaults = {
+          user: options.speakerNames.userDefault,
+          assistant: options.speakerNames.assistantDefault,
+        };
+        options.onExport(
+          this.selectedFormat,
+          fontSize,
+          imageWidth,
+          usePromptAsTurnHeading,
+          resolveExportSpeakerLabels(this.speakerLabels, defaults),
+        );
+      } else {
+        options.onExport(this.selectedFormat, fontSize, imageWidth, usePromptAsTurnHeading);
+      }
       this.hide();
     });
 
@@ -178,6 +217,9 @@ export class ExportDialog {
     }
     dialog.appendChild(formatsList);
     dialog.appendChild(promptHeadingSection);
+    if (speakerNamesSection) {
+      dialog.appendChild(speakerNamesSection);
+    }
     dialog.appendChild(fontSizeSection);
     dialog.appendChild(imageWidthSection);
     dialog.appendChild(buttons);
@@ -202,6 +244,63 @@ export class ExportDialog {
     document.addEventListener('keydown', handleEscape);
 
     return overlay;
+  }
+
+  private createSpeakerNamesSection(options: ExportDialogOptions): HTMLElement | null {
+    if (!options.speakerNames || options.speakerLabelsEnabled === false || !this.speakerLabels) {
+      return null;
+    }
+
+    const section = document.createElement('div');
+    section.className = 'gv-export-speakers-section';
+
+    const title = document.createElement('div');
+    title.className = 'gv-export-speakers-title';
+    title.textContent = options.speakerNames.title;
+
+    const fields = document.createElement('div');
+    fields.className = 'gv-export-speakers-fields';
+
+    const createField = (
+      id: string,
+      labelText: string,
+      key: keyof ExportSpeakerLabels,
+    ): HTMLElement => {
+      const field = document.createElement('div');
+      field.className = 'gv-export-speaker-field';
+
+      const label = document.createElement('label');
+      label.className = 'gv-export-speaker-label';
+      label.htmlFor = id;
+      label.textContent = labelText;
+
+      const input = document.createElement('input');
+      input.id = id;
+      input.type = 'text';
+      input.className = 'gv-export-speaker-input';
+      input.autocomplete = 'off';
+      input.value = this.speakerLabels?.[key] ?? '';
+      input.addEventListener('input', () => {
+        if (this.speakerLabels) {
+          this.speakerLabels[key] = input.value;
+        }
+      });
+
+      field.appendChild(label);
+      field.appendChild(input);
+      return field;
+    };
+
+    fields.appendChild(
+      createField('gv-export-speaker-user', options.speakerNames.userLabel, 'user'),
+    );
+    fields.appendChild(
+      createField('gv-export-speaker-assistant', options.speakerNames.assistantLabel, 'assistant'),
+    );
+
+    section.appendChild(title);
+    section.appendChild(fields);
+    return section;
   }
 
   /**
@@ -440,6 +539,9 @@ export class ExportDialog {
     const promptHeadingSection = this.overlay.querySelector(
       '.gv-export-prompt-heading-section',
     ) as HTMLElement | null;
+    const speakerNamesSection = this.overlay.querySelector(
+      '.gv-export-speakers-section',
+    ) as HTMLElement | null;
 
     if (!fontSizeSection || !imageWidthSection || !promptHeadingSection) return;
 
@@ -451,6 +553,10 @@ export class ExportDialog {
     imageWidthSection.style.display = isImage ? 'block' : 'none';
     promptHeadingSection.style.display =
       isMarkdown && promptHeadingSection.dataset.enabled === 'true' ? 'flex' : 'none';
+    if (speakerNamesSection) {
+      speakerNamesSection.style.display =
+        this.selectedFormat === ('json' as ExportFormat) ? 'none' : 'block';
+    }
 
     if (isPdf || isImage) {
       const slider = fontSizeSection.querySelector(

--- a/src/features/export/ui/ExportDialog.ts
+++ b/src/features/export/ui/ExportDialog.ts
@@ -300,9 +300,7 @@ export class ExportDialog {
       return field;
     };
 
-    fields.appendChild(
-      createField('gv-export-speaker-user', speakerNames.userLabel, 'user'),
-    );
+    fields.appendChild(createField('gv-export-speaker-user', speakerNames.userLabel, 'user'));
     fields.appendChild(
       createField('gv-export-speaker-assistant', speakerNames.assistantLabel, 'assistant'),
     );

--- a/src/features/export/ui/__tests__/ExportDialog.test.ts
+++ b/src/features/export/ui/__tests__/ExportDialog.test.ts
@@ -237,4 +237,228 @@ describe('ExportDialog', () => {
     ) as HTMLElement | null;
     expect(section?.style.display).toBe('none');
   });
+
+  it('restores saved speaker labels with accessible field labels', () => {
+    const dialog = new ExportDialog();
+    dialog.show({
+      onExport: () => {},
+      onCancel: () => {},
+      initialSpeakerLabels: { user: 'Erik', assistant: 'Nova' },
+      speakerNames: {
+        title: 'Speaker names',
+        userLabel: 'User label',
+        assistantLabel: 'AI label',
+        userDefault: 'User',
+        assistantDefault: 'Assistant',
+      },
+      translations: {
+        title: 'Export',
+        selectFormat: 'Select format',
+        warning: '',
+        safariCmdpHint: 'Safari tip',
+        safariMarkdownHint: 'Safari markdown tip',
+        cancel: 'Cancel',
+        export: 'Export',
+        fontSizeLabel: 'Font Size',
+        fontSizePreview: 'The quick brown fox jumps over the lazy dog.',
+        imageWidthLabel: 'Image Width',
+        imageWidthNarrow: 'Narrow',
+        imageWidthMedium: 'Medium',
+        imageWidthWide: 'Wide',
+        promptHeadingLabel: 'Use prompts as turn headings',
+        promptHeadingHint: 'Put each prompt in its turn heading.',
+        formatDescriptions: {
+          json: 'JSON format',
+          markdown: 'Markdown format',
+          pdf: 'PDF format',
+          image: 'Image format',
+        },
+      },
+    });
+
+    const userInput = document.querySelector('#gv-export-speaker-user') as HTMLInputElement | null;
+    const assistantInput = document.querySelector(
+      '#gv-export-speaker-assistant',
+    ) as HTMLInputElement | null;
+    expect(userInput?.value).toBe('Erik');
+    expect(assistantInput?.value).toBe('Nova');
+    expect(document.querySelector('label[for="gv-export-speaker-user"]')?.textContent).toBe(
+      'User label',
+    );
+    expect(document.querySelector('label[for="gv-export-speaker-assistant"]')?.textContent).toBe(
+      'AI label',
+    );
+  });
+
+  it('hides labels for JSON without clearing values and restores them for human-readable formats', () => {
+    const onExport = vi.fn();
+    const dialog = new ExportDialog();
+    dialog.show({
+      onExport,
+      onCancel: () => {},
+      showPromptHeadingOption: true,
+      speakerNames: {
+        title: 'Speaker names',
+        userLabel: 'User label',
+        assistantLabel: 'AI label',
+        userDefault: 'User',
+        assistantDefault: 'Assistant',
+      },
+      translations: {
+        title: 'Export',
+        selectFormat: 'Select format',
+        warning: '',
+        safariCmdpHint: 'Safari tip',
+        safariMarkdownHint: 'Safari markdown tip',
+        cancel: 'Cancel',
+        export: 'Export',
+        fontSizeLabel: 'Font Size',
+        fontSizePreview: 'The quick brown fox jumps over the lazy dog.',
+        imageWidthLabel: 'Image Width',
+        imageWidthNarrow: 'Narrow',
+        imageWidthMedium: 'Medium',
+        imageWidthWide: 'Wide',
+        promptHeadingLabel: 'Use prompts as turn headings',
+        promptHeadingHint: 'Put each prompt in its turn heading.',
+        formatDescriptions: {
+          json: 'JSON format',
+          markdown: 'Markdown format',
+          pdf: 'PDF format',
+          image: 'Image format',
+        },
+      },
+    });
+
+    const section = document.querySelector('.gv-export-speakers-section') as HTMLElement | null;
+    const userInput = document.querySelector('#gv-export-speaker-user') as HTMLInputElement | null;
+    const assistantInput = document.querySelector(
+      '#gv-export-speaker-assistant',
+    ) as HTMLInputElement | null;
+    if (userInput) userInput.value = 'Erik';
+    userInput?.dispatchEvent(new Event('input', { bubbles: true }));
+    if (assistantInput) assistantInput.value = 'Nova';
+    assistantInput?.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const jsonRadio = document.querySelector(
+      'input[name="export-format"][value="json"]',
+    ) as HTMLInputElement | null;
+    if (jsonRadio) jsonRadio.checked = true;
+    jsonRadio?.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(section?.style.display).toBe('none');
+
+    const markdownRadio = document.querySelector(
+      'input[name="export-format"][value="markdown"]',
+    ) as HTMLInputElement | null;
+    if (markdownRadio) markdownRadio.checked = true;
+    markdownRadio?.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(section?.style.display).toBe('block');
+    expect(userInput?.value).toBe('Erik');
+    expect(assistantInput?.value).toBe('Nova');
+
+    (
+      document.querySelector(
+        '.gv-export-prompt-heading-section [role="switch"]',
+      ) as HTMLButtonElement | null
+    )?.click();
+    (document.querySelector('.gv-export-dialog-btn-primary') as HTMLButtonElement | null)?.click();
+    expect(onExport).toHaveBeenCalledWith('markdown', undefined, undefined, true, {
+      user: 'Erik',
+      assistant: 'Nova',
+    });
+  });
+
+  it('resolves blank values to localized defaults on export', () => {
+    const onExport = vi.fn();
+    const dialog = new ExportDialog();
+    dialog.show({
+      onExport,
+      onCancel: () => {},
+      speakerNames: {
+        title: 'Speaker names',
+        userLabel: 'User label',
+        assistantLabel: 'AI label',
+        userDefault: 'Utilisateur',
+        assistantDefault: 'Assistant IA',
+      },
+      translations: {
+        title: 'Export',
+        selectFormat: 'Select format',
+        warning: '',
+        safariCmdpHint: 'Safari tip',
+        safariMarkdownHint: 'Safari markdown tip',
+        cancel: 'Cancel',
+        export: 'Export',
+        fontSizeLabel: 'Font Size',
+        fontSizePreview: 'Preview',
+        imageWidthLabel: 'Image Width',
+        imageWidthNarrow: 'Narrow',
+        imageWidthMedium: 'Medium',
+        imageWidthWide: 'Wide',
+        promptHeadingLabel: 'Use prompts as turn headings',
+        promptHeadingHint: 'Put each prompt in its turn heading.',
+        formatDescriptions: {
+          json: 'JSON format',
+          markdown: 'Markdown format',
+          pdf: 'PDF format',
+          image: 'Image format',
+        },
+      },
+    });
+
+    const userInput = document.querySelector('#gv-export-speaker-user') as HTMLInputElement | null;
+    const assistantInput = document.querySelector(
+      '#gv-export-speaker-assistant',
+    ) as HTMLInputElement | null;
+    if (userInput) userInput.value = '';
+    userInput?.dispatchEvent(new Event('input', { bubbles: true }));
+    if (assistantInput) assistantInput.value = '   ';
+    assistantInput?.dispatchEvent(new Event('input', { bubbles: true }));
+
+    (document.querySelector('.gv-export-dialog-btn-primary') as HTMLButtonElement | null)?.click();
+    expect(onExport).toHaveBeenCalledWith('markdown', undefined, undefined, false, {
+      user: 'Utilisateur',
+      assistant: 'Assistant IA',
+    });
+  });
+
+  it('does not render speaker controls for standalone document exports', () => {
+    const dialog = new ExportDialog();
+    dialog.show({
+      onExport: () => {},
+      onCancel: () => {},
+      speakerLabelsEnabled: false,
+      speakerNames: {
+        title: 'Speaker names',
+        userLabel: 'User label',
+        assistantLabel: 'AI label',
+        userDefault: 'User',
+        assistantDefault: 'Assistant',
+      },
+      translations: {
+        title: 'Save Report',
+        selectFormat: 'Select format',
+        warning: '',
+        safariCmdpHint: 'Safari tip',
+        safariMarkdownHint: 'Safari markdown tip',
+        cancel: 'Cancel',
+        export: 'Export',
+        fontSizeLabel: 'Font Size',
+        fontSizePreview: 'Preview',
+        imageWidthLabel: 'Image Width',
+        imageWidthNarrow: 'Narrow',
+        imageWidthMedium: 'Medium',
+        imageWidthWide: 'Wide',
+        promptHeadingLabel: 'Use prompts as turn headings',
+        promptHeadingHint: 'Put each prompt in its turn heading.',
+        formatDescriptions: {
+          json: 'JSON format',
+          markdown: 'Markdown format',
+          pdf: 'PDF format',
+          image: 'Image format',
+        },
+      },
+    });
+
+    expect(document.querySelector('.gv-export-speakers-section')).toBeNull();
+  });
 });

--- a/src/features/export/ui/__tests__/ExportDialog.test.ts
+++ b/src/features/export/ui/__tests__/ExportDialog.test.ts
@@ -243,7 +243,7 @@ describe('ExportDialog', () => {
     dialog.show({
       onExport: () => {},
       onCancel: () => {},
-      initialSpeakerLabels: { user: 'Erik', assistant: 'Nova' },
+      initialSpeakerLabelOverrides: { user: 'Erik', assistant: 'Nova' },
       speakerNames: {
         title: 'Speaker names',
         userLabel: 'User label',
@@ -287,6 +287,118 @@ describe('ExportDialog', () => {
     );
     expect(document.querySelector('label[for="gv-export-speaker-assistant"]')?.textContent).toBe(
       'AI label',
+    );
+  });
+
+  it('preserves an untouched explicit override that matches the localized default', () => {
+    const onExport = vi.fn();
+    const dialog = new ExportDialog();
+    dialog.show({
+      onExport,
+      onCancel: () => {},
+      initialSpeakerLabelOverrides: { assistant: 'Utilisateur' },
+      speakerNames: {
+        title: 'Speaker names',
+        userLabel: 'User label',
+        assistantLabel: 'AI label',
+        userDefault: 'Utilisateur',
+        assistantDefault: 'Utilisateur',
+      },
+      translations: {
+        title: 'Export',
+        selectFormat: 'Select format',
+        warning: '',
+        safariCmdpHint: 'Safari tip',
+        safariMarkdownHint: 'Safari markdown tip',
+        cancel: 'Cancel',
+        export: 'Export',
+        fontSizeLabel: 'Font Size',
+        fontSizePreview: 'Preview',
+        imageWidthLabel: 'Image Width',
+        imageWidthNarrow: 'Narrow',
+        imageWidthMedium: 'Medium',
+        imageWidthWide: 'Wide',
+        promptHeadingLabel: 'Use prompts as turn headings',
+        promptHeadingHint: 'Put each prompt in its turn heading.',
+        formatDescriptions: {
+          json: 'JSON format',
+          markdown: 'Markdown format',
+          pdf: 'PDF format',
+          image: 'Image format',
+        },
+      },
+    });
+
+    (document.querySelector('.gv-export-dialog-btn-primary') as HTMLButtonElement | null)?.click();
+
+    expect(onExport).toHaveBeenCalledWith(
+      'markdown',
+      undefined,
+      undefined,
+      false,
+      {
+        user: 'Utilisateur',
+        assistant: 'Utilisateur',
+      },
+      { assistant: 'Utilisateur' },
+    );
+  });
+
+  it('clears only the edited explicit override and falls back to its localized default', () => {
+    const onExport = vi.fn();
+    const dialog = new ExportDialog();
+    dialog.show({
+      onExport,
+      onCancel: () => {},
+      initialSpeakerLabelOverrides: { user: 'Erik', assistant: 'Nova' },
+      speakerNames: {
+        title: 'Speaker names',
+        userLabel: 'User label',
+        assistantLabel: 'AI label',
+        userDefault: 'User',
+        assistantDefault: 'Assistant',
+      },
+      translations: {
+        title: 'Export',
+        selectFormat: 'Select format',
+        warning: '',
+        safariCmdpHint: 'Safari tip',
+        safariMarkdownHint: 'Safari markdown tip',
+        cancel: 'Cancel',
+        export: 'Export',
+        fontSizeLabel: 'Font Size',
+        fontSizePreview: 'Preview',
+        imageWidthLabel: 'Image Width',
+        imageWidthNarrow: 'Narrow',
+        imageWidthMedium: 'Medium',
+        imageWidthWide: 'Wide',
+        promptHeadingLabel: 'Use prompts as turn headings',
+        promptHeadingHint: 'Put each prompt in its turn heading.',
+        formatDescriptions: {
+          json: 'JSON format',
+          markdown: 'Markdown format',
+          pdf: 'PDF format',
+          image: 'Image format',
+        },
+      },
+    });
+
+    const userInput = document.querySelector('#gv-export-speaker-user') as HTMLInputElement | null;
+    if (userInput) userInput.value = ' User ';
+    userInput?.dispatchEvent(new Event('input', { bubbles: true }));
+
+    (document.querySelector('.gv-export-dialog-btn-primary') as HTMLButtonElement | null)?.click();
+
+    expect(onExport).toHaveBeenCalledWith(
+      'markdown',
+      undefined,
+      undefined,
+      false,
+      {
+        user: 'User',
+        assistant: 'Nova',
+      },
+      { assistant: 'Nova' },
     );
   });
 
@@ -361,10 +473,20 @@ describe('ExportDialog', () => {
       ) as HTMLButtonElement | null
     )?.click();
     (document.querySelector('.gv-export-dialog-btn-primary') as HTMLButtonElement | null)?.click();
-    expect(onExport).toHaveBeenCalledWith('markdown', undefined, undefined, true, {
-      user: 'Erik',
-      assistant: 'Nova',
-    });
+    expect(onExport).toHaveBeenCalledWith(
+      'markdown',
+      undefined,
+      undefined,
+      true,
+      {
+        user: 'Erik',
+        assistant: 'Nova',
+      },
+      {
+        user: 'Erik',
+        assistant: 'Nova',
+      },
+    );
   });
 
   it('resolves blank values to localized defaults on export', () => {
@@ -415,10 +537,17 @@ describe('ExportDialog', () => {
     assistantInput?.dispatchEvent(new Event('input', { bubbles: true }));
 
     (document.querySelector('.gv-export-dialog-btn-primary') as HTMLButtonElement | null)?.click();
-    expect(onExport).toHaveBeenCalledWith('markdown', undefined, undefined, false, {
-      user: 'Utilisateur',
-      assistant: 'Assistant IA',
-    });
+    expect(onExport).toHaveBeenCalledWith(
+      'markdown',
+      undefined,
+      undefined,
+      false,
+      {
+        user: 'Utilisateur',
+        assistant: 'Assistant IA',
+      },
+      {},
+    );
   });
 
   it('does not render speaker controls for standalone document exports', () => {

--- a/src/locales/ar/messages.json
+++ b/src/locales/ar/messages.json
@@ -703,6 +703,26 @@
     "message": "تصدير المحادثة",
     "description": "Export dialog title"
   },
+  "export_speaker_names": {
+    "message": "أسماء المتحدثين",
+    "description": "Heading for speaker label fields in the export dialog"
+  },
+  "export_speaker_user_label": {
+    "message": "تسمية المستخدم",
+    "description": "Label for the human speaker name field"
+  },
+  "export_speaker_ai_label": {
+    "message": "تسمية الذكاء الاصطناعي",
+    "description": "Label for the AI speaker name field"
+  },
+  "export_speaker_user_default": {
+    "message": "المستخدم",
+    "description": "Default human speaker label in conversation exports"
+  },
+  "export_speaker_assistant_default": {
+    "message": "المساعد",
+    "description": "Default AI speaker label in conversation exports"
+  },
   "export_dialog_select": {
     "message": "اختر تنسيق التصدير:",
     "description": "Export format selection label"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -703,6 +703,26 @@
     "message": "Export Conversation",
     "description": "Export dialog title"
   },
+  "export_speaker_names": {
+    "message": "Speaker names",
+    "description": "Heading for speaker label fields in the export dialog"
+  },
+  "export_speaker_user_label": {
+    "message": "User label",
+    "description": "Label for the human speaker name field"
+  },
+  "export_speaker_ai_label": {
+    "message": "AI label",
+    "description": "Label for the AI speaker name field"
+  },
+  "export_speaker_user_default": {
+    "message": "User",
+    "description": "Default human speaker label in conversation exports"
+  },
+  "export_speaker_assistant_default": {
+    "message": "Assistant",
+    "description": "Default AI speaker label in conversation exports"
+  },
   "export_dialog_select": {
     "message": "Choose export format:",
     "description": "Export format selection label"

--- a/src/locales/es/messages.json
+++ b/src/locales/es/messages.json
@@ -703,6 +703,26 @@
     "message": "Exportar Conversación",
     "description": "Export dialog title"
   },
+  "export_speaker_names": {
+    "message": "Nombres de los participantes",
+    "description": "Heading for speaker label fields in the export dialog"
+  },
+  "export_speaker_user_label": {
+    "message": "Etiqueta de usuario",
+    "description": "Label for the human speaker name field"
+  },
+  "export_speaker_ai_label": {
+    "message": "Etiqueta de IA",
+    "description": "Label for the AI speaker name field"
+  },
+  "export_speaker_user_default": {
+    "message": "Usuario",
+    "description": "Default human speaker label in conversation exports"
+  },
+  "export_speaker_assistant_default": {
+    "message": "Asistente",
+    "description": "Default AI speaker label in conversation exports"
+  },
   "export_dialog_select": {
     "message": "Elige formato de exportación:",
     "description": "Export format selection label"

--- a/src/locales/fr/messages.json
+++ b/src/locales/fr/messages.json
@@ -703,6 +703,26 @@
     "message": "Exporter la discussion",
     "description": "Export dialog title"
   },
+  "export_speaker_names": {
+    "message": "Noms des intervenants",
+    "description": "Heading for speaker label fields in the export dialog"
+  },
+  "export_speaker_user_label": {
+    "message": "Libellé utilisateur",
+    "description": "Label for the human speaker name field"
+  },
+  "export_speaker_ai_label": {
+    "message": "Libellé IA",
+    "description": "Label for the AI speaker name field"
+  },
+  "export_speaker_user_default": {
+    "message": "Utilisateur",
+    "description": "Default human speaker label in conversation exports"
+  },
+  "export_speaker_assistant_default": {
+    "message": "Assistant",
+    "description": "Default AI speaker label in conversation exports"
+  },
   "export_dialog_select": {
     "message": "Format d'export :",
     "description": "Export format selection label"

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -703,6 +703,26 @@
     "message": "会話のエクスポート",
     "description": "Export dialog title"
   },
+  "export_speaker_names": {
+    "message": "話者名",
+    "description": "エクスポートダイアログの話者ラベル欄の見出し"
+  },
+  "export_speaker_user_label": {
+    "message": "ユーザーラベル",
+    "description": "ユーザー話者名欄のラベル"
+  },
+  "export_speaker_ai_label": {
+    "message": "AIラベル",
+    "description": "AI話者名欄のラベル"
+  },
+  "export_speaker_user_default": {
+    "message": "ユーザー",
+    "description": "会話エクスポートのデフォルトユーザーラベル"
+  },
+  "export_speaker_assistant_default": {
+    "message": "アシスタント",
+    "description": "会話エクスポートのデフォルトAIラベル"
+  },
   "export_dialog_select": {
     "message": "エクスポート形式を選択：",
     "description": "Export format selection label"

--- a/src/locales/ko/messages.json
+++ b/src/locales/ko/messages.json
@@ -703,6 +703,26 @@
     "message": "대화 내보내기",
     "description": "Export dialog title"
   },
+  "export_speaker_names": {
+    "message": "화자 이름",
+    "description": "Heading for speaker label fields in the export dialog"
+  },
+  "export_speaker_user_label": {
+    "message": "사용자 라벨",
+    "description": "Label for the human speaker name field"
+  },
+  "export_speaker_ai_label": {
+    "message": "AI 라벨",
+    "description": "Label for the AI speaker name field"
+  },
+  "export_speaker_user_default": {
+    "message": "사용자",
+    "description": "Default human speaker label in conversation exports"
+  },
+  "export_speaker_assistant_default": {
+    "message": "어시스턴트",
+    "description": "Default AI speaker label in conversation exports"
+  },
   "export_dialog_select": {
     "message": "내보내기 형식 선택:",
     "description": "Export format selection label"

--- a/src/locales/pt/messages.json
+++ b/src/locales/pt/messages.json
@@ -703,6 +703,26 @@
     "message": "Exportar Conversa",
     "description": "Export dialog title"
   },
+  "export_speaker_names": {
+    "message": "Nomes dos participantes",
+    "description": "Heading for speaker label fields in the export dialog"
+  },
+  "export_speaker_user_label": {
+    "message": "Rótulo do usuário",
+    "description": "Label for the human speaker name field"
+  },
+  "export_speaker_ai_label": {
+    "message": "Rótulo da IA",
+    "description": "Label for the AI speaker name field"
+  },
+  "export_speaker_user_default": {
+    "message": "Usuário",
+    "description": "Default human speaker label in conversation exports"
+  },
+  "export_speaker_assistant_default": {
+    "message": "Assistente",
+    "description": "Default AI speaker label in conversation exports"
+  },
   "export_dialog_select": {
     "message": "Escolha o formato de exportação:",
     "description": "Export format selection label"

--- a/src/locales/ru/messages.json
+++ b/src/locales/ru/messages.json
@@ -703,6 +703,26 @@
     "message": "Экспорт разговора",
     "description": "Export dialog title"
   },
+  "export_speaker_names": {
+    "message": "Имена участников",
+    "description": "Heading for speaker label fields in the export dialog"
+  },
+  "export_speaker_user_label": {
+    "message": "Метка пользователя",
+    "description": "Label for the human speaker name field"
+  },
+  "export_speaker_ai_label": {
+    "message": "Метка ИИ",
+    "description": "Label for the AI speaker name field"
+  },
+  "export_speaker_user_default": {
+    "message": "Пользователь",
+    "description": "Default human speaker label in conversation exports"
+  },
+  "export_speaker_assistant_default": {
+    "message": "Ассистент",
+    "description": "Default AI speaker label in conversation exports"
+  },
   "export_dialog_select": {
     "message": "Выберите формат экспорта:",
     "description": "Export format selection label"

--- a/src/locales/zh/messages.json
+++ b/src/locales/zh/messages.json
@@ -703,6 +703,26 @@
     "message": "导出对话",
     "description": "导出对话框标题"
   },
+  "export_speaker_names": {
+    "message": "说话者名称",
+    "description": "导出对话框中说话者标签字段的标题"
+  },
+  "export_speaker_user_label": {
+    "message": "用户标签",
+    "description": "用户说话者名称字段的标签"
+  },
+  "export_speaker_ai_label": {
+    "message": "AI 标签",
+    "description": "AI 说话者名称字段的标签"
+  },
+  "export_speaker_user_default": {
+    "message": "用户",
+    "description": "对话导出中的默认用户标签"
+  },
+  "export_speaker_assistant_default": {
+    "message": "助手",
+    "description": "对话导出中的默认 AI 标签"
+  },
   "export_dialog_select": {
     "message": "选择导出格式：",
     "description": "导出格式选择标签"

--- a/src/locales/zh_TW/messages.json
+++ b/src/locales/zh_TW/messages.json
@@ -663,6 +663,26 @@
     "message": "匯出對話",
     "description": "匯出對話框標題"
   },
+  "export_speaker_names": {
+    "message": "說話者名稱",
+    "description": "匯出對話框中說話者標籤欄位的標題"
+  },
+  "export_speaker_user_label": {
+    "message": "使用者標籤",
+    "description": "使用者說話者名稱欄位的標籤"
+  },
+  "export_speaker_ai_label": {
+    "message": "AI 標籤",
+    "description": "AI 說話者名稱欄位的標籤"
+  },
+  "export_speaker_user_default": {
+    "message": "使用者",
+    "description": "對話匯出中的預設使用者標籤"
+  },
+  "export_speaker_assistant_default": {
+    "message": "助理",
+    "description": "對話匯出中的預設 AI 標籤"
+  },
   "export_dialog_select": {
     "message": "選擇匯出格式：",
     "description": "匯出格式選擇標籤"

--- a/src/pages/content/deepResearch/menuButton.ts
+++ b/src/pages/content/deepResearch/menuButton.ts
@@ -422,6 +422,7 @@ function handleSaveReport(dict: Dictionaries, lang: AppLanguage): void {
       },
       onCancel: () => {},
       initialImageWidth,
+      speakerLabelsEnabled: false,
       translations: {
         title: t('deepResearchSaveReport'),
         selectFormat: t('export_dialog_select'),

--- a/src/pages/content/export/__tests__/pendingExportState.test.ts
+++ b/src/pages/content/export/__tests__/pendingExportState.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ConversationExportService } from '../../../../features/export/services/ConversationExportService';
+import type { ChatTurn, ConversationMetadata } from '../../../../features/export/types/export';
+import { ExportFormat } from '../../../../features/export/types/export';
+import {
+  PENDING_EXPORT_SESSION_KEY,
+  advancePendingExportState,
+  clearPendingExportState,
+  createPendingExportState,
+  exportPendingConversation,
+  persistPendingExportState,
+  restorePendingExportState,
+} from '../pendingExportState';
+
+const url = 'https://gemini.google.com/app/conversation';
+const labels = { user: 'Erik', assistant: 'Nova' };
+const metadata: ConversationMetadata = {
+  title: 'Pending export',
+  url,
+  exportedAt: '2026-07-25T00:00:00.000Z',
+  count: 1,
+};
+const turns: ChatTurn[] = [{ user: 'Hello', assistant: 'Hi', starred: false }];
+
+function validSerializedState(speakerLabels: unknown = labels): string {
+  return JSON.stringify({
+    format: 'markdown',
+    fontSize: 16,
+    imageWidth: 960,
+    usePromptAsTurnHeading: true,
+    speakerLabels,
+    initialSelectedMessageId: 'turn-1',
+    attempt: 1,
+    url,
+    status: 'clicking',
+    timestamp: 1001,
+  });
+}
+
+describe('pendingExportState', () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('persists, restores, and delivers custom labels to the resumed export call', async () => {
+    const state = createPendingExportState(ExportFormat.MARKDOWN, url, 1000, {
+      fontSize: 16,
+      imageWidth: 960,
+      usePromptAsTurnHeading: true,
+      speakerLabels: labels,
+      initialSelectedMessageId: 'turn-1',
+    });
+
+    expect(state.speakerLabels).toEqual(labels);
+
+    persistPendingExportState(sessionStorage, state, 1001);
+    expect(JSON.parse(sessionStorage.getItem(PENDING_EXPORT_SESSION_KEY) ?? '{}')).toMatchObject({
+      speakerLabels: labels,
+      attempt: 1,
+    });
+
+    const restored = restorePendingExportState(sessionStorage, url);
+    expect(restored?.speakerLabels).toEqual(labels);
+    expect(restored?.usePromptAsTurnHeading).toBe(true);
+
+    const exportSpy = vi
+      .spyOn(ConversationExportService, 'export')
+      .mockResolvedValue({ success: true, format: ExportFormat.MARKDOWN });
+    await exportPendingConversation(restored!, turns, metadata, true);
+
+    expect(exportSpy).toHaveBeenCalledWith(turns, metadata, {
+      format: 'markdown',
+      fontSize: 16,
+      includeImageSource: true,
+      imageWidth: 960,
+      usePromptAsTurnHeading: true,
+      speakerLabels: labels,
+    });
+  });
+
+  it('preserves labels through recursive or delayed continuation', () => {
+    const state = createPendingExportState(ExportFormat.IMAGE, url, 1000, {
+      usePromptAsTurnHeading: true,
+      speakerLabels: labels,
+    });
+    const delayed = advancePendingExportState(state, 2000);
+    const recursive = advancePendingExportState(delayed, 3000);
+
+    expect(recursive).toMatchObject({
+      attempt: 2,
+      timestamp: 3000,
+      usePromptAsTurnHeading: true,
+      speakerLabels: labels,
+    });
+  });
+
+  it('restores legacy pending state without speaker labels', () => {
+    const serialized = validSerializedState(undefined);
+    const parsed = JSON.parse(serialized);
+    delete parsed.speakerLabels;
+    sessionStorage.setItem(PENDING_EXPORT_SESSION_KEY, JSON.stringify(parsed));
+
+    expect(restorePendingExportState(sessionStorage, url)).toMatchObject({
+      format: 'markdown',
+      attempt: 1,
+      speakerLabels: undefined,
+    });
+  });
+
+  it.each([
+    ['partial object', { user: 'Erik' }],
+    ['non-string value', { user: 'Erik', assistant: 42 }],
+    ['array', ['Erik', 'Nova']],
+    ['null', null],
+  ])('drops %s speaker labels without rejecting the pending export', async (_name, malformed) => {
+    sessionStorage.setItem(PENDING_EXPORT_SESSION_KEY, validSerializedState(malformed));
+
+    const restored = restorePendingExportState(sessionStorage, url);
+
+    expect(restored).toMatchObject({
+      format: 'markdown',
+      fontSize: 16,
+      imageWidth: 960,
+      attempt: 1,
+    });
+    expect(restored?.speakerLabels).toBeUndefined();
+    expect(sessionStorage.getItem(PENDING_EXPORT_SESSION_KEY)).not.toBeNull();
+
+    const exportSpy = vi
+      .spyOn(ConversationExportService, 'export')
+      .mockResolvedValue({ success: true, format: ExportFormat.MARKDOWN });
+    await expect(exportPendingConversation(restored!, turns, metadata, true)).resolves.toEqual({
+      success: true,
+      format: ExportFormat.MARKDOWN,
+    });
+    expect(exportSpy.mock.calls[0]?.[2].speakerLabels).toBeUndefined();
+  });
+
+  it('retains existing cleanup decisions for invalid, mismatched, and completed state', () => {
+    sessionStorage.setItem(PENDING_EXPORT_SESSION_KEY, '{invalid');
+    expect(restorePendingExportState(sessionStorage, url)).toBeNull();
+    expect(sessionStorage.getItem(PENDING_EXPORT_SESSION_KEY)).toBeNull();
+
+    sessionStorage.setItem(PENDING_EXPORT_SESSION_KEY, validSerializedState());
+    expect(restorePendingExportState(sessionStorage, `${url}/other`)).toBeNull();
+    expect(sessionStorage.getItem(PENDING_EXPORT_SESSION_KEY)).toBeNull();
+
+    sessionStorage.setItem(PENDING_EXPORT_SESSION_KEY, validSerializedState());
+    expect(restorePendingExportState(sessionStorage, url)).not.toBeNull();
+    expect(sessionStorage.getItem(PENDING_EXPORT_SESSION_KEY)).not.toBeNull();
+    clearPendingExportState(sessionStorage);
+    expect(sessionStorage.getItem(PENDING_EXPORT_SESSION_KEY)).toBeNull();
+  });
+
+  it('keeps JSON pending state backward compatible and conversation-scoped', async () => {
+    const state = createPendingExportState(ExportFormat.JSON, url, 1000);
+    const exportSpy = vi
+      .spyOn(ConversationExportService, 'export')
+      .mockResolvedValue({ success: true, format: ExportFormat.JSON });
+
+    await exportPendingConversation(state, turns, metadata, false);
+
+    expect(exportSpy).toHaveBeenCalledWith(turns, metadata, {
+      format: 'json',
+      fontSize: undefined,
+      includeImageSource: false,
+      imageWidth: undefined,
+      usePromptAsTurnHeading: undefined,
+      speakerLabels: undefined,
+    });
+    expect(exportSpy.mock.calls[0]?.[2]).not.toHaveProperty('layout');
+  });
+});

--- a/src/pages/content/export/__tests__/responseImageCopy.test.ts
+++ b/src/pages/content/export/__tests__/responseImageCopy.test.ts
@@ -1,15 +1,31 @@
 import { toBlob } from 'html-to-image';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ImageExportService } from '@/features/export/services/ImageExportService';
+import type { ChatTurn, ConversationMetadata } from '@/features/export/types/export';
+
 import {
   copyElementAsImageToClipboard,
   copyImageBlobToClipboard,
   copyImageBlobViaSafariNativePasteboard,
   downloadImageBlob,
+  renderResponseImageBlob,
 } from '../responseImageCopy';
+
+const { storageGetMock } = vi.hoisted(() => ({
+  storageGetMock: vi.fn(),
+}));
 
 vi.mock('html-to-image', () => ({
   toBlob: vi.fn(),
+}));
+
+vi.mock('@/core/services/StorageService', () => ({
+  storageService: {
+    get: storageGetMock,
+    remove: vi.fn(),
+    set: vi.fn(),
+  },
 }));
 
 vi.mock('@/core/utils/safariNativeClipboard', () => ({
@@ -25,8 +41,89 @@ class MockClipboardItem {
 }
 
 describe('responseImageCopy', () => {
+  const responseTurn: ChatTurn[] = [
+    {
+      user: '',
+      assistant: 'Selected reply',
+      starred: false,
+      omitEmptySections: true,
+    },
+  ];
+  const metadata: ConversationMetadata = {
+    url: 'https://gemini.google.com/app/test',
+    exportedAt: '2026-07-30T00:00:00.000Z',
+    count: 1,
+    title: 'Selected reply',
+  };
+  const speakerDefaults = {
+    user: 'User',
+    assistant: 'Assistant',
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
+    storageGetMock.mockResolvedValue({ success: true, data: undefined });
+  });
+
+  it('renders a single reply with saved custom speaker labels', async () => {
+    storageGetMock.mockResolvedValue({
+      success: true,
+      data: { user: 'Erik', assistant: 'Nova' },
+    });
+    let renderedTarget: HTMLElement | null = null;
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (node: HTMLElement) => {
+        renderedTarget = node;
+        return new Blob(['img'], { type: 'image/png' });
+      },
+    );
+    const renderSpy = vi.spyOn(ImageExportService, 'renderConversationBlob');
+
+    try {
+      await renderResponseImageBlob(responseTurn, metadata, {
+        imageWidth: 960,
+        speakerDefaults,
+      });
+
+      expect(renderSpy).toHaveBeenCalledWith(responseTurn, metadata, {
+        imageWidth: 960,
+        speakerLabels: { user: 'Erik', assistant: 'Nova' },
+      });
+      const target = renderedTarget as HTMLElement | null;
+      expect(
+        Array.from(target?.querySelectorAll('.gv-image-export-label') ?? []).map(
+          (label) => label.textContent,
+        ),
+      ).toEqual(['Nova']);
+    } finally {
+      renderSpy.mockRestore();
+    }
+  });
+
+  it('renders a single reply with default labels when no override is saved', async () => {
+    const localizedSpeakerDefaults = {
+      user: 'Question',
+      assistant: 'AI response',
+    };
+    let renderedTarget: HTMLElement | null = null;
+    (toBlob as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (node: HTMLElement) => {
+        renderedTarget = node;
+        return new Blob(['img'], { type: 'image/png' });
+      },
+    );
+
+    await renderResponseImageBlob(responseTurn, metadata, {
+      imageWidth: 720,
+      speakerDefaults: localizedSpeakerDefaults,
+    });
+
+    const target = renderedTarget as HTMLElement | null;
+    expect(
+      Array.from(target?.querySelectorAll('.gv-image-export-label') ?? []).map(
+        (label) => label.textContent,
+      ),
+    ).toEqual(['AI response']);
   });
 
   it('writes rendered png blob to clipboard', async () => {

--- a/src/pages/content/export/index.ts
+++ b/src/pages/content/export/index.ts
@@ -10,15 +10,20 @@ import { type AppLanguage, normalizeLanguage } from '@/utils/language';
 import { extractMessageDictionary } from '@/utils/localeMessages';
 import type { TranslationKey } from '@/utils/translations';
 
-import { ConversationExportService } from '../../../features/export/services/ConversationExportService';
 import {
   getSavedImageExportWidth,
   saveImageExportWidth,
 } from '../../../features/export/services/ImageExportPreferenceService';
 import { ImageExportService } from '../../../features/export/services/ImageExportService';
 import {
+  getSavedSpeakerLabelOverrides,
+  saveSpeakerLabelOverrides,
+} from '../../../features/export/services/SpeakerLabelPreferenceService';
+import {
   DEFAULT_IMAGE_EXPORT_WIDTH,
   type ExportFormat,
+  type ExportSpeakerLabels,
+  resolveExportSpeakerLabels,
 } from '../../../features/export/types/export';
 import type {
   CanvasDoc,
@@ -39,6 +44,15 @@ import {
   injectResponseMenuExportButton,
 } from './conversationMenuInjection';
 import { resolveExportLogoAnchor } from './exportLogoAnchor';
+import {
+  type PendingExportState,
+  advancePendingExportState,
+  clearPendingExportState,
+  createPendingExportState,
+  exportPendingConversation,
+  persistPendingExportState,
+  restorePendingExportState,
+} from './pendingExportState';
 import { mountPersistentExportToolbar } from './persistentExportToolbar';
 import { injectResponseActionCopyImageButtons } from './responseActionImageButton';
 import { showResponseActionCopyImageMenu } from './responseActionImageMenu';
@@ -55,8 +69,6 @@ import {
   waitForConversationFingerprintChangeOrTimeout,
 } from './topNodePreload';
 
-// Storage key to persist export state across reloads (e.g. when clicking top node triggers refresh)
-const SESSION_KEY_PENDING_EXPORT = 'gv_export_pending';
 const CONVERSATION_MENU_SELECTOR = '.mat-mdc-menu-panel[role="menu"], gem-menu';
 const CONVERSATION_MENU_TRIGGER_TEST_IDS = [
   'actions-menu-button',
@@ -227,22 +239,6 @@ async function captureGeneratedUiScreenshots(): Promise<void> {
       overlay.style.display = previousDisplay[index] || '';
     });
   }
-}
-
-interface PendingExportState {
-  format: ExportFormat;
-  fontSize?: number;
-  imageWidth?: number;
-  usePromptAsTurnHeading?: boolean;
-  initialSelectedMessageId?: string;
-  attempt: number;
-  url: string;
-  status: 'clicking';
-  timestamp: number;
-}
-
-function isExportFormat(value: unknown): value is ExportFormat {
-  return value === 'json' || value === 'markdown' || value === 'pdf' || value === 'image';
 }
 
 function waitForElement(selector: string, timeoutMs: number = 6000): Promise<Element | null> {
@@ -1401,6 +1397,7 @@ async function executeExportSequence(
   initialSelectedMessageId?: string,
   imageWidth?: number,
   usePromptAsTurnHeading?: boolean,
+  speakerLabels?: ExportSpeakerLabels,
 ): Promise<void> {
   // Cache Canvas documents at the very start of the export sequence,
   // before we click the top node or cause any DOM updates/scrolling.
@@ -1408,21 +1405,19 @@ async function executeExportSequence(
     cachedCanvasDocs = extractAllCanvasDocs();
   }
 
-  const state: PendingExportState = paramState || {
-    format,
-    fontSize,
-    imageWidth,
-    usePromptAsTurnHeading,
-    initialSelectedMessageId,
-    attempt: 0,
-    url: location.href,
-    status: 'clicking',
-    timestamp: Date.now(),
-  };
+  const state =
+    paramState ||
+    createPendingExportState(format, location.href, Date.now(), {
+      fontSize,
+      imageWidth,
+      usePromptAsTurnHeading,
+      speakerLabels,
+      initialSelectedMessageId,
+    });
 
   if (state.attempt > 25) {
     console.warn('[Gemini Voyager] Export aborted: too many attempts.');
-    sessionStorage.removeItem(SESSION_KEY_PENDING_EXPORT);
+    clearPendingExportState(sessionStorage);
     alert('Export stopped: Too many attempts detected.');
     return;
   }
@@ -1447,16 +1442,8 @@ async function executeExportSequence(
 
   if (!topNode) {
     console.log('[Gemini Voyager] No top node found, proceeding to export directly.');
-    sessionStorage.removeItem(SESSION_KEY_PENDING_EXPORT);
-    await performFinalExport(
-      format,
-      dict,
-      lang,
-      state.fontSize,
-      state.initialSelectedMessageId,
-      state.imageWidth,
-      state.usePromptAsTurnHeading,
-    );
+    clearPendingExportState(sessionStorage);
+    await performFinalExport(state, dict, lang);
     return;
   }
 
@@ -1466,14 +1453,7 @@ async function executeExportSequence(
   console.log(`[Gemini Voyager] Simulating click on top node (Attempt ${state.attempt + 1})...`);
 
   // Update state before action to persist across potential reload
-  sessionStorage.setItem(
-    SESSION_KEY_PENDING_EXPORT,
-    JSON.stringify({
-      ...state,
-      attempt: state.attempt + 1,
-      timestamp: Date.now(),
-    }),
-  );
+  persistPendingExportState(sessionStorage, state, Date.now());
 
   // Dispatch click logic
   try {
@@ -1497,25 +1477,13 @@ async function executeExportSequence(
 
   if (changed) {
     console.log('[Gemini Voyager] History expanded (soft refresh). Clicking top node again...');
-    await executeExportSequence(format, dict, lang, {
-      ...state,
-      attempt: state.attempt + 1,
-      timestamp: Date.now(),
-    });
+    await executeExportSequence(format, dict, lang, advancePendingExportState(state, Date.now()));
     return;
   }
 
   console.log('[Gemini Voyager] No refresh or update detected. Exporting...');
-  sessionStorage.removeItem(SESSION_KEY_PENDING_EXPORT);
-  await performFinalExport(
-    format,
-    dict,
-    lang,
-    state.fontSize,
-    state.initialSelectedMessageId,
-    state.imageWidth,
-    state.usePromptAsTurnHeading,
-  );
+  clearPendingExportState(sessionStorage);
+  await performFinalExport(state, dict, lang);
 }
 
 async function executeExportSequenceWithProgress(
@@ -1527,6 +1495,7 @@ async function executeExportSequenceWithProgress(
   initialSelectedMessageId?: string,
   imageWidth?: number,
   usePromptAsTurnHeading?: boolean,
+  speakerLabels?: ExportSpeakerLabels,
 ): Promise<void> {
   const t = (key: TranslationKey) => dict[lang]?.[key] ?? dict.en?.[key] ?? key;
   const hideProgress = showExportProgressOverlay(t);
@@ -1540,6 +1509,7 @@ async function executeExportSequenceWithProgress(
       initialSelectedMessageId,
       imageWidth,
       usePromptAsTurnHeading,
+      speakerLabels,
     );
   } finally {
     hideProgress();
@@ -1553,13 +1523,9 @@ async function executeExportSequenceWithProgress(
  * Performs the actual file generation and download.
  */
 async function performFinalExport(
-  format: ExportFormat,
+  state: PendingExportState,
   dict: Record<AppLanguage, Record<string, string>>,
   lang: AppLanguage,
-  fontSize?: number,
-  initialSelectedMessageId?: string,
-  imageWidth?: number,
-  usePromptAsTurnHeading?: boolean,
 ) {
   const t = (key: TranslationKey) => dict[lang]?.[key] ?? dict.en?.[key] ?? key;
 
@@ -1579,7 +1545,7 @@ async function performFinalExport(
   const idToHost = new Map<string, HTMLElement>();
   const idToCheckbox = new Map<string, HTMLButtonElement>();
   const knownIds = new Set<string>();
-  let pendingInitialSelectionId: string | null = initialSelectedMessageId || null;
+  let pendingInitialSelectionId: string | null = state.initialSelectedMessageId || null;
 
   let autoSelectAll = false;
 
@@ -1903,7 +1869,7 @@ async function performFinalExport(
     };
 
     let includeImageSource = true;
-    if (format === 'markdown') {
+    if (state.format === 'markdown') {
       const hasSearchImages = turnsForExport.some(
         (turn) =>
           turn.assistantElement?.querySelector('.attachment-container.search-images') != null,
@@ -1915,19 +1881,18 @@ async function performFinalExport(
 
     const hideProgress = showExportProgressOverlay(t);
     try {
-      const resultPromise = ConversationExportService.export(turnsForExport, metadata, {
-        format,
-        fontSize,
+      const resultPromise = exportPendingConversation(
+        state,
+        turnsForExport,
+        metadata,
         includeImageSource,
-        imageWidth,
-        usePromptAsTurnHeading,
-      });
+      );
       const minVisiblePromise = new Promise((resolve) => setTimeout(resolve, 420));
       const [result] = await Promise.all([resultPromise, minVisiblePromise]);
 
       if (!result.success) {
         alert(resolveExportErrorMessage(result.error, t));
-      } else if (format === 'pdf' && isSafari()) {
+      } else if (state.format === 'pdf' && isSafari()) {
         showExportToast(t('export_toast_safari_pdf_ready'), {
           autoDismissMs: 5000,
         });
@@ -2015,41 +1980,8 @@ function showExportProgressOverlay(t: (key: TranslationKey) => string): () => vo
  */
 async function checkPendingExport() {
   try {
-    const raw = sessionStorage.getItem(SESSION_KEY_PENDING_EXPORT);
-    if (!raw) return;
-
-    const parsed = JSON.parse(raw) as Partial<PendingExportState>;
-    if (
-      !isExportFormat(parsed.format) ||
-      typeof parsed.attempt !== 'number' ||
-      typeof parsed.url !== 'string' ||
-      parsed.status !== 'clicking' ||
-      typeof parsed.timestamp !== 'number'
-    ) {
-      sessionStorage.removeItem(SESSION_KEY_PENDING_EXPORT);
-      return;
-    }
-    const state: PendingExportState = {
-      format: parsed.format,
-      fontSize: typeof parsed.fontSize === 'number' ? parsed.fontSize : undefined,
-      imageWidth: typeof parsed.imageWidth === 'number' ? parsed.imageWidth : undefined,
-      usePromptAsTurnHeading: parsed.usePromptAsTurnHeading === true,
-      initialSelectedMessageId:
-        typeof parsed.initialSelectedMessageId === 'string'
-          ? parsed.initialSelectedMessageId
-          : undefined,
-      attempt: parsed.attempt,
-      url: parsed.url,
-      status: parsed.status,
-      timestamp: parsed.timestamp,
-    };
-
-    // Validate context
-    if (state.url !== location.href) {
-      // User navigated away? Abort.
-      sessionStorage.removeItem(SESSION_KEY_PENDING_EXPORT);
-      return;
-    }
+    const state = restorePendingExportState(sessionStorage, location.href);
+    if (!state) return;
 
     // If state exists, it means we clicked and page refreshed.
     // So we resume the sequence.
@@ -2068,10 +2000,11 @@ async function checkPendingExport() {
       state.initialSelectedMessageId,
       state.imageWidth,
       state.usePromptAsTurnHeading,
+      state.speakerLabels,
     );
   } catch (e) {
     console.error('[Gemini Voyager] Failed to resume pending export:', e);
-    sessionStorage.removeItem(SESSION_KEY_PENDING_EXPORT);
+    clearPendingExportState(sessionStorage);
   }
 }
 
@@ -2732,18 +2665,32 @@ async function showExportDialog(
   },
 ): Promise<void> {
   const t = (key: TranslationKey) => dict[lang]?.[key] ?? dict.en?.[key] ?? key;
-  const initialImageWidth = await getSavedImageExportWidth();
+  const speakerDefaults: ExportSpeakerLabels = {
+    user: t('export_speaker_user_default'),
+    assistant: t('export_speaker_assistant_default'),
+  };
+  const [initialImageWidth, savedSpeakerLabelOverrides] = await Promise.all([
+    getSavedImageExportWidth(),
+    getSavedSpeakerLabelOverrides(speakerDefaults),
+  ]);
+  const initialSpeakerLabels = resolveExportSpeakerLabels(
+    savedSpeakerLabelOverrides,
+    speakerDefaults,
+  );
 
   // We defer collection until after the export sequence (scrolling/refresh checks)
 
   const dialog = new ExportDialog();
 
   dialog.show({
-    onExport: async (format, fontSize, imageWidth, usePromptAsTurnHeading) => {
+    onExport: async (format, fontSize, imageWidth, usePromptAsTurnHeading, speakerLabels) => {
       try {
         await ensureGeneratedUiScreenshotPermission();
         if (format === 'image') {
           await saveImageExportWidth(imageWidth);
+        }
+        if (speakerLabels) {
+          await saveSpeakerLabelOverrides(speakerLabels, speakerDefaults);
         }
         await executeExportSequenceWithProgress(
           format,
@@ -2754,6 +2701,7 @@ async function showExportDialog(
           options?.initialSelectedMessageId || undefined,
           imageWidth,
           usePromptAsTurnHeading,
+          speakerLabels,
         );
       } catch (err) {
         console.error('[Gemini Voyager] Export error:', err);
@@ -2765,6 +2713,14 @@ async function showExportDialog(
     },
     initialImageWidth,
     showPromptHeadingOption: true,
+    initialSpeakerLabels,
+    speakerNames: {
+      title: t('export_speaker_names'),
+      userLabel: t('export_speaker_user_label'),
+      assistantLabel: t('export_speaker_ai_label'),
+      userDefault: speakerDefaults.user,
+      assistantDefault: speakerDefaults.assistant,
+    },
     translations: {
       title: t('export_dialog_title'),
       selectFormat: t('export_dialog_select'),

--- a/src/pages/content/export/index.ts
+++ b/src/pages/content/export/index.ts
@@ -22,7 +22,6 @@ import {
   DEFAULT_IMAGE_EXPORT_WIDTH,
   type ExportFormat,
   type ExportSpeakerLabels,
-  resolveExportSpeakerLabels,
 } from '../../../features/export/types/export';
 import type {
   CanvasDoc,
@@ -2678,26 +2677,29 @@ async function showExportDialog(
   };
   const [initialImageWidth, savedSpeakerLabelOverrides] = await Promise.all([
     getSavedImageExportWidth(),
-    getSavedSpeakerLabelOverrides(speakerDefaults),
+    getSavedSpeakerLabelOverrides(),
   ]);
-  const initialSpeakerLabels = resolveExportSpeakerLabels(
-    savedSpeakerLabelOverrides,
-    speakerDefaults,
-  );
 
   // We defer collection until after the export sequence (scrolling/refresh checks)
 
   const dialog = new ExportDialog();
 
   dialog.show({
-    onExport: async (format, fontSize, imageWidth, usePromptAsTurnHeading, speakerLabels) => {
+    onExport: async (
+      format,
+      fontSize,
+      imageWidth,
+      usePromptAsTurnHeading,
+      speakerLabels,
+      speakerLabelOverrides,
+    ) => {
       try {
         await ensureGeneratedUiScreenshotPermission();
         if (format === 'image') {
           await saveImageExportWidth(imageWidth);
         }
-        if (speakerLabels) {
-          await saveSpeakerLabelOverrides(speakerLabels, speakerDefaults);
+        if (speakerLabelOverrides) {
+          await saveSpeakerLabelOverrides(speakerLabelOverrides);
         }
         await executeExportSequenceWithProgress(
           format,
@@ -2720,7 +2722,7 @@ async function showExportDialog(
     },
     initialImageWidth,
     showPromptHeadingOption: true,
-    initialSpeakerLabels,
+    initialSpeakerLabelOverrides: savedSpeakerLabelOverrides,
     speakerNames: {
       title: t('export_speaker_names'),
       userLabel: t('export_speaker_user_label'),

--- a/src/pages/content/export/index.ts
+++ b/src/pages/content/export/index.ts
@@ -14,7 +14,6 @@ import {
   getSavedImageExportWidth,
   saveImageExportWidth,
 } from '../../../features/export/services/ImageExportPreferenceService';
-import { ImageExportService } from '../../../features/export/services/ImageExportService';
 import {
   getSavedSpeakerLabelOverrides,
   saveSpeakerLabelOverrides,
@@ -60,6 +59,7 @@ import {
   copyImageBlobToClipboard,
   copyImageBlobViaSafariNativePasteboard,
   downloadImageBlob,
+  renderResponseImageBlob,
 } from './responseImageCopy';
 import { resolveUniqueExportTurnIds } from './selectionIds';
 import { groupSelectedMessagesByTurn, resolveInitialSelectedMessageIds } from './selectionUtils';
@@ -2125,7 +2125,13 @@ async function handleResponseCopyImageClick(
   }
   trigger.dataset.gvCopyImageBusy = '1';
 
-  const texts = getResponseCopyImageTexts(getCurrentLanguage(), dict);
+  const lang = getCurrentLanguage();
+  const texts = getResponseCopyImageTexts(lang, dict);
+  const t = (key: TranslationKey) => dict[lang]?.[key] ?? dict.en?.[key] ?? key;
+  const speakerDefaults: ExportSpeakerLabels = {
+    user: t('export_speaker_user_default'),
+    assistant: t('export_speaker_assistant_default'),
+  };
   const messageId = resolveAssistantMessageIdFromMenuTrigger(trigger);
   let blobForFallback: Blob | null = null;
   try {
@@ -2148,8 +2154,9 @@ async function handleResponseCopyImageClick(
       title: getConversationTitleForExport(),
     };
 
-    const blob = await ImageExportService.renderConversationBlob(turnsForExport, metadata, {
+    const blob = await renderResponseImageBlob(turnsForExport, metadata, {
       imageWidth,
+      speakerDefaults,
     });
     blobForFallback = blob;
     await copyImageBlobToClipboard(blob);

--- a/src/pages/content/export/pendingExportState.ts
+++ b/src/pages/content/export/pendingExportState.ts
@@ -1,0 +1,160 @@
+import { ConversationExportService } from '../../../features/export/services/ConversationExportService';
+import type {
+  ChatTurn,
+  ConversationMetadata,
+  ExportFormat,
+  ExportSpeakerLabels,
+} from '../../../features/export/types/export';
+
+export const PENDING_EXPORT_SESSION_KEY = 'gv_export_pending';
+
+export interface PendingExportState {
+  format: ExportFormat;
+  fontSize?: number;
+  imageWidth?: number;
+  usePromptAsTurnHeading?: boolean;
+  speakerLabels?: ExportSpeakerLabels;
+  initialSelectedMessageId?: string;
+  attempt: number;
+  url: string;
+  status: 'clicking';
+  timestamp: number;
+}
+
+type PendingExportStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+function isExportFormat(value: unknown): value is ExportFormat {
+  return value === 'json' || value === 'markdown' || value === 'pdf' || value === 'image';
+}
+
+function parseSpeakerLabels(value: unknown): ExportSpeakerLabels | undefined {
+  if (
+    !value ||
+    Array.isArray(value) ||
+    typeof value !== 'object' ||
+    typeof (value as Record<string, unknown>).user !== 'string' ||
+    typeof (value as Record<string, unknown>).assistant !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return {
+    user: (value as Record<string, string>).user,
+    assistant: (value as Record<string, string>).assistant,
+  };
+}
+
+export function createPendingExportState(
+  format: ExportFormat,
+  url: string,
+  now: number,
+  options: {
+    fontSize?: number;
+    imageWidth?: number;
+    usePromptAsTurnHeading?: boolean;
+    speakerLabels?: ExportSpeakerLabels;
+    initialSelectedMessageId?: string;
+  } = {},
+): PendingExportState {
+  return {
+    format,
+    ...options,
+    attempt: 0,
+    url,
+    status: 'clicking',
+    timestamp: now,
+  };
+}
+
+export function advancePendingExportState(
+  state: PendingExportState,
+  now: number,
+): PendingExportState {
+  return {
+    ...state,
+    attempt: state.attempt + 1,
+    timestamp: now,
+  };
+}
+
+export function persistPendingExportState(
+  storage: PendingExportStorage,
+  state: PendingExportState,
+  now: number,
+): PendingExportState {
+  const nextState = advancePendingExportState(state, now);
+  storage.setItem(PENDING_EXPORT_SESSION_KEY, JSON.stringify(nextState));
+  return nextState;
+}
+
+export function parsePendingExportState(raw: string): PendingExportState | null {
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (!value || Array.isArray(value) || typeof value !== 'object') return null;
+
+    const parsed = value as Record<string, unknown>;
+    if (
+      !isExportFormat(parsed.format) ||
+      typeof parsed.attempt !== 'number' ||
+      typeof parsed.url !== 'string' ||
+      parsed.status !== 'clicking' ||
+      typeof parsed.timestamp !== 'number'
+    ) {
+      return null;
+    }
+
+    return {
+      format: parsed.format,
+      fontSize: typeof parsed.fontSize === 'number' ? parsed.fontSize : undefined,
+      imageWidth: typeof parsed.imageWidth === 'number' ? parsed.imageWidth : undefined,
+      usePromptAsTurnHeading: parsed.usePromptAsTurnHeading === true,
+      speakerLabels: parseSpeakerLabels(parsed.speakerLabels),
+      initialSelectedMessageId:
+        typeof parsed.initialSelectedMessageId === 'string'
+          ? parsed.initialSelectedMessageId
+          : undefined,
+      attempt: parsed.attempt,
+      url: parsed.url,
+      status: parsed.status,
+      timestamp: parsed.timestamp,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function restorePendingExportState(
+  storage: PendingExportStorage,
+  currentUrl: string,
+): PendingExportState | null {
+  const raw = storage.getItem(PENDING_EXPORT_SESSION_KEY);
+  if (!raw) return null;
+
+  const state = parsePendingExportState(raw);
+  if (!state || state.url !== currentUrl) {
+    storage.removeItem(PENDING_EXPORT_SESSION_KEY);
+    return null;
+  }
+
+  return state;
+}
+
+export function clearPendingExportState(storage: PendingExportStorage): void {
+  storage.removeItem(PENDING_EXPORT_SESSION_KEY);
+}
+
+export function exportPendingConversation(
+  state: PendingExportState,
+  turns: ChatTurn[],
+  metadata: ConversationMetadata,
+  includeImageSource: boolean,
+) {
+  return ConversationExportService.export(turns, metadata, {
+    format: state.format,
+    fontSize: state.fontSize,
+    includeImageSource,
+    imageWidth: state.imageWidth,
+    usePromptAsTurnHeading: state.usePromptAsTurnHeading,
+    speakerLabels: state.speakerLabels,
+  });
+}

--- a/src/pages/content/export/responseImageCopy.ts
+++ b/src/pages/content/export/responseImageCopy.ts
@@ -1,5 +1,13 @@
 import { requestSafariNativeImageCopy } from '@/core/utils/safariNativeClipboard';
+import { ImageExportService } from '@/features/export/services/ImageExportService';
 import { renderElementToImageBlob } from '@/features/export/services/ImageRenderService';
+import { getSavedSpeakerLabelOverrides } from '@/features/export/services/SpeakerLabelPreferenceService';
+import {
+  type ChatTurn,
+  type ConversationMetadata,
+  type ExportSpeakerLabels,
+  resolveExportSpeakerLabels,
+} from '@/features/export/types/export';
 
 type ClipboardWriteLike = Pick<Clipboard, 'write'>;
 type ClipboardItemLike = new (items: Record<string, Blob>) => ClipboardItem;
@@ -8,6 +16,25 @@ export type CopyElementAsImageOptions = {
   clipboard?: ClipboardWriteLike | null;
   ClipboardItemCtor?: ClipboardItemLike | null;
 };
+
+export type RenderResponseImageBlobOptions = {
+  imageWidth: number;
+  speakerDefaults: ExportSpeakerLabels;
+};
+
+export async function renderResponseImageBlob(
+  turns: ChatTurn[],
+  metadata: ConversationMetadata,
+  options: RenderResponseImageBlobOptions,
+): Promise<Blob> {
+  const savedOverrides = await getSavedSpeakerLabelOverrides(options.speakerDefaults);
+  const speakerLabels = resolveExportSpeakerLabels(savedOverrides, options.speakerDefaults);
+
+  return await ImageExportService.renderConversationBlob(turns, metadata, {
+    imageWidth: options.imageWidth,
+    speakerLabels,
+  });
+}
 
 function resolveClipboardDependencies(options?: CopyElementAsImageOptions): {
   clipboard: ClipboardWriteLike | null;

--- a/src/pages/content/export/responseImageCopy.ts
+++ b/src/pages/content/export/responseImageCopy.ts
@@ -27,7 +27,7 @@ export async function renderResponseImageBlob(
   metadata: ConversationMetadata,
   options: RenderResponseImageBlobOptions,
 ): Promise<Blob> {
-  const savedOverrides = await getSavedSpeakerLabelOverrides(options.speakerDefaults);
+  const savedOverrides = await getSavedSpeakerLabelOverrides();
   const speakerLabels = resolveExportSpeakerLabels(savedOverrides, options.speakerDefaults);
 
   return await ImageExportService.renderConversationBlob(turns, metadata, {


### PR DESCRIPTION
## Summary

This PR adds customizable speaker labels for human-readable conversation exports.

Changes include:

- Add localized User and AI label fields to the export dialog.
- Persist normalized custom speaker label preferences using extension storage while preserving explicit user overrides across locale changes.
- Apply resolved labels to Markdown, PDF, and image conversation exports.
- Apply persisted speaker labels to single-reply "Copy as image" exports.
- Preserve JSON export structure and stable `user` / `assistant` roles.
- Safely escape user-provided labels in Markdown and HTML-based export paths.
- Preserve speaker labels through pending-export serialization and restoration.
- Keep standalone Deep Research document exports isolated from speaker labels.
- Preserve explicit speaker-label customization even when a saved value matches another locale's default label.

Closes #863

---

## Behavior

Empty and whitespace-only values resolve to localized defaults.

Users can customize User and AI labels independently, for example:

- User → `Erik`
- AI → `Nova`

Custom values are restored in future export dialog sessions.

Explicit custom overrides are stored separately from localized effective labels.
This prevents user-defined values from being removed when they happen to match
the default label of another locale.

For example, a custom value saved in one locale remains preserved after
switching to another locale where that same value becomes the localized default.

Selecting JSON hides the speaker-name fields without clearing current values or removing saved preferences. JSON exports continue to use stable machine-readable roles:

```json
{
  "user": "...",
  "assistant": "..."
}
```

Storage read, write, and removal failures are handled safely and do not block export operations.

Single-reply image copy now uses the same persisted speaker-label preferences as full conversation image exports.

---

## Safety

- Markdown-special characters in speaker labels are escaped without modifying conversation content.
- PDF and image export labels are HTML-escaped before rendering.
- Existing callers that omit speaker labels continue to use the current default behavior.
- Deep Research document exports do not apply conversation speaker labels.

---

## Automated Verification

Passed:

- `bun run typecheck`
- `bun run i18n:check` (10 locales, 662 keys)
- Focused export regression suite (29 export/content test files, 295 tests passed)
- P2 single-reply image regression tests
- `bun run build:all` (Chrome, Firefox, Safari builds)
- `git diff --check`

Focused coverage includes:

- Default localized labels
- Custom speaker labels
- Independent User/AI customization
- Blank and whitespace fallback
- Preference persistence and restoration
- Storage failure handling
- Markdown escaping
- PDF/Image HTML injection prevention
- JSON schema stability
- Pending-export serialization and restoration
- Backward-compatible pending state handling
- Deep Research isolation
- Locale consistency and settings backup behavior
- Single-reply image copy with persisted speaker labels
- Single-reply image copy fallback to localized defaults
- Full conversation image export behavior preservation
- Locale-switch persistence regression coverage
- Explicit override preservation across locale-default collisions
- Custom value retention after locale changes

---

## Related Issue

Closes #863

- [ ] If the issue is labeled `community-only`, I was assigned after maintainer approval before starting.

---

## Visual Proof

Manual browser verification was completed with Chrome, Firefox, and Safari.

Additional P2 verification was performed for single-reply "Copy as image" exports after the follow-up fix.

Attached evidence includes:

- Export dialog showing the Speaker names section.
- Custom labels (`Erik` / `Nova`) applied to human-readable exports.
- Markdown, PDF, Image, and JSON export verification.
- Preference persistence after reopening the export dialog.
- Single-reply "Copy as image" output using custom speaker labels.
- Single-reply "Copy as image" output using localized default labels.
- Chrome, Firefox, and Safari verification screenshots.
- Light mode, dark mode, and responsive layout verification.

### Chrome

<!-- Existing Chrome evidence -->

<img width="1846" height="1119" alt="02-markdown-custom-labels" src="https://github.com/user-attachments/assets/3e64c640-b0b5-4fc7-b1d9-59b221861f9f" />
<img width="741" height="759" alt="03-pdf-custom-labels" src="https://github.com/user-attachments/assets/1da6f054-8ca7-4054-89ee-d1d8c6574e2a" />
<img width="1352" height="1011" alt="05-json-schema-unchanged" src="https://github.com/user-attachments/assets/754aa4ce-97d2-49ba-8cc2-8aee320e5827" />
<img width="476" height="690" alt="06-persistence-after-reopen" src="https://github.com/user-attachments/assets/19ae003b-15c5-4cdb-9792-2fee76818e9f" />
<img width="1632" height="936" alt="09-security-image" src="https://github.com/user-attachments/assets/b6201778-2e29-4ca9-b1e3-6ff2196b5b18" />
<img width="1021" height="1157" alt="11-chrome-dialog-narrow" src="https://github.com/user-attachments/assets/fe120f14-f1f8-4042-afa9-852862edd2ac" />
<img width="480" height="675" alt="01-chrome-default-dialog-light" src="https://github.com/user-attachments/assets/f6ea5e2a-7f78-4d90-b5d4-120b2f02421b" />

<!-- P2 follow-up evidence -->

<img width="430" height="299" alt="chrome-extension-loaded-p2" src="https://github.com/user-attachments/assets/5626d1bd-4dd7-4fc2-a8ee-ce983f72948b" />
<img width="2556" height="478" alt="chrome-json-export-p2" src="https://github.com/user-attachments/assets/325bb66f-0b5f-4942-b8ea-ba0e302ff138" />
<img width="2556" height="1385" alt="chrome-single-reply-default" src="https://github.com/user-attachments/assets/e590e9f6-02ea-48ad-85e4-dbf467aea5e5" />
<img width="2559" height="1389" alt="chrome-single-reply-nova" src="https://github.com/user-attachments/assets/c2aef435-5772-4dbc-96ed-2a7a07cbc260" />
<img width="2479" height="1313" alt="chrome-custom-labels-restored-p2" src="https://github.com/user-attachments/assets/f952981d-a148-401a-aa3f-794a0cef2515" />

---

### Firefox

<img width="2375" height="1198" alt="firefox-dark-mode" src="https://github.com/user-attachments/assets/27793430-49a4-47a6-87ca-fe2fe423165b" />
<img width="746" height="1199" alt="firefox-dialog-narrow" src="https://github.com/user-attachments/assets/59afba5d-179e-481e-a2e9-44a772b9a010" />
<img width="2348" height="1181" alt="firefox-dialog-speaker-names" src="https://github.com/user-attachments/assets/b7562e43-b812-44e7-a15a-a0d2785f9c3e" />
<img width="1211" height="1099" alt="firefox-extension-loaded" src="https://github.com/user-attachments/assets/00c09722-084c-4d22-abae-0b2237c98d79" />
<img width="2039" height="1240" alt="firefox-markdown-export" src="https://github.com/user-attachments/assets/89f6c1af-c20e-4436-a8a6-24397ae7d98a" />
<img width="2369" height="1197" alt="firefox-persistence" src="https://github.com/user-attachments/assets/12af5c67-4d55-49d9-99b4-404aaf3fcff3" />
<img width="2559" height="1201" alt="firefox-console" src="https://github.com/user-attachments/assets/b76e11f2-935d-41b4-b182-e93efa60921d" />
<img width="2559" height="1383" alt="firefox-image-export-final" src="https://github.com/user-attachments/assets/ff4ddd18-22b1-4a5d-8aaf-a8b4fe8878b8" />
<img width="2553" height="1341" alt="firefox-json-export-final" src="https://github.com/user-attachments/assets/295749f2-e0d2-4b33-b687-6150846e1c05" />
<img width="2548" height="1265" alt="firefox-pdf-export-final" src="https://github.com/user-attachments/assets/99902204-2b0c-4cf5-96bb-e999d5ad0818" />
<img width="2556" height="1359" alt="firefox-single-reply-nova" src="https://github.com/user-attachments/assets/294cf1a7-a727-4055-8a8d-f958e25db34d" />
<img width="2554" height="1376" alt="firefox-single-reply-default" src="https://github.com/user-attachments/assets/aef8d4d4-e769-40d5-94d5-a0e260bdd46b" />



---

### Safari

[
<img width="1438" height="789" alt="safari-extension-loaded" src="https://github.com/user-attachments/assets/768580fc-fe6e-4d10-90e0-c2bff3b88e1e" />
<img width="1470" height="956" alt="safari-image-export" src="https://github.com/user-attachments/assets/7cd612fc-dae7-4ca2-af8b-d28d1b96f6d4" />
<img width="1470" height="956" alt="safari-json-export" src="https://github.com/user-attachments/assets/52c2fe18-c9fe-4805-97f8-fe00fd31a9d3" />
<img width="1470" height="956" alt="safari-markdown-export" src="https://github.com/user-attachments/assets/11f42b49-c5d1-46bc-84dc-1a9c3616a4fa" />
<img width="1470" height="956" alt="safari-pdf-export" src="https://github.com/user-attachments/assets/af0cd135-c78b-4d64-80c0-5f32189bcbc8" />
<img width="1470" height="956" alt="safari-single-reply-default" src="https://github.com/user-attachments/assets/e0859fff-5182-473d-95d7-f0d0408ac706" />
<img width="1470" height="956" alt="safari-single-reply-nova" src="https://github.com/user-attachments/assets/00deb92d-4c03-4829-813d-ac331441b4cc" />
<img width="1227" height="923" alt="safari-custom-labels-restored" src="https://github.com/user-attachments/assets/37227ac5-a455-475e-9e87-04e0e9d9b797" />

---

## Browser Testing

Tested commit:

```
ae9fc72b912a7c69cc483ffb577b56a605aa9040
```

| Browser / version | Scenario and result | Evidence |
| ----------------- | ------------------ | -------- |
| Chrome 150.0.7871.187 | Verified export dialog, custom labels, Markdown/PDF/Image exports, JSON behavior, persistence across locale-aware storage handling, responsive layout, and single-reply Copy as image with custom/default speaker labels. | Attached screenshots |
| Firefox 153.0.1 | Verified extension loading, speaker label UI, Markdown/PDF/Image/JSON exports, persistence, responsive layout, and single-reply Copy as image with custom/default speaker labels. | Attached screenshots |
| Safari 18.6 | Verified Safari extension loading, export flows, JSON stability, persistence, and single-reply Copy as image with custom/default speaker labels. | Attached screenshots |

### Missing checks and owner, or N/A reason

- Pending-export hard reload was not reproduced during live browser testing.
  Automated regression tests cover state creation, serialization, restoration, continuation, malformed state handling, and export propagation.

- Deep Research live verification was blocked by a separate pre-existing upstream compatibility issue where Voyager's existing Deep Research export buttons are not injected when a legacy Gemini menu marker is absent.

  This issue is unrelated to #863.

### Commands not run and reason

`bun run verify:pr` was not completed successfully because the current upstream branch fails the tracked `AGENTS.md` Prettier trailing newline check before the verification workflow can continue.

Equivalent verification commands were executed separately and passed:

- `bun run typecheck`
- `bun run i18n:check`
- focused export regression tests
- `bun run build:all`
- `git diff --check`

The full test suite was not green on this Windows environment due to unrelated Windows-specific release-privacy test failures involving:

- symlink creation returning `EPERM`
- provisioning-profile path handling differences

---

## Checklist

- [x] I discussed the requirement, affected scope, and verification plan with an AI agent before implementation.
- [x] I have manually verified that the feature works as intended.
- [x] For UI/behavior changes, I have tried the real workflow for about 15 minutes when possible.
- [x] For UI/behavior changes, I have included visual proof after verification.
- [x] I have confirmed that this PR does not break existing functionality.
- [x] This PR focuses on one issue or one coherent change.
- [x] I added and updated regression tests for the behavior changes.
- [x] I listed the affected browsers actually tested.

The following checklist item is intentionally not checked:

- [ ] I ran `bun run format`, `bun run lint`, then the standard local `bun run verify:pr`, or listed every omitted command and reason above.

Reason:

`bun run verify:pr` could not complete because the current upstream branch fails the tracked `AGENTS.md` Prettier formatting check before the workflow continues.

---

## Known Limitations

The pending-export hard reload workflow was not reproduced manually in the available browser sessions.

Its behavior is covered by automated regression tests for:

- state creation;
- serialization;
- restoration;
- recursive continuation;
- malformed state handling;
- cleanup behavior;
- final export service propagation.

A P2 follow-up fixed missing persisted speaker labels in single-reply "Copy as image" exports. The fix was verified through regression tests and live browser verification across Chrome, Firefox, and Safari.

Standalone Deep Research live verification was blocked by a separate upstream compatibility issue. This PR does not modify Deep Research menu detection logic and does not cause that behavior.

Speaker-label persistence now tracks explicit user overrides independently
from localized effective labels. This prevents accidental removal of custom
values when switching between locales with matching default labels.