### PR TITLE
fix(watermark): apply toggles to open Gemini tabs

### DIFF
--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -112,21 +112,21 @@ when download removal changed from disabled to enabled.
 Fix:
 
 Route watermark storage changes through the existing content-script storage
-listener, fully stop and restart the watermark runtime, reuse its initialized
-engine, and reject stale async starts and in-flight preview writes with a
-lifecycle generation. If a restart leaves preview removal enabled, retry stale
-preview work after releasing its queue slot. When download removal is enabled,
-also inject the guarded MAIN-world interceptor once into matching open tabs;
-disabling keeps installed wrappers in immediate pass-through mode through the
-DOM bridge.
+listener only after normal Gemini startup has activated the watermark runtime,
+fully stop and restart the runtime, reuse its initialized engine, and reject
+stale async starts and in-flight preview writes with a lifecycle generation. If
+a restart leaves preview removal enabled, retry stale preview work after
+releasing its queue slot. When download removal is enabled, also inject the
+guarded MAIN-world interceptor once into matching open tabs; disabling keeps
+installed wrappers in immediate pass-through mode through the DOM bridge.
 
 Regression test:
 
 `src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts` verifies
 bidirectional runtime changes, engine reuse, stale-start and stale-preview
-rejection, latest-lifecycle preview retry, and content entry wiring.
-`src/pages/background/__tests__/watermarkOpenTabs.test.ts` verifies targeted
-MAIN-world injection and closed-tab failure handling.
+rejection, latest-lifecycle preview retry, and startup-gated content entry
+wiring. `src/pages/background/__tests__/watermarkOpenTabs.test.ts` verifies
+targeted MAIN-world injection and closed-tab failure handling.
 
 Commit:
 

--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -118,16 +118,19 @@ stale async starts and in-flight preview writes with a lifecycle generation. If
 a restart leaves preview removal enabled, retry stale preview work after
 releasing its queue slot. Clear preview bookkeeping on stop without restoring
 the current image source, so Gemini can reuse the same image node without stale
-markers blocking a later preview. When download removal is enabled, also inject
-the guarded MAIN-world interceptor once into matching open tabs; disabling
-keeps installed wrappers in immediate pass-through mode through the DOM bridge.
+markers blocking a later preview. Stop also clears the active download
+sequence's fallback timer and pending status toasts, so disabling the feature
+cannot show delayed processing feedback after its listeners are gone. When
+download removal is enabled, also inject the guarded MAIN-world interceptor
+once into matching open tabs; disabling keeps installed wrappers in immediate
+pass-through mode through the DOM bridge.
 
 Regression test:
 
 `src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts` verifies
 bidirectional runtime changes, engine reuse, stale-start and stale-preview
-rejection, latest-lifecycle preview retry, reused-node processing, and
-startup-gated content entry wiring.
+rejection, latest-lifecycle preview retry, reused-node processing, stopped
+download-feedback cleanup, and startup-gated content entry wiring.
 `src/pages/background/__tests__/watermarkOpenTabs.test.ts` verifies targeted
 MAIN-world injection and closed-tab failure handling.
 

--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -95,6 +95,40 @@ Commit:
 
 `fix(watermark): distinguish dark restoration from clipping damage`
 
+## Watermark toggles must reconfigure already-open Gemini tabs
+
+Symptom:
+
+Changing either watermark-removal toggle in the popup had no effect in an
+already-open Gemini tab until the page was refreshed.
+
+Root cause:
+
+The content runtime read both settings only during startup. Background
+registration kept future documents in sync, but dynamically registering
+`fetchInterceptor.js` did not install it into a document that was already open
+when download removal changed from disabled to enabled.
+
+Fix:
+
+Route watermark storage changes through the existing content-script storage
+listener, fully stop and restart the watermark runtime, reuse its initialized
+engine, and reject stale async starts with a lifecycle generation. When
+download removal is enabled, also inject the guarded MAIN-world interceptor
+once into matching open tabs; disabling keeps installed wrappers in immediate
+pass-through mode through the DOM bridge.
+
+Regression test:
+
+`src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts` verifies
+bidirectional runtime changes, engine reuse, stale-start rejection, and content
+entry wiring. `src/pages/background/__tests__/watermarkOpenTabs.test.ts`
+verifies targeted MAIN-world injection and closed-tab failure handling.
+
+Commit:
+
+`fix(watermark): apply toggles to open Gemini tabs`
+
 ## Mermaid must honor Gemini explicit light theme
 
 Symptom:

--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -116,17 +116,20 @@ listener only after normal Gemini startup has activated the watermark runtime,
 fully stop and restart the runtime, reuse its initialized engine, and reject
 stale async starts and in-flight preview writes with a lifecycle generation. If
 a restart leaves preview removal enabled, retry stale preview work after
-releasing its queue slot. When download removal is enabled, also inject the
-guarded MAIN-world interceptor once into matching open tabs; disabling keeps
-installed wrappers in immediate pass-through mode through the DOM bridge.
+releasing its queue slot. Clear preview bookkeeping on stop without restoring
+the current image source, so Gemini can reuse the same image node without stale
+markers blocking a later preview. When download removal is enabled, also inject
+the guarded MAIN-world interceptor once into matching open tabs; disabling
+keeps installed wrappers in immediate pass-through mode through the DOM bridge.
 
 Regression test:
 
 `src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts` verifies
 bidirectional runtime changes, engine reuse, stale-start and stale-preview
-rejection, latest-lifecycle preview retry, and startup-gated content entry
-wiring. `src/pages/background/__tests__/watermarkOpenTabs.test.ts` verifies
-targeted MAIN-world injection and closed-tab failure handling.
+rejection, latest-lifecycle preview retry, reused-node processing, and
+startup-gated content entry wiring.
+`src/pages/background/__tests__/watermarkOpenTabs.test.ts` verifies targeted
+MAIN-world injection and closed-tab failure handling.
 
 Commit:
 

--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -113,24 +113,27 @@ Fix:
 
 Route watermark storage changes through the existing content-script storage
 listener only after normal Gemini startup has activated the watermark runtime,
-fully stop and restart the runtime, reuse its initialized engine, and reject
-stale async starts and in-flight preview writes with a lifecycle generation. If
-a restart leaves preview removal enabled, retry stale preview work after
-releasing its queue slot. Clear preview bookkeeping on stop without restoring
-the current image source, so Gemini can reuse the same image node without stale
-markers blocking a later preview. Stop also clears the active download
-sequence's fallback timer and pending status toasts, so disabling the feature
-cannot show delayed processing feedback after its listeners are gone. When
-download removal is enabled, also inject the guarded MAIN-world interceptor
-once into matching open tabs; disabling keeps installed wrappers in immediate
+reuse its initialized engine, and reject stale async starts and in-flight
+preview writes with a lifecycle generation. Reconfigure preview and download
+as separate lifecycles: if download removal stays enabled, preserve its bridge,
+intent, observers, and active feedback while preview changes; only a true
+download disable performs the full download teardown. Tag each download intent
+and MAIN-world status with the same token so a late result from an older
+download cannot finalize a newer sequence. If a restart leaves preview removal
+enabled, retry stale preview work after releasing its queue slot. Clear preview
+bookkeeping without restoring the current image source, so Gemini can reuse the
+same image node without stale markers blocking a later preview. When download
+removal is enabled, also inject the guarded MAIN-world interceptor once into
+matching open tabs; disabling keeps installed wrappers in immediate
 pass-through mode through the DOM bridge.
 
 Regression test:
 
 `src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts` verifies
 bidirectional runtime changes, engine reuse, stale-start and stale-preview
-rejection, latest-lifecycle preview retry, reused-node processing, stopped
-download-feedback cleanup, and startup-gated content entry wiring.
+rejection, latest-lifecycle preview retry, reused-node processing, preview-only
+download preservation, stopped-download cleanup, stale-status rejection, and
+startup-gated content entry wiring.
 `src/pages/background/__tests__/watermarkOpenTabs.test.ts` verifies targeted
 MAIN-world injection and closed-tab failure handling.
 

--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -113,17 +113,20 @@ Fix:
 
 Route watermark storage changes through the existing content-script storage
 listener, fully stop and restart the watermark runtime, reuse its initialized
