### PR TITLE
fix(deep-research): restore report export menu actions

### DIFF
--- a/src/pages/content/deepResearch/__tests__/menuButton.test.ts
+++ b/src/pages/content/deepResearch/__tests__/menuButton.test.ts
@@ -52,7 +52,9 @@ function createNativeMenuButton({
   return button;
 }
 
-function createDeepResearchReportMenuPanel(): HTMLElement {
+function createDeepResearchReportMenuPanel(
+  shareMarker = 'share-button-tooltip-container',
+): HTMLElement {
   const panel = document.createElement('div');
   panel.className = 'mat-mdc-menu-panel';
   panel.setAttribute('role', 'menu');
@@ -61,7 +63,7 @@ function createDeepResearchReportMenuPanel(): HTMLElement {
   content.className = 'mat-mdc-menu-content';
 
   const shareContainer = document.createElement('div');
-  shareContainer.setAttribute('data-test-id', 'share-button-tooltip-container');
+  shareContainer.setAttribute('data-test-id', shareMarker);
   const shareButtonWrapper = document.createElement('share-button');
   const shareButton = createNativeMenuButton({
     testId: 'share-button',
@@ -131,6 +133,63 @@ describe('applyDeepResearchDownloadButtonI18n', () => {
     panel.appendChild(content);
 
     expect(isDeepResearchReportMenuPanel(panel)).toBe(true);
+  });
+
+  it.each([
+    ['share-drive-button', 'export-to-docs-button'],
+    ['share-classroom-button', 'copy-button'],
+  ])('identifies report menu with %s and %s', (shareTestId, exportTestId) => {
+    const panel = document.createElement('div');
+    panel.className = 'mat-mdc-menu-panel';
+    panel.setAttribute('role', 'menu');
+
+    const content = document.createElement('div');
+    content.className = 'mat-mdc-menu-content';
+
+    for (const testId of [shareTestId, exportTestId]) {
+      const action = document.createElement('button');
+      action.setAttribute('data-test-id', testId);
+      content.appendChild(action);
+    }
+
+    panel.appendChild(content);
+
+    expect(isDeepResearchReportMenuPanel(panel)).toBe(true);
+  });
+
+  it('rejects report share actions without an export action', () => {
+    const panel = document.createElement('div');
+    panel.className = 'mat-mdc-menu-panel';
+    panel.setAttribute('role', 'menu');
+
+    const content = document.createElement('div');
+    content.className = 'mat-mdc-menu-content';
+
+    const shareAction = document.createElement('button');
+    shareAction.setAttribute('data-test-id', 'share-drive-button');
+    content.appendChild(shareAction);
+    panel.appendChild(content);
+
+    expect(isDeepResearchReportMenuPanel(panel)).toBe(false);
+  });
+
+  it('rejects generic export menu without deep research share actions', () => {
+    const panel = document.createElement('div');
+    panel.className = 'mat-mdc-menu-panel';
+    panel.setAttribute('role', 'menu');
+
+    const content = document.createElement('div');
+    content.className = 'mat-mdc-menu-content';
+
+    for (const testId of ['export-to-docs-button', 'copy-button']) {
+      const action = document.createElement('button');
+      action.setAttribute('data-test-id', testId);
+      content.appendChild(action);
+    }
+
+    panel.appendChild(content);
+
+    expect(isDeepResearchReportMenuPanel(panel)).toBe(false);
   });
 
   it('rejects sidebar conversation menu panel for deep research injection', () => {
@@ -281,6 +340,32 @@ describe('applyDeepResearchDownloadButtonI18n', () => {
     expect(downloadText?.className).toBe(templateText?.className);
     expect(saveReportText?.className).toBe(templateText?.className);
     expect(saveReport?.textContent?.toLowerCase()).not.toContain('description');
+  });
+
+  it('injects both export actions into a report menu with direct share actions', async () => {
+    const w = window as unknown as {
+      chrome?: {
+        storage?: {
+          sync?: {
+            get: (key: string, cb: (result: Record<string, unknown>) => void) => void;
+          };
+        };
+      };
+    };
+    w.chrome = {
+      storage: {
+        sync: {
+          get: (_key, cb) => cb({}),
+        },
+      },
+    };
+
+    const panel = createDeepResearchReportMenuPanel('share-drive-button');
+
+    await injectDownloadButton(panel);
+
+    expect(panel.querySelector('.gv-deep-research-download')).toBeTruthy();
+    expect(panel.querySelector('.gv-deep-research-save-report')).toBeTruthy();
   });
 
   it('renders and removes deep research export progress overlay', () => {

--- a/src/pages/content/deepResearch/menuButton.ts
+++ b/src/pages/content/deepResearch/menuButton.ts
@@ -494,15 +494,17 @@ export function isDeepResearchReportMenuPanel(menuPanel: HTMLElement): boolean {
   const menuContent = menuPanel.querySelector('.mat-mdc-menu-content');
   if (!(menuContent instanceof HTMLElement)) return false;
 
-  const hasShareContainer = Boolean(
-    menuContent.querySelector('[data-test-id="share-button-tooltip-container"]'),
+  const hasReportShareActions = Boolean(
+    menuContent.querySelector('[data-test-id="share-button-tooltip-container"]') ||
+      menuContent.querySelector('[data-test-id="share-drive-button"]') ||
+      menuContent.querySelector('[data-test-id="share-classroom-button"]'),
   );
   const hasReportExportActions = Boolean(
     menuContent.querySelector('[data-test-id="export-to-docs-button"]') ||
       menuContent.querySelector('[data-test-id="copy-button"]'),
   );
 
-  return hasShareContainer && hasReportExportActions;
+  return hasReportShareActions && hasReportExportActions;
 }
 
 /**


### PR DESCRIPTION
### Description / 描述

Restore Voyager's existing Deep Research export actions for Gemini accounts where the legacy share container has been replaced by direct Drive/Classroom share actions.

- Accept either the legacy `share-button-tooltip-container` marker or the newer `share-drive-button` / `share-classroom-button` markers.
- Continue requiring a native Docs/Copy export action, so generic Angular Material menus are not treated as Deep Research report menus.
- Add DOM regression coverage for both Gemini rollouts and for negative menu matches.

This changes menu detection only. Export behavior, labels, and styling are unchanged.

### Related Issue / 相关 Issue

Fixes #882

- [x] N/A: #882 is not labeled `community-only`; it was claimed through `/claim`.

### Visual Proof / 可视化证据

Affected-account before state, provided by the reporter in #882:

![Deep Research menu without Voyager export actions](https://github.com/user-attachments/assets/b2b68296-dc7e-4165-be3a-4e4796835279)

![Affected Gemini menu evidence](https://github.com/user-attachments/assets/9cfc45c9-6c73-44f5-8696-8cab8c1f9f30)

<img width="290" height="254" alt="image" src="https://github.com/user-attachments/assets/dcc080bd-cef5-4208-976e-2153fd2cb7d2" />


The contributor account currently receives Gemini's legacy DOM and already showed both Voyager actions before this change, so it cannot produce a truthful affected-rollout before/after comparison. A post-fix screenshot from the affected rollout is pending from `@slyu0021` or a maintainer with access to it.

Firefox legacy-rollout Loaded/Live evidence was also collected manually on Firefox 154.0. The supplied screenshots include report content, so unredacted copies are not attached publicly; the redacted structural and interaction results are recorded in the browser table below.

### Browser Testing / 浏览器测试

Tested commit / 测试提交: `5824eb2cc508cb2a2b2708eb27cf6804e02655a3`

| Browser / version | Scenario and result / 场景与结果 | Evidence / 证据 |
| ----------------- | -------------------------------- | --------------- |
| Chrome 150.0.7871.130 | Voyager Dev 1.6.0 on a completed Deep Research report using the legacy Gemini DOM. Loaded/Live passed: Download Thinking and Save Report were visible and interactive. | Manual verification; DOM markers: legacy share container present, Docs/Copy present, 2 Voyager buttons. |
| Firefox 154.0 | Voyager 1.6.0 temporarily loaded from `dist_firefox` on a completed Deep Research report using the legacy Gemini DOM. Loaded/Live passed: both actions appeared exactly once; Save Report opened the export dialog; Download Thinking completed a 9.0 KB Markdown download. | `about:debugging` showed `gemini-voyager@nagi-ovo` running from `dist_firefox`. DOM evidence: Deep Research panel present; legacy share container and Docs/Copy present; Drive/Classroom absent; download count 1; save-report count 1. |

Missing checks and owner, or N/A reason / 缺失检查与负责人，或不适用理由:

- Chrome Live on the affected modern Gemini DOM (`share-drive-button` / `share-classroom-button`, no legacy container) and post-fix screenshot: pending; owner `@slyu0021` or a maintainer with this rollout.
- Edge release was used only as baseline confirmation on the legacy DOM; it was not the tested commit and is not claimed as PR Live evidence.

Automated verification:

- `bun run lint`: passed with 0 errors and 209 existing warnings.
- `bun run typecheck`: passed.
- `bun run i18n:check`: passed (10 locales, 657 keys).
- `bun run test src/pages/content/deepResearch`: passed (15/15).
- `bun run build:all`: passed (Chrome, Firefox, Safari).
- `bun run docs:build`: passed.
- `git diff --check`: passed.
- `bun run test`: 253/254 files and 2350/2351 tests passed. The only failure is the unchanged `scripts/__tests__/verify-release-privacy.test.ts`, whose embedded provisioning-profile allowlist uses POSIX separators and rejects the Windows test paths.
- `bun run verify:pr`: stopped at `format:check` because this Windows checkout represents the `AGENTS.md -> CLAUDE.md` Git symlink as a one-line plain file. `bun run format` adds a newline to that placeholder; the unrelated change was restored. All downstream checks applicable to this PR were run separately above.

Commands not run and reason / 未运行命令及原因:

- No required automated command was omitted. Only the affected-account Chrome Live check remains pending as listed above.

### Checklist / 检查清单

- [x] If I used an agent, I discussed the requirement, affected scope, and verification plan clearly. / 如果使用了 Agent，我已讨论清楚需求、影响范围和验证方式。
- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] For UI/behavior changes, I have tried the real workflow for about 15 minutes when possible. / 对于 UI/行为改动，条件允许时我已用真实流程体验约 15 分钟。
- [x] For UI/behavior changes, I have included visual proof after verification. / 对于 UI/行为改动，我已在验证后提供可视化证据。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] This PR focuses on one issue or one coherent change. / 此 PR 只聚焦一个问题或一个清晰完整的改动。
- [x] I ran `bun run format`, `bun run lint`, then the standard local `bun run verify:pr`, or listed every omitted command and reason above. / 我已依次运行格式化、自动修复及标准本地 `bun run verify:pr` 验证，或在上方逐项说明未运行命令及原因。
- [x] I added/updated regression tests for behavior changes, or explained why no test is useful. / 行为改动已添加或更新回归测试；若无需测试，我已说明理由。
- [x] I listed the affected browsers actually tested and identified any required follow-up owner. / 我已列出实际测试的受影响浏览器，并标明所有必需补测的负责人。