-engine, and reject stale async starts with a lifecycle generation. When
-download removal is enabled, also inject the guarded MAIN-world interceptor
-once into matching open tabs; disabling keeps installed wrappers in immediate
-pass-through mode through the DOM bridge.
+engine, and reject stale async starts and in-flight preview writes with a
+lifecycle generation. If a restart leaves preview removal enabled, retry stale
+preview work after releasing its queue slot. When download removal is enabled,
+also inject the guarded MAIN-world interceptor once into matching open tabs;
+disabling keeps installed wrappers in immediate pass-through mode through the
+DOM bridge.
 
 Regression test:
 
 `src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts` verifies
-bidirectional runtime changes, engine reuse, stale-start rejection, and content
-entry wiring. `src/pages/background/__tests__/watermarkOpenTabs.test.ts`
-verifies targeted MAIN-world injection and closed-tab failure handling.
+bidirectional runtime changes, engine reuse, stale-start and stale-preview
+rejection, latest-lifecycle preview retry, and content entry wiring.
+`src/pages/background/__tests__/watermarkOpenTabs.test.ts` verifies targeted
+MAIN-world injection and closed-tab failure handling.
 
 Commit:
 

--- a/public/fetchInterceptor.js
+++ b/public/fetchInterceptor.js
@@ -16,6 +16,7 @@
   /** Timeout for watermark processing in milliseconds */
   const WATERMARK_PROCESSING_TIMEOUT_MS = 30000;
   const DOWNLOAD_INTENT_ATTRIBUTE = 'data-download-intent-expires-at';
+  const DOWNLOAD_INTENT_TOKEN_ATTRIBUTE = 'data-download-intent-token';
   const NOTEBOOK_PATH_PATTERN = /^\/(?:u\/\d+\/)?notebooks?(?:\/|$)/;
 
   const isNotebookRoute = () => NOTEBOOK_PATH_PATTERN.test(window.location.pathname);
@@ -109,12 +110,13 @@
   /**
    * Update status on the bridge for the content script to pick up (and show Toasts)
    */
-  const updateStatus = (status, details = {}) => {
+  const updateStatus = (status, intentToken, details = {}) => {
     const bridge = getBridgeElement();
     if (bridge) {
       bridge.dataset.status = JSON.stringify({
         type: status, // 'START', 'PROGRESS', 'SUCCESS', 'ERROR', 'WARNING'
         timestamp: Date.now(),
+        intentToken,
         ...details,
       });
     }
@@ -137,8 +139,10 @@
   const consumeDownloadIntent = () => {
     const bridge = getBridgeElement();
     const expiresAt = Number(bridge.dataset.downloadIntentExpiresAt || 0);
+    const intentToken = bridge.dataset.downloadIntentToken || `legacy:${expiresAt}`;
     bridge.removeAttribute(DOWNLOAD_INTENT_ATTRIBUTE);
-    return Number.isFinite(expiresAt) && expiresAt >= Date.now();
+    bridge.removeAttribute(DOWNLOAD_INTENT_TOKEN_ATTRIBUTE);
+    return Number.isFinite(expiresAt) && expiresAt >= Date.now() ? intentToken : null;
   };
 
   // Store original fetch
@@ -168,8 +172,8 @@
 
     // Check if this is a Gemini download request (specifically rd-gg-dl for downloads)
     if (url && typeof url === 'string' && GEMINI_DOWNLOAD_PATTERN.test(url)) {
-      const shouldProcessDownload = isWatermarkRemoverEnabled() && consumeDownloadIntent();
-      if (!shouldProcessDownload) {
+      const downloadIntentToken = isWatermarkRemoverEnabled() ? consumeDownloadIntent() : null;
+      if (!downloadIntentToken) {
         return originalFetch.apply(this, args);
       }
 
@@ -206,27 +210,29 @@
         try {
           // Check content length first (via HEAD request) to show appropriate message
           // But we'll just show "downloading" first and update if large
-          updateStatus('DOWNLOADING');
+          updateStatus('DOWNLOADING', downloadIntentToken);
 
           // Fetch the original size image
           response = await originalFetch.apply(this, args);
 
           if (!response.ok) {
-            updateStatus('ERROR', { message: `HTTP Error: ${response.status}` });
+            updateStatus('ERROR', downloadIntentToken, {
+              message: `HTTP Error: ${response.status}`,
+            });
             return response;
           }
 
           // Check content length for large files (5MB) - update status
           const contentLength = response.headers.get('content-length');
           if (contentLength && parseInt(contentLength, 10) > 5 * 1024 * 1024) {
-            updateStatus('DOWNLOADING_LARGE');
+            updateStatus('DOWNLOADING_LARGE', downloadIntentToken);
           }
 
           // Clone response to read blob
           blob = await response.blob();
 
           // Step 2: Processing
-          updateStatus('PROCESSING');
+          updateStatus('PROCESSING', downloadIntentToken);
 
           // Send blob to content script for watermark removal via DOM bridge
           const processedBlob = await new Promise((resolve, reject) => {
@@ -272,7 +278,7 @@
             }, WATERMARK_PROCESSING_TIMEOUT_MS);
           });
 
-          updateStatus('SUCCESS');
+          updateStatus('SUCCESS', downloadIntentToken);
 
           // Return processed response
           return new Response(processedBlob, {
@@ -282,7 +288,9 @@
           });
         } catch (error) {
           console.warn('[Gemini Voyager] Watermark processing failed, using original:', error);
-          updateStatus('ERROR', { message: error.message || 'Unknown error' });
+          updateStatus('ERROR', downloadIntentToken, {
+            message: error.message || 'Unknown error',
+          });
           // Return the original blob if available, otherwise fall through to originalFetch
           if (blob && response) {
             return new Response(blob, {

--- a/src/pages/background/__tests__/watermarkOpenTabs.test.ts
+++ b/src/pages/background/__tests__/watermarkOpenTabs.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { injectWatermarkInterceptorIntoOpenTabs } from '../watermarkOpenTabs';
+
+const originalScriptingDescriptor = Object.getOwnPropertyDescriptor(chrome, 'scripting');
+
+describe('injectWatermarkInterceptorIntoOpenTabs', () => {
+  const executeScript = vi.fn();
+  const queryTabs = chrome.tabs.query as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    executeScript.mockReset();
+    queryTabs.mockReset();
+    Object.defineProperty(chrome, 'scripting', {
+      value: { executeScript },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalScriptingDescriptor) {
+      Object.defineProperty(chrome, 'scripting', originalScriptingDescriptor);
+    } else {
+      Reflect.deleteProperty(chrome, 'scripting');
+    }
+  });
+
+  it('injects the MAIN-world interceptor into every matching open tab', async () => {
+    queryTabs.mockResolvedValue([{ id: 11 }, { id: 22 }, { url: 'https://gemini.google.com/app' }]);
+    executeScript.mockResolvedValue([]);
+
+    await injectWatermarkInterceptorIntoOpenTabs([
+      'https://gemini.google.com/*',
+      'https://aistudio.google.com/*',
+    ]);
+
+    expect(chrome.tabs.query).toHaveBeenCalledWith({
+      url: ['https://gemini.google.com/*', 'https://aistudio.google.com/*'],
+    });
+    expect(executeScript).toHaveBeenCalledTimes(2);
+    expect(executeScript).toHaveBeenNthCalledWith(1, {
+      target: { tabId: 11 },
+      files: ['fetchInterceptor.js'],
+      world: 'MAIN',
+    });
+    expect(executeScript).toHaveBeenNthCalledWith(2, {
+      target: { tabId: 22 },
+      files: ['fetchInterceptor.js'],
+      world: 'MAIN',
+    });
+  });
+
+  it('ignores tabs that close or reject injection during the one-shot sync', async () => {
+    queryTabs.mockResolvedValue([{ id: 11 }, { id: 22 }]);
+    executeScript.mockRejectedValueOnce(new Error('tab closed')).mockResolvedValueOnce([]);
+
+    await expect(
+      injectWatermarkInterceptorIntoOpenTabs(['https://gemini.google.com/*']),
+    ).resolves.toBeUndefined();
+    expect(executeScript).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing when matching tabs cannot be queried', async () => {
+    queryTabs.mockRejectedValue(new Error('tabs unavailable'));
+
+    await expect(
+      injectWatermarkInterceptorIntoOpenTabs(['https://gemini.google.com/*']),
+    ).resolves.toBeUndefined();
+    expect(executeScript).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -76,6 +76,7 @@ import type { TranslationKey } from '@/utils/translations';
 
 import { resolveOptionalHighlightSetting } from './highlightOptionalSetting';
 import { isHandledBackgroundRuntimeMessage } from './runtimeMessageRouting';
+import { injectWatermarkInterceptorIntoOpenTabs } from './watermarkOpenTabs';
 
 const CUSTOM_CONTENT_SCRIPT_ID = 'gv-custom-content-script';
 const PLUGIN_CONTENT_SCRIPT_ID = 'gv-plugin-content-script';
@@ -617,7 +618,7 @@ function filterForkNodesByRouteScope(
  * Register the fetch interceptor script into MAIN world
  * This allows intercepting fetch calls made by the page itself
  */
-async function registerFetchInterceptor(): Promise<void> {
+async function doRegisterFetchInterceptor(injectOpenTabs: boolean): Promise<void> {
   if (!chrome.scripting?.registerContentScripts) return;
 
   // Safari ships the interceptor as a static MAIN-world content script. A
@@ -661,9 +662,24 @@ async function registerFetchInterceptor(): Promise<void> {
       },
     ]);
     console.log('[Background] Fetch interceptor registered for MAIN world');
+    if (injectOpenTabs) {
+      await injectWatermarkInterceptorIntoOpenTabs(GEMINI_FETCH_INTERCEPTOR_MATCHES);
+    }
   } catch (error) {
     console.error('[Background] Failed to register fetch interceptor:', error);
   }
+}
+
+// Serialize startup and storage-triggered syncs so rapid toggle changes cannot
+// leave an older registration result as the final state.
+let fetchInterceptorRegistrationQueue: Promise<void> = Promise.resolve();
+
+function registerFetchInterceptor(injectOpenTabs = false): Promise<void> {
+  const next = fetchInterceptorRegistrationQueue.then(() =>
+    doRegisterFetchInterceptor(injectOpenTabs),
+  );
+  fetchInterceptorRegistrationQueue = next.catch(() => {});
+  return next;
 }
 
 async function unregisterResponseCompleteObserver(): Promise<void> {
@@ -1236,7 +1252,7 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
   // (Only the download flag actually affects registration, but we also watch
   // the legacy key so a one-time migration write triggers re-registration.)
   if (WATERMARK_STORAGE_KEYS.some((key) => Object.prototype.hasOwnProperty.call(changes, key))) {
-    void registerFetchInterceptor();
+    void registerFetchInterceptor(true);
   }
 
   if (

--- a/src/pages/background/watermarkOpenTabs.ts
+++ b/src/pages/background/watermarkOpenTabs.ts
@@ -1,0 +1,34 @@
+/**
+ * Install the MAIN-world watermark download interceptor into Gemini tabs that
+ * are already open. Persistent content-script registration only applies on a
+ * later navigation, so runtime enablement needs this one-shot companion step.
+ */
+export async function injectWatermarkInterceptorIntoOpenTabs(
+  matches: readonly string[],
+): Promise<void> {
+  if (!chrome.scripting?.executeScript) return;
+
+  let tabs: chrome.tabs.Tab[];
+  try {
+    tabs = await chrome.tabs.query({ url: [...matches] });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    tabs.map(async (tab) => {
+      if (typeof tab.id !== 'number') return;
+
+      try {
+        await chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          files: ['fetchInterceptor.js'],
+          world: 'MAIN',
+        });
+      } catch {
+        // A tab can close, navigate, or reject injection between query and
+        // executeScript. Persistent registration covers its next navigation.
+      }
+    }),
+  );
+}

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -124,6 +124,7 @@ let remoteAnnouncementsCleanup: (() => void) | null = null;
 let storageQuotaWarningCleanup: (() => void) | null = null;
 let accountContextBridgeCleanup: (() => void) | null = null;
 let codeBlockCollapseCleanup: (() => void) | null = null;
+let watermarkRemoverStarted = false;
 
 async function isForkFeatureEnabled(): Promise<boolean> {
   try {
@@ -321,7 +322,8 @@ async function initializeFeatures(): Promise<void> {
       await delay(LIGHT_FEATURE_INIT_DELAY);
 
       // Independent content helpers can initialize in the same idle slice.
-      startWatermarkRemover();
+      watermarkRemoverStarted = true;
+      void startWatermarkRemover();
       startDeepResearchExport();
       startContextSync();
       startGemsHider();
@@ -537,6 +539,7 @@ function handleVisibilityChange(): void {
       areaName: string,
     ) => {
       if (
+        watermarkRemoverStarted &&
         areaName === 'sync' &&
         WATERMARK_STORAGE_KEYS.some((key) => Object.prototype.hasOwnProperty.call(changes, key))
       ) {

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -6,6 +6,7 @@ import {
   isExtensionContextInvalidatedError,
 } from '@/core/utils/extensionContext';
 import { isGeminiEnterpriseEnvironment } from '@/core/utils/gemini';
+import { WATERMARK_STORAGE_KEYS } from '@/core/utils/watermarkSettings';
 import { startFormulaCopy, stopFormulaCopy } from '@/features/formulaCopy';
 import { startPluginHost } from '@/features/plugins';
 import {
@@ -69,7 +70,11 @@ import { startUsageStatus } from './usageStatus/index';
 import { usageCoachmarkStep } from './usageStatus/usageCoachmark';
 import { startUserLatex } from './userLatex/index';
 import { startVisualEffects } from './visualEffects';
-import { startWatermarkRemover, stopWatermarkRemover } from './watermarkRemover/index';
+import {
+  restartWatermarkRemover,
+  startWatermarkRemover,
+  stopWatermarkRemover,
+} from './watermarkRemover/index';
 
 // Suppress Vite's CSS preload errors in the Chrome extension content script context.
 // Dynamic imports (e.g., mermaid) trigger Vite's __vitePreload helper which tries to
@@ -531,6 +536,13 @@ function handleVisibilityChange(): void {
       changes: Record<string, chrome.storage.StorageChange>,
       areaName: string,
     ) => {
+      if (
+        areaName === 'sync' &&
+        WATERMARK_STORAGE_KEYS.some((key) => Object.prototype.hasOwnProperty.call(changes, key))
+      ) {
+        void restartWatermarkRemover();
+      }
+
       if (
         (areaName !== 'sync' && areaName !== 'local') ||
         location.hostname !== 'gemini.google.com'

--- a/src/pages/content/watermarkRemover/__tests__/downloadToasts.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/downloadToasts.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { startWatermarkRemover } from '../index';
+import { startWatermarkRemover, stopWatermarkRemover } from '../index';
 
 vi.mock('@/utils/i18n', () => ({
   getTranslationSync: (key: string) => key,
@@ -33,6 +33,7 @@ describe('watermarkRemover download toasts', () => {
   });
 
   afterEach(() => {
+    stopWatermarkRemover();
     vi.useRealTimers();
   });
 
@@ -55,7 +56,10 @@ describe('watermarkRemover download toasts', () => {
     expect(intentTtlMs).toBeGreaterThanOrEqual(59000);
     expect(intentTtlMs).toBeLessThanOrEqual(60000);
 
-    (bridge as HTMLElement).dataset.status = JSON.stringify({ type: 'DOWNLOADING_LARGE' });
+    (bridge as HTMLElement).dataset.status = JSON.stringify({
+      type: 'DOWNLOADING_LARGE',
+      intentToken: (bridge as HTMLElement).dataset.downloadIntentToken,
+    });
     await flushMutationObservers();
 
     const toastsAfter = document.querySelectorAll('.gv-status-toast');
@@ -64,5 +68,24 @@ describe('watermarkRemover download toasts', () => {
     vi.advanceTimersByTime(8000);
     const toastsFinal = document.querySelectorAll('.gv-status-toast');
     expect([...toastsFinal].some((toast) => toast.textContent === '大文件警告')).toBe(false);
+  });
+
+  it('ignores a late status from an older download sequence', async () => {
+    await startWatermarkRemover();
+
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const bridge = document.getElementById('gv-watermark-bridge') as HTMLElement;
+    bridge.dataset.status = JSON.stringify({
+      type: 'SUCCESS',
+      intentToken: 'stale-download-token',
+    });
+    await flushMutationObservers();
+
+    const toasts = [...document.querySelectorAll('.gv-status-toast')];
+    expect(toasts.some((toast) => toast.textContent === '正在下载原始图片')).toBe(true);
+    expect(toasts.some((toast) => toast.textContent === '正在下载')).toBe(false);
   });
 });

--- a/src/pages/content/watermarkRemover/__tests__/fetchInterceptor.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/fetchInterceptor.test.ts
@@ -128,6 +128,7 @@ describe('fetchInterceptor (MAIN world script)', () => {
   it('uses the watermark pipeline for a recent user download intent', async () => {
     const bridge = createEnabledBridge();
     bridge.dataset.downloadIntentExpiresAt = String(Date.now() + 1000);
+    bridge.dataset.downloadIntentToken = 'intent-1';
     installInterceptor();
 
     const responsePromise = window.fetch(GEMINI_DOWNLOAD_URL);
@@ -150,7 +151,10 @@ describe('fetchInterceptor (MAIN world script)', () => {
       'https://lh3.googleusercontent.com/rd-gg-dl/example=s0',
     );
     expect(bridge.dataset.downloadIntentExpiresAt).toBeUndefined();
-    expect(bridge.dataset.status).toContain('"type":"SUCCESS"');
+    expect(JSON.parse(bridge.dataset.status ?? '{}')).toMatchObject({
+      type: 'SUCCESS',
+      intentToken: 'intent-1',
+    });
   });
 
   it('uses the watermark pipeline for rd-gg/ URLs (without -dl suffix)', async () => {

--- a/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
@@ -227,6 +227,41 @@ describe('watermarkRemover runtime toggle', () => {
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
   });
 
+  it('processes a replacement source after preview removal is re-enabled', async () => {
+    const activeEngine = createEngine();
+    engineCreate.mockResolvedValue(activeEngine);
+    runtime = await import('../index');
+    const image = createPreviewImage();
+
+    settings.gvWatermarkPreviewEnabled = true;
+    await runtime.startWatermarkRemover();
+    await vi.waitFor(() => expect(image.dataset.watermarkProcessed).toBe('true'));
+
+    const processedSrc = image.src;
+    expect(image.dataset.watermarkOriginalSrc).toBe(
+      'https://lh3.googleusercontent.com/generated=s1024',
+    );
+    expect(image.dataset.processedUrl).toBe('blob:processed-preview');
+
+    settings.gvWatermarkPreviewEnabled = false;
+    await runtime.restartWatermarkRemover();
+
+    expect(image.src).toBe(processedSrc);
+    expect(image.dataset.watermarkProcessed).toBeUndefined();
+    expect(image.dataset.watermarkOriginalSrc).toBeUndefined();
+    expect(image.dataset.processedUrl).toBeUndefined();
+
+    image.src = 'https://lh3.googleusercontent.com/replacement=s1024';
+    settings.gvWatermarkPreviewEnabled = true;
+    await runtime.restartWatermarkRemover();
+
+    await vi.waitFor(() => expect(activeEngine.removeWatermarkFromImage).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(image.dataset.watermarkProcessed).toBe('true'));
+    expect(image.dataset.watermarkOriginalSrc).toBe(
+      'https://lh3.googleusercontent.com/replacement=s1024',
+    );
+  });
+
   it('wires sync watermark setting changes to the current-page restart', () => {
     const contentEntry = readFileSync(
       resolve(process.cwd(), 'src/pages/content/index.tsx'),

--- a/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
@@ -148,6 +148,31 @@ describe('watermarkRemover runtime toggle', () => {
     expect(engineCreate).toHaveBeenCalledTimes(1);
   });
 
+  it('clears delayed download feedback when the runtime stops', async () => {
+    vi.useFakeTimers();
+    try {
+      engineCreate.mockResolvedValue(createEngine());
+      runtime = await import('../index');
+      const button = document.createElement('button');
+      document.body.appendChild(button);
+
+      settings.gvWatermarkDownloadEnabled = true;
+      await runtime.startWatermarkRemover();
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(document.querySelectorAll('.gv-status-toast')).toHaveLength(1);
+
+      settings.gvWatermarkDownloadEnabled = false;
+      await runtime.restartWatermarkRemover();
+
+      expect(document.querySelectorAll('.gv-status-toast')).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(35_000);
+      expect(document.querySelectorAll('.gv-status-toast')).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('prevents a stale async start from restoring an older enabled mode', async () => {
     let resolveEngine: (engine: ReturnType<typeof createEngine>) => void = () => undefined;
     engineCreate.mockReturnValue(

--- a/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
@@ -95,6 +95,9 @@ describe('watermarkRemover runtime toggle', () => {
       },
     );
     vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:processed-preview');
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
+      'data:image/png;base64,cHJvY2Vzc2Vk',
+    );
     vi.mocked(chrome.storage.sync.get).mockImplementation(async () => ({ ...settings }));
   });
 
@@ -166,11 +169,63 @@ describe('watermarkRemover runtime toggle', () => {
       await runtime.restartWatermarkRemover();
 
       expect(document.querySelectorAll('.gv-status-toast')).toHaveLength(0);
+      const bridge = document.getElementById('gv-watermark-bridge') as HTMLElement | null;
+      expect(bridge?.dataset.downloadIntentExpiresAt).toBeUndefined();
+      expect(bridge?.dataset.downloadIntentToken).toBeUndefined();
       await vi.advanceTimersByTimeAsync(35_000);
       expect(document.querySelectorAll('.gv-status-toast')).toHaveLength(0);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('preserves an active download while only preview removal changes', async () => {
+    engineCreate.mockResolvedValue(createEngine());
+    runtime = await import('../index');
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+
+    settings.gvWatermarkDownloadEnabled = true;
+    await runtime.startWatermarkRemover();
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const bridge = document.getElementById('gv-watermark-bridge') as HTMLElement;
+    const intentExpiresAt = bridge.dataset.downloadIntentExpiresAt;
+    const intentToken = bridge.dataset.downloadIntentToken;
+    expect(intentExpiresAt).toBeDefined();
+    expect(intentToken).toBeDefined();
+    expect(document.querySelectorAll('.gv-status-toast')).toHaveLength(1);
+
+    let resolveSettings: (value: Record<string, unknown>) => void = () => undefined;
+    vi.mocked(chrome.storage.sync.get).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSettings = resolve;
+        }),
+    );
+    settings.gvWatermarkPreviewEnabled = true;
+    const restart = runtime.restartWatermarkRemover();
+
+    // The download bridge must remain live while the preview reconfiguration
+    // waits for storage; otherwise a request written in this window times out.
+    bridge.dataset.request = JSON.stringify({
+      requestId: 'request-during-preview-restart',
+      base64: 'data:image/png;base64,b3JpZ2luYWw=',
+    });
+    await vi.waitFor(() =>
+      expect(JSON.parse(bridge.dataset.response ?? '{}')).toMatchObject({
+        requestId: 'request-during-preview-restart',
+        base64: 'data:image/png;base64,cHJvY2Vzc2Vk',
+      }),
+    );
+
+    resolveSettings({ ...settings });
+    await restart;
+
+    expect(bridge.dataset.enabled).toBe('true');
+    expect(bridge.dataset.downloadIntentExpiresAt).toBe(intentExpiresAt);
+    expect(bridge.dataset.downloadIntentToken).toBe(intentToken);
+    expect(document.querySelectorAll('.gv-status-toast')).toHaveLength(1);
   });
 
   it('prevents a stale async start from restoring an older enabled mode', async () => {

--- a/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
@@ -3,9 +3,14 @@ import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const engineCreate = vi.hoisted(() => vi.fn());
+const fetchImageViaExtensionRuntime = vi.hoisted(() => vi.fn());
 
 vi.mock('@/utils/i18n', () => ({
   getTranslationSync: (key: string) => key,
+}));
+
+vi.mock('@/core/utils/runtimeImageFetch', () => ({
+  fetchImageViaExtensionRuntime,
 }));
 
 vi.mock('../downloadButton', () => ({
@@ -29,8 +34,26 @@ const createDownloadHost = (): HTMLElement => {
   return host;
 };
 
+const createPreviewImage = (): HTMLImageElement => {
+  const host = document.createElement('generated-image');
+  const image = document.createElement('img');
+  image.src = 'https://lh3.googleusercontent.com/generated=s1024';
+  host.appendChild(image);
+  document.body.appendChild(host);
+  return image;
+};
+
+const createProcessedCanvas = (): HTMLCanvasElement => {
+  const canvas = document.createElement('canvas');
+  Object.defineProperty(canvas, 'toBlob', {
+    value: (callback: BlobCallback) => callback(new Blob(['processed'], { type: 'image/png' })),
+    configurable: true,
+  });
+  return canvas;
+};
+
 const createEngine = () => ({
-  removeWatermarkFromImage: vi.fn(async () => document.createElement('canvas')),
+  removeWatermarkFromImage: vi.fn(async () => createProcessedCanvas()),
 });
 
 describe('watermarkRemover runtime toggle', () => {
@@ -48,11 +71,37 @@ describe('watermarkRemover runtime toggle', () => {
     };
     runtime = null;
     engineCreate.mockReset();
+    fetchImageViaExtensionRuntime.mockReset();
+    fetchImageViaExtensionRuntime.mockResolvedValue({
+      base64: 'cHJldmlldy1pbWFnZQ==',
+      contentType: 'image/png',
+    });
+    vi.stubGlobal(
+      'Image',
+      class AutoLoadingImage {
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        crossOrigin = '';
+        private currentSrc = '';
+
+        get src(): string {
+          return this.currentSrc;
+        }
+
+        set src(value: string) {
+          this.currentSrc = value;
+          queueMicrotask(() => this.onload?.());
+        }
+      },
+    );
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:processed-preview');
     vi.mocked(chrome.storage.sync.get).mockImplementation(async () => ({ ...settings }));
   });
 
   afterEach(() => {
     runtime?.stopWatermarkRemover();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it('reconfigures the current page and reuses the initialized engine', async () => {
@@ -121,6 +170,61 @@ describe('watermarkRemover runtime toggle', () => {
     const bridge = document.getElementById('gv-watermark-bridge') as HTMLElement | null;
     expect(bridge?.dataset.enabled).toBe('false');
     expect(host.querySelector('.nanobanana-indicator')).toBeNull();
+  });
+
+  it('does not write an in-flight preview result after preview removal is disabled', async () => {
+    let resolveRemoval: (canvas: HTMLCanvasElement) => void = () => undefined;
+    const removeWatermarkFromImage = vi.fn(
+      () =>
+        new Promise<HTMLCanvasElement>((resolveRemovalPromise) => {
+          resolveRemoval = resolveRemovalPromise;
+        }),
+    );
+    engineCreate.mockResolvedValue({ removeWatermarkFromImage });
+    runtime = await import('../index');
+    const image = createPreviewImage();
+    const originalSrc = image.src;
+
+    settings.gvWatermarkPreviewEnabled = true;
+    await runtime.startWatermarkRemover();
+    await vi.waitFor(() => expect(removeWatermarkFromImage).toHaveBeenCalledTimes(1));
+
+    settings.gvWatermarkPreviewEnabled = false;
+    await runtime.restartWatermarkRemover();
+    resolveRemoval(createProcessedCanvas());
+
+    await vi.waitFor(() => expect(image.dataset.watermarkProcessed).toBeUndefined());
+    expect(image.src).toBe(originalSrc);
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('retries stale preview work when the latest lifecycle still enables previews', async () => {
+    let resolveFirstRemoval: (canvas: HTMLCanvasElement) => void = () => undefined;
+    const removeWatermarkFromImage = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<HTMLCanvasElement>((resolveRemovalPromise) => {
+            resolveFirstRemoval = resolveRemovalPromise;
+          }),
+      )
+      .mockResolvedValue(createProcessedCanvas());
+    engineCreate.mockResolvedValue({ removeWatermarkFromImage });
+    runtime = await import('../index');
+    const image = createPreviewImage();
+
+    settings.gvWatermarkPreviewEnabled = true;
+    await runtime.startWatermarkRemover();
+    await vi.waitFor(() => expect(removeWatermarkFromImage).toHaveBeenCalledTimes(1));
+
+    settings.gvWatermarkDownloadEnabled = true;
+    await runtime.restartWatermarkRemover();
+    resolveFirstRemoval(createProcessedCanvas());
+
+    await vi.waitFor(() => expect(removeWatermarkFromImage).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(image.dataset.watermarkProcessed).toBe('true'));
+    expect(image.src).toBe('blob:processed-preview');
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
   });
 
   it('wires sync watermark setting changes to the current-page restart', () => {

--- a/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const engineCreate = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/i18n', () => ({
+  getTranslationSync: (key: string) => key,
+}));
+
+vi.mock('../downloadButton', () => ({
+  DOWNLOAD_ICON_SELECTOR: '.gv-test-download-icon',
+  findNativeDownloadButton: (target: unknown) =>
+    target instanceof HTMLButtonElement ? target : null,
+}));
+
+vi.mock('../watermarkEngine', () => ({
+  WatermarkEngine: {
+    create: engineCreate,
+  },
+}));
+
+type WatermarkRuntime = typeof import('../index');
+
+const createDownloadHost = (): HTMLElement => {
+  const host = document.createElement('download-generated-image-button');
+  host.appendChild(document.createElement('button'));
+  document.body.appendChild(host);
+  return host;
+};
+
+const createEngine = () => ({
+  removeWatermarkFromImage: vi.fn(async () => document.createElement('canvas')),
+});
+
+describe('watermarkRemover runtime toggle', () => {
+  let settings: Record<string, unknown>;
+  let runtime: WatermarkRuntime | null;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    settings = {
+      gvWatermarkDownloadEnabled: false,
+      gvWatermarkPreviewEnabled: false,
+    };
+    runtime = null;
+    engineCreate.mockReset();
+    vi.mocked(chrome.storage.sync.get).mockImplementation(async () => ({ ...settings }));
+  });
+
+  afterEach(() => {
+    runtime?.stopWatermarkRemover();
+  });
+
+  it('reconfigures the current page and reuses the initialized engine', async () => {
+    engineCreate.mockResolvedValue(createEngine());
+    runtime = await import('../index');
+    const host = createDownloadHost();
+
+    await runtime.startWatermarkRemover();
+    expect(engineCreate).not.toHaveBeenCalled();
+
+    settings.gvWatermarkPreviewEnabled = true;
+    await runtime.restartWatermarkRemover();
+
+    const bridge = document.getElementById('gv-watermark-bridge') as HTMLElement | null;
+    expect(bridge?.dataset.enabled).toBe('false');
+    expect(host.querySelector('.nanobanana-indicator')).toBeNull();
+    expect(engineCreate).toHaveBeenCalledTimes(1);
+
+    settings.gvWatermarkPreviewEnabled = false;
+    await runtime.restartWatermarkRemover();
+
+    settings.gvWatermarkDownloadEnabled = true;
+    await runtime.restartWatermarkRemover();
+
+    expect(bridge?.dataset.enabled).toBe('true');
+    expect(host.querySelector('.nanobanana-indicator')).not.toBeNull();
+    expect(engineCreate).toHaveBeenCalledTimes(1);
+
+    if (bridge) {
+      bridge.dataset.downloadIntentExpiresAt = String(Date.now() + 60_000);
+    }
+    settings.gvWatermarkDownloadEnabled = false;
+    await runtime.restartWatermarkRemover();
+
+    expect(bridge?.dataset.enabled).toBe('false');
+    expect(bridge?.dataset.downloadIntentExpiresAt).toBeUndefined();
+    expect(host.querySelector('.nanobanana-indicator')).toBeNull();
+
+    settings.gvWatermarkDownloadEnabled = true;
+    await runtime.restartWatermarkRemover();
+
+    expect(bridge?.dataset.enabled).toBe('true');
+    expect(host.querySelector('.nanobanana-indicator')).not.toBeNull();
+    expect(engineCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('prevents a stale async start from restoring an older enabled mode', async () => {
+    let resolveEngine: (engine: ReturnType<typeof createEngine>) => void = () => undefined;
+    engineCreate.mockReturnValue(
+      new Promise<ReturnType<typeof createEngine>>((resolveEnginePromise) => {
+        resolveEngine = resolveEnginePromise;
+      }),
+    );
+    runtime = await import('../index');
+    const host = createDownloadHost();
+
+    settings.gvWatermarkDownloadEnabled = true;
+    const staleStart = runtime.startWatermarkRemover();
+    await vi.waitFor(() => expect(engineCreate).toHaveBeenCalledTimes(1));
+
+    settings.gvWatermarkDownloadEnabled = false;
+    await runtime.restartWatermarkRemover();
+    resolveEngine(createEngine());
+    await staleStart;
+
+    const bridge = document.getElementById('gv-watermark-bridge') as HTMLElement | null;
+    expect(bridge?.dataset.enabled).toBe('false');
+    expect(host.querySelector('.nanobanana-indicator')).toBeNull();
+  });
+
+  it('wires sync watermark setting changes to the current-page restart', () => {
+    const contentEntry = readFileSync(
+      resolve(process.cwd(), 'src/pages/content/index.tsx'),
+      'utf8',
+    );
+
+    expect(contentEntry).toContain('WATERMARK_STORAGE_KEYS.some');
+    expect(contentEntry).toContain('void restartWatermarkRemover();');
+  });
+});

--- a/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
+++ b/src/pages/content/watermarkRemover/__tests__/runtimeToggle.test.ts
@@ -234,6 +234,11 @@ describe('watermarkRemover runtime toggle', () => {
     );
 
     expect(contentEntry).toContain('WATERMARK_STORAGE_KEYS.some');
-    expect(contentEntry).toContain('void restartWatermarkRemover();');
+    expect(contentEntry).toMatch(
+      /watermarkRemoverStarted = true;\s+void startWatermarkRemover\(\);/,
+    );
+    expect(contentEntry).toMatch(
+      /watermarkRemoverStarted &&\s+areaName === 'sync'[\s\S]*?void restartWatermarkRemover\(\);/,
+    );
   });
 });

--- a/src/pages/content/watermarkRemover/index.ts
+++ b/src/pages/content/watermarkRemover/index.ts
@@ -110,6 +110,24 @@ const findGeminiImages = (): HTMLImageElement[] =>
   );
 
 /**
+ * Clear preview bookkeeping without restoring the current image source.
+ * Gemini can reuse an existing <img> for a later generated image, so stale
+ * processed markers must not prevent the replacement source from being handled
+ * after preview removal is re-enabled.
+ */
+const clearPreviewImageState = (): void => {
+  document
+    .querySelectorAll<HTMLImageElement>(
+      'img[data-watermark-processed], img[data-watermark-original-src]',
+    )
+    .forEach((img) => {
+      delete img.dataset.watermarkProcessed;
+      delete img.dataset.watermarkOriginalSrc;
+      delete img.dataset.processedUrl;
+    });
+};
+
+/**
  * Replace image URL size parameter to get full resolution
  */
 const replaceWithNormalSize = (src: string): string => {
@@ -503,6 +521,7 @@ export function stopWatermarkRemover(): void {
   statusObserver = null;
   for (const timeout of pendingDebounceTimeouts) clearTimeout(timeout);
   pendingDebounceTimeouts.clear();
+  clearPreviewImageState();
 
   // Tell the MAIN-world fetch interceptor the feature is off, so it stops
   // intercepting and doesn't wait on bridge responses that will never come.

--- a/src/pages/content/watermarkRemover/index.ts
+++ b/src/pages/content/watermarkRemover/index.ts
@@ -522,6 +522,7 @@ export function stopWatermarkRemover(): void {
   for (const timeout of pendingDebounceTimeouts) clearTimeout(timeout);
   pendingDebounceTimeouts.clear();
   clearPreviewImageState();
+  clearActiveDownloadSequence();
 
   // Tell the MAIN-world fetch interceptor the feature is off, so it stops
   // intercepting and doesn't wait on bridge responses that will never come.
@@ -567,6 +568,26 @@ type DownloadToastSequence = {
 };
 
 let activeSequence: DownloadToastSequence | null = null;
+
+function clearActiveDownloadSequence(): void {
+  if (!activeSequence) return;
+
+  if (activeSequence.processingTimer) {
+    clearTimeout(activeSequence.processingTimer);
+  }
+
+  if (statusToastManager) {
+    for (const toastId of [
+      activeSequence.downloadToastId,
+      activeSequence.warningToastId,
+      activeSequence.processingToastId,
+    ]) {
+      if (toastId) statusToastManager.removeToast(toastId);
+    }
+  }
+
+  activeSequence = null;
+}
 
 const getStatusToastManager = (): StatusToastManager => {
   if (!statusToastManager) {

--- a/src/pages/content/watermarkRemover/index.ts
+++ b/src/pages/content/watermarkRemover/index.ts
@@ -418,9 +418,12 @@ async function processImageRequest(
 }
 
 /**
- * Start the watermark remover
+ * Read the latest settings and configure the watermark runtime.
+ * Reconfiguration tears down preview work every time, but keeps an unchanged
+ * download runtime alive so an in-flight native download cannot lose its
+ * bridge request, intent, or feedback sequence.
  */
-export async function startWatermarkRemover(): Promise<void> {
+async function configureWatermarkRemover(reconfigure: boolean): Promise<void> {
   const generation = ++lifecycleGeneration;
 
   try {
@@ -433,6 +436,10 @@ export async function startWatermarkRemover(): Promise<void> {
       result ?? null,
     );
     if (generation !== lifecycleGeneration) return;
+
+    if (reconfigure) {
+      teardownWatermarkRemover(downloadRemovalEnabled && downloadEnabled);
+    }
 
     downloadRemovalEnabled = downloadEnabled;
     previewRemovalEnabled = previewEnabled;
@@ -491,37 +498,46 @@ export async function startWatermarkRemover(): Promise<void> {
 }
 
 /**
- * Re-read storage and apply the latest watermark mode to the current page.
- * The generation guard in startWatermarkRemover makes rapid restarts
- * latest-wins even while the engine is still loading.
+ * Start the watermark remover.
  */
-export async function restartWatermarkRemover(): Promise<void> {
-  stopWatermarkRemover();
-  await startWatermarkRemover();
+export function startWatermarkRemover(): Promise<void> {
+  return configureWatermarkRemover(false);
 }
 
 /**
- * Fully tear down the watermark remover. Safe to call when nothing was started.
- * Wired into the content-script beforeunload teardown so the two document.body
- * subtree observers don't outlive the page; also written to be a complete stop
- * (observers + MAIN-world interceptor + document listeners) so it can be reused
- * for SPA teardown/restart without leaving the interceptor thinking it's enabled.
+ * Re-read storage and apply the latest watermark mode to the current page.
+ * The shared generation guard makes rapid restarts
+ * latest-wins even while the engine is still loading.
  */
-export function stopWatermarkRemover(): void {
-  lifecycleGeneration += 1;
-  downloadRemovalEnabled = false;
+export async function restartWatermarkRemover(): Promise<void> {
+  await configureWatermarkRemover(true);
+}
+
+/**
+ * Tear down preview work and, unless it is unchanged and still enabled, the
+ * download runtime. Keeping download state is what makes preview-only toggles
+ * safe while a native download is already in progress.
+ */
+function teardownWatermarkRemover(preserveDownloadRuntime: boolean): void {
+  const keepDownloadRuntime = preserveDownloadRuntime && downloadRemovalEnabled;
   previewRemovalEnabled = false;
 
-  for (const observer of [previewObserver, indicatorObserver, bridgeObserver, statusObserver]) {
+  for (const observer of [previewObserver, indicatorObserver]) {
     observer?.disconnect();
   }
   previewObserver = null;
   indicatorObserver = null;
-  bridgeObserver = null;
-  statusObserver = null;
   for (const timeout of pendingDebounceTimeouts) clearTimeout(timeout);
   pendingDebounceTimeouts.clear();
   clearPreviewImageState();
+
+  if (keepDownloadRuntime) return;
+
+  downloadRemovalEnabled = false;
+  bridgeObserver?.disconnect();
+  statusObserver?.disconnect();
+  bridgeObserver = null;
+  statusObserver = null;
   clearActiveDownloadSequence();
 
   // Tell the MAIN-world fetch interceptor the feature is off, so it stops
@@ -532,6 +548,7 @@ export function stopWatermarkRemover(): void {
   if (existingBridge) {
     existingBridge.dataset.enabled = 'false';
     existingBridge.removeAttribute('data-download-intent-expires-at');
+    existingBridge.removeAttribute('data-download-intent-token');
   }
 
   document
@@ -545,6 +562,16 @@ export function stopWatermarkRemover(): void {
     downloadCaptureHandler = null;
   }
   downloadTrackingReady = false;
+}
+
+/**
+ * Fully tear down the watermark remover. Safe to call when nothing was started.
+ * Wired into the content-script beforeunload teardown so document observers,
+ * the MAIN-world bridge, and global listeners cannot outlive the page.
+ */
+export function stopWatermarkRemover(): void {
+  lifecycleGeneration += 1;
+  teardownWatermarkRemover(false);
 }
 
 let statusToastManager: StatusToastManager | null = null;
@@ -561,6 +588,7 @@ const DOWNLOAD_INTENT_TTL_MS = 60000;
 
 type DownloadToastSequence = {
   id: number;
+  token: string;
   downloadToastId: string | null;
   warningToastId: string | null;
   processingToastId: string | null;
@@ -601,16 +629,18 @@ const t = (key: TranslationKey, fallback: string): string => {
   return value === key ? fallback : value;
 };
 
-function markDownloadIntent(): void {
+function markDownloadIntent(token: string): void {
   const bridge = getBridgeElement();
   bridge.dataset.downloadIntentExpiresAt = String(Date.now() + DOWNLOAD_INTENT_TTL_MS);
+  bridge.dataset.downloadIntentToken = token;
 }
 
 function showImmediateDownloadToast(button: HTMLButtonElement): void {
-  markDownloadIntent();
-
   const now = Date.now();
-  if (now - lastImmediateToastAt < 300) return;
+  if (now - lastImmediateToastAt < 300 && activeSequence) {
+    markDownloadIntent(activeSequence.token);
+    return;
+  }
   lastImmediateToastAt = now;
 
   const manager = getStatusToastManager();
@@ -624,6 +654,8 @@ function showImmediateDownloadToast(button: HTMLButtonElement): void {
   }
 
   const sequenceId = ++sequenceCounter;
+  const token = `gv_download_${now}_${sequenceId}`;
+  markDownloadIntent(token);
   const downloadToastId = manager.addToast(downloadMessage, 'info', {
     pending: true,
     autoDismissMs: 3000,
@@ -645,6 +677,7 @@ function showImmediateDownloadToast(button: HTMLButtonElement): void {
 
   activeSequence = {
     id: sequenceId,
+    token,
     downloadToastId,
     warningToastId: null,
     processingToastId: null,
@@ -722,8 +755,9 @@ function setupStatusListener(): void {
     if (!statusData) return;
 
     try {
-      const { type, message } = JSON.parse(statusData);
+      const { type, message, intentToken } = JSON.parse(statusData);
       bridge.removeAttribute('data-status');
+      if (!activeSequence || intentToken !== activeSequence.token) return;
 
       switch (type) {
         case 'DOWNLOADING':

--- a/src/pages/content/watermarkRemover/index.ts
+++ b/src/pages/content/watermarkRemover/index.ts
@@ -27,6 +27,8 @@ import { WatermarkEngine } from './watermarkEngine';
 let engine: WatermarkEngine | null = null;
 let enginePromise: Promise<WatermarkEngine> | null = null;
 const processingQueue = new Set<HTMLImageElement>();
+let lifecycleGeneration = 0;
+let downloadRemovalEnabled = false;
 
 // Observers are kept at module scope so they can be disconnected on teardown
 // and so re-running startWatermarkRemover() can't stack duplicate observers.
@@ -195,8 +197,9 @@ async function processImage(imgElement: HTMLImageElement): Promise<void> {
 
     console.log('[Gemini Voyager] Watermark removed from preview image');
 
-    // Add indicator to download button
-    addDownloadIndicator(imgElement);
+    if (downloadRemovalEnabled) {
+      addDownloadIndicator(imgElement);
+    }
   } catch (error) {
     console.warn('[Gemini Voyager] Failed to process image for watermark removal:', error);
     imgElement.dataset.watermarkProcessed = 'failed';
@@ -212,9 +215,11 @@ const processAllImages = (): void => {
   const images = findGeminiImages();
   images.forEach(processImage);
 
-  // Always re-run the indicator pass so blob-src previews and late-loading
-  // native buttons still pick up the 🍌 badge (idempotent).
-  decorateDownloadButtons();
+  if (downloadRemovalEnabled) {
+    // Re-run the indicator pass so blob-src previews and late-loading native
+    // buttons still pick up the 🍌 badge (idempotent).
+    decorateDownloadButtons();
+  }
 };
 
 /**
@@ -375,6 +380,8 @@ async function processImageRequest(
  * Start the watermark remover
  */
 export async function startWatermarkRemover(): Promise<void> {
+  const generation = ++lifecycleGeneration;
+
   try {
     // Initialize bridge element first (so it exists when fetch interceptor loads)
     getBridgeElement();
@@ -384,6 +391,9 @@ export async function startWatermarkRemover(): Promise<void> {
     const { download: downloadEnabled, preview: previewEnabled } = resolveWatermarkSettings(
       result ?? null,
     );
+    if (generation !== lifecycleGeneration) return;
+
+    downloadRemovalEnabled = downloadEnabled;
     notifyFetchInterceptor(downloadEnabled);
 
     if (!downloadEnabled && !previewEnabled) {
@@ -391,16 +401,15 @@ export async function startWatermarkRemover(): Promise<void> {
       return;
     }
 
-    // Setup status listener for UI feedback ASAP (avoid missing early signals).
-    // Both paths benefit from the toast/status pipeline when downloads happen.
-    setupStatusListener();
-    setupDownloadButtonTracking();
-
     console.log(
       `[Gemini Voyager] Initializing watermark remover (download=${downloadEnabled}, preview=${previewEnabled})`,
     );
 
     if (downloadEnabled) {
+      // Setup download feedback and intent tracking only for the download path.
+      setupStatusListener();
+      setupDownloadButtonTracking();
+
       // Install the bridge observer BEFORE awaiting engine init so requests
       // that arrive during the asset-loading window (typically 100ms-2s, and
       // larger after a hard navigation like an account switch) are not lost.
@@ -408,8 +417,12 @@ export async function startWatermarkRemover(): Promise<void> {
       setupFetchInterceptorBridge();
     }
 
-    enginePromise = WatermarkEngine.create();
-    engine = await enginePromise;
+    if (!enginePromise) {
+      enginePromise = WatermarkEngine.create();
+    }
+    const initializedEngine = engine ?? (await enginePromise);
+    if (generation !== lifecycleGeneration) return;
+    engine = initializedEngine;
 
     if (previewEnabled) {
       // Heavy path: replace each image's src with a watermark-stripped blob.
@@ -426,11 +439,23 @@ export async function startWatermarkRemover(): Promise<void> {
 
     console.log('[Gemini Voyager] Watermark remover ready');
   } catch (error) {
+    if (!engine) enginePromise = null;
+    if (generation !== lifecycleGeneration) return;
     if (isExtensionContextInvalidatedError(error)) {
       return;
     }
     console.error('[Gemini Voyager] Watermark remover initialization failed:', error);
   }
+}
+
+/**
+ * Re-read storage and apply the latest watermark mode to the current page.
+ * The generation guard in startWatermarkRemover makes rapid restarts
+ * latest-wins even while the engine is still loading.
+ */
+export async function restartWatermarkRemover(): Promise<void> {
+  stopWatermarkRemover();
+  await startWatermarkRemover();
 }
 
 /**
@@ -441,6 +466,9 @@ export async function startWatermarkRemover(): Promise<void> {
  * for SPA teardown/restart without leaving the interceptor thinking it's enabled.
  */
 export function stopWatermarkRemover(): void {
+  lifecycleGeneration += 1;
+  downloadRemovalEnabled = false;
+
   for (const observer of [previewObserver, indicatorObserver, bridgeObserver, statusObserver]) {
     observer?.disconnect();
   }
@@ -458,7 +486,12 @@ export function stopWatermarkRemover(): void {
   const existingBridge = document.getElementById(GV_BRIDGE_ID);
   if (existingBridge) {
     existingBridge.dataset.enabled = 'false';
+    existingBridge.removeAttribute('data-download-intent-expires-at');
   }
+
+  document
+    .querySelectorAll<HTMLElement>('.nanobanana-indicator')
+    .forEach((indicator) => indicator.remove());
 
   // Remove the global download-button tracking listeners.
   if (downloadCaptureHandler) {

--- a/src/pages/content/watermarkRemover/index.ts
+++ b/src/pages/content/watermarkRemover/index.ts
@@ -29,6 +29,7 @@ let enginePromise: Promise<WatermarkEngine> | null = null;
 const processingQueue = new Set<HTMLImageElement>();
 let lifecycleGeneration = 0;
 let downloadRemovalEnabled = false;
+let previewRemovalEnabled = false;
 
 // Observers are kept at module scope so they can be disconnected on teardown
 // and so re-running startWatermarkRemover() can't stack duplicate observers.
@@ -175,6 +176,13 @@ function addDownloadIndicator(imgElement: HTMLImageElement): void {
 async function processImage(imgElement: HTMLImageElement): Promise<void> {
   if (!engine || processingQueue.has(imgElement)) return;
 
+  const generation = lifecycleGeneration;
+  let stale = false;
+  const isStale = (): boolean => {
+    stale = generation !== lifecycleGeneration || !previewRemovalEnabled;
+    return stale;
+  };
+
   processingQueue.add(imgElement);
   imgElement.dataset.watermarkProcessed = 'processing';
 
@@ -183,10 +191,13 @@ async function processImage(imgElement: HTMLImageElement): Promise<void> {
     // Fetch full resolution image via background script (bypasses CORS)
     const normalSizeSrc = replaceWithNormalSize(originalSrc);
     const normalSizeImg = await fetchImageViaBackground(normalSizeSrc);
+    if (isStale()) return;
 
     // Process image to remove watermark
     const processedCanvas = await engine.removeWatermarkFromImage(normalSizeImg);
+    if (isStale()) return;
     const processedBlob = await canvasToBlob(processedCanvas);
+    if (isStale()) return;
 
     // Replace image source with processed blob URL
     const processedUrl = URL.createObjectURL(processedBlob);
@@ -201,10 +212,22 @@ async function processImage(imgElement: HTMLImageElement): Promise<void> {
       addDownloadIndicator(imgElement);
     }
   } catch (error) {
+    if (isStale()) return;
     console.warn('[Gemini Voyager] Failed to process image for watermark removal:', error);
     imgElement.dataset.watermarkProcessed = 'failed';
   } finally {
     processingQueue.delete(imgElement);
+    if (stale) {
+      if (imgElement.dataset.watermarkProcessed === 'processing') {
+        delete imgElement.dataset.watermarkProcessed;
+      }
+      // A full restart can invalidate this task while leaving preview removal
+      // enabled (for example, when only the download toggle changed). Retry
+      // after releasing the queue slot so the latest lifecycle owns the write.
+      if (previewRemovalEnabled && imgElement.isConnected && isValidGeminiImage(imgElement)) {
+        void processImage(imgElement);
+      }
+    }
   }
 }
 
@@ -394,6 +417,7 @@ export async function startWatermarkRemover(): Promise<void> {
     if (generation !== lifecycleGeneration) return;
 
     downloadRemovalEnabled = downloadEnabled;
+    previewRemovalEnabled = previewEnabled;
     notifyFetchInterceptor(downloadEnabled);
 
     if (!downloadEnabled && !previewEnabled) {
@@ -468,6 +492,7 @@ export async function restartWatermarkRemover(): Promise<void> {
 export function stopWatermarkRemover(): void {
   lifecycleGeneration += 1;
   downloadRemovalEnabled = false;
+  previewRemovalEnabled = false;
 
   for (const observer of [previewObserver, indicatorObserver, bridgeObserver, statusObserver]) {
     observer?.disconnect();


### PR DESCRIPTION
### Description / 描述

Fixes watermark-removal setting changes not taking effect in already-open Gemini tabs until the page is refreshed.

This PR:

- routes watermark setting changes through the existing content-script storage listener;
- reconfigures preview and download lifecycles independently, preserving active downloads when only preview removal changes;
- reuses the initialized watermark engine instead of reloading templates;
- uses a lifecycle generation to prevent stale asynchronous initialization from restoring an older setting;
- injects the guarded MAIN-world download interceptor into already-open matching tabs when download removal is enabled;
- clears download intent state and indicators only when download removal is actually disabled;
- tags download intent and status messages so a late result cannot finalize a newer download sequence;
- adds focused regression tests and a regression note.

The implementation does not add another persistent storage listener. Open-tab injection only runs when the watermark settings change.

Non-goals:

- Already processed preview images are not restored when preview removal is disabled.
- This PR does not address the separate pre-existing issue where preview watermark removal currently has no visible effect. That behavior was reproduced on both `main` and this branch in Chrome and Firefox.

### Related Issue / 相关 Issue

Fixes #872

- [ ] If the issue is labeled `community-only`, I was assigned after maintainer approval before starting. / 如果 Issue 带有 `community-only` 标签，我已在开始前获得维护者确认并被分配。

### Visual Proof / 可视化证据

https://github.com/user-attachments/assets/cfd9a784-82f1-4d20-aff9-eaa90c2de277

A recording demonstrates download watermark removal being toggled:

```text
off → on → off → on
```

in the same already-open Gemini tab without reloading the page. The download indicator and downloaded watermark result follow the latest setting.

### Browser Testing / 浏览器测试

Automated final head / 自动化最终提交: `040ddb3e6e749753c46316dfede65269024c1545`

Live browser workflow commit / 浏览器实测提交: `04470cd9473119d4e06b7bebfac08b5e943929dd`

| Browser / version | Scenario and result / 场景与结果 | Evidence / 证据 |
| ----------------- | -------------------------------- | --------------- |
| Chrome 150.0.7871.187 | Loaded the development extension and toggled download watermark removal off → on → off → on in the same Gemini tab without reloading. The indicator and downloaded image followed the latest setting. No page or service-worker console errors. PASS. | See the screen recording in [Visual Proof](#visual-proof--可视化证据). |
| Firefox 153.0 | Loaded the extension and repeated the download toggle workflow in the same Gemini tab without reloading. The downloaded image followed the latest setting. No console errors. PASS. | Manually verified; no separate recording. |
| Automated final head | Typecheck and lint passed; all 2,358 tests passed; Chrome and Safari production builds passed, including Safari resource-wiring verification. | Local verification on `040ddb3e`. |

Missing checks and owner, or N/A reason / 缺失检查与负责人，或不适用理由:

- Safari Live verification remains pending because loading the temporary extension requires local macOS authentication; Safari build and resource wiring passed on the final head.
- Preview watermark removal could not be Live-verified because it currently had no visible effect on either `main` or this branch in both Chrome and Firefox. This appears to be a separate pre-existing issue.

Commands not run and reason / 未运行命令及原因:

- None for the standard local automation suite.

### Checklist / 检查清单

- [x] If I used an agent, I discussed the requirement, affected scope, and verification plan clearly. / 如果使用了 Agent，我已讨论清楚需求、影响范围和验证方式。
- [x] I have manually verified the download-removal runtime toggle in Chrome and Firefox. / 我已在 Chrome 和 Firefox 中手动验证下载去水印的实时切换。
- [x] This PR focuses on one issue or one coherent change. / 此 PR 只聚焦一个问题或一个清晰完整的改动。
- [x] I ran `bun run format`, `bun run lint`, then the standard local `bun run verify:pr`. / 我已依次运行格式化、自动修复及标准本地验证。
- [x] I added regression tests for the behavior changes. / 行为改动已添加回归测试。
- [x] I listed the browsers actually tested and identified pending verification. / 我已列出实际测试的浏览器及待完成的验证。
- [x] I have included visual proof after verification. / 我已提供验证后的可视化证据。
