### PR TITLE
feat(popup): remember settings scroll position

### DIFF
--- a/src/core/services/SettingsBackupService.ts
+++ b/src/core/services/SettingsBackupService.ts
@@ -356,6 +356,11 @@ export const NON_SETTINGS_BACKUP_POLICIES = {
     reason:
       'Gemini response-id aliases are bounded, device-local, and rebuilt from conversation history.',
   },
+  [StorageKeys.GV_POPUP_SCROLL_TOP]: {
+    storage: 'local',
+    disposition: 'device-local',
+    reason: 'Popup scroll position is specific to this device and viewport.',
+  },
   [StorageKeys.FOLDER_PROJECT_PENDING_FOLDER_ID]: {
     storage: 'local',
     disposition: 'transient',

--- a/src/core/services/__tests__/SettingsBackupService.test.ts
+++ b/src/core/services/__tests__/SettingsBackupService.test.ts
@@ -38,6 +38,17 @@ describe('SettingsBackupService', () => {
     );
   });
 
+  it('keeps popup scroll position device-local and outside settings backup', () => {
+    const popupScrollKey = 'gvPopupScrollTop';
+
+    expect(BACKUPABLE_SYNC_SETTINGS_DEFAULTS).not.toHaveProperty(popupScrollKey);
+    expect(NON_SETTINGS_BACKUP_POLICIES).toHaveProperty(popupScrollKey, {
+      storage: 'local',
+      disposition: 'device-local',
+      reason: 'Popup scroll position is specific to this device and viewport.',
+    });
+  });
+
   it('exports only backupable sync settings with defaults applied', async () => {
     const storageArea = {
       get: vi.fn().mockResolvedValue({

--- a/src/core/types/common.ts
+++ b/src/core/types/common.ts
@@ -269,6 +269,8 @@ export const StorageKeys = {
 
   // Popup section order
   GV_POPUP_SECTION_ORDER: 'gvPopupSectionOrder',
+  // Device-local vertical position for the popup's full main settings view.
+  GV_POPUP_SCROLL_TOP: 'gvPopupScrollTop',
 
   // Context sync
   CONTEXT_SYNC_ENABLED: 'contextSyncEnabled',

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -90,6 +90,7 @@ import {
   IconQwen,
 } from './components/WebsiteLogos';
 import WidthSlider from './components/WidthSlider';
+import { usePopupScrollRestoration } from './hooks/usePopupScrollRestoration';
 import { type SettingsSearchItem, getSettingsSearchMatches } from './utils/settingsSearch';
 
 /**
@@ -2396,6 +2397,12 @@ export default function Popup({ sourceTabId }: PopupProps = {}) {
 
   const visibleSections = sectionOrder.filter(isSectionVisible);
   const hasSettingsSearch = settingsSearchQuery.trim().length > 0;
+  usePopupScrollRestoration({
+    hasSettingsSearch,
+    isPluginSite,
+    showStarredHistory,
+    showStorageManager,
+  });
   const settingsSearchMatches = useMemo(
     () => getSettingsSearchMatches(POPUP_SETTINGS_SEARCH_ITEMS, settingsSearchQuery),
     [settingsSearchQuery],

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -1036,6 +1036,7 @@ export default function Popup({ sourceTabId }: PopupProps = {}) {
     useState<boolean>(true);
   const [activeAccountPlatform, setActiveAccountPlatform] = useState<AccountPlatform>('gemini');
   const [activeUrl, setActiveUrl] = useState<string>('');
+  const [activeTabContextLoaded, setActiveTabContextLoaded] = useState(false);
   const [pluginManifests, setPluginManifests] = useState<readonly PluginManifest[]>([]);
   const [pluginSourceIds, setPluginSourceIds] = useState<Readonly<Record<string, string>>>({});
   const [pluginState, setPluginState] = useState<PluginStateMap>({});
@@ -1210,7 +1211,11 @@ export default function Popup({ sourceTabId }: PopupProps = {}) {
       const url = tab?.url || '';
       setActiveUrl(url);
       setActiveAccountPlatform(detectAccountPlatformFromUrl(url));
-    } catch {}
+    } catch {
+      // Keep the default empty URL when the tab cannot be inspected.
+    } finally {
+      setActiveTabContextLoaded(true);
+    }
   }, [sourceTabId]);
 
   useEffect(() => {
@@ -2398,6 +2403,7 @@ export default function Popup({ sourceTabId }: PopupProps = {}) {
   const visibleSections = sectionOrder.filter(isSectionVisible);
   const hasSettingsSearch = settingsSearchQuery.trim().length > 0;
   usePopupScrollRestoration({
+    activeTabContextLoaded,
     hasSettingsSearch,
     isPluginSite,
     showStarredHistory,

--- a/src/pages/popup/hooks/__tests__/usePopupScrollRestoration.test.tsx
+++ b/src/pages/popup/hooks/__tests__/usePopupScrollRestoration.test.tsx
@@ -26,6 +26,7 @@ vi.mock('webextension-polyfill', () => ({
 }));
 
 const MAIN_VIEW: PopupScrollViewState = {
+  activeTabContextLoaded: true,
   hasSettingsSearch: false,
   isPluginSite: false,
   showStarredHistory: false,
@@ -133,6 +134,9 @@ describe('usePopupScrollRestoration', () => {
 
   it('tracks only the full main settings view', () => {
     expect(shouldTrackPopupSettingsScroll(MAIN_VIEW)).toBe(true);
+    expect(shouldTrackPopupSettingsScroll({ ...MAIN_VIEW, activeTabContextLoaded: false })).toBe(
+      false,
+    );
     expect(shouldTrackPopupSettingsScroll({ ...MAIN_VIEW, hasSettingsSearch: true })).toBe(false);
     expect(shouldTrackPopupSettingsScroll({ ...MAIN_VIEW, showStorageManager: true })).toBe(false);
     expect(shouldTrackPopupSettingsScroll({ ...MAIN_VIEW, showStarredHistory: true })).toBe(false);
@@ -246,15 +250,19 @@ describe('usePopupScrollRestoration', () => {
     expect(container.scrollTop).toBe(1400);
   });
 
-  it('persists the final clamp when the stored target stays outside the settled layout', async () => {
+  it('keeps retrying an oversized target when layout growth happens after two seconds', async () => {
     storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 5000 });
 
     await renderState(MAIN_VIEW);
     storageSet.mockClear();
-    act(() => vi.advanceTimersByTime(2000));
+    act(() => vi.advanceTimersByTime(5000));
 
-    expect(storageSet).toHaveBeenCalledOnce();
-    expect(storageSet).toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 1400 });
+    expect(storageSet).not.toHaveBeenCalled();
+
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 5600 });
+    act(() => resizeObserverCallback?.([], {} as ResizeObserver));
+
+    expect(container.scrollTop).toBe(5000);
   });
 
   it('falls back to the top when local storage cannot be read', async () => {
@@ -361,10 +369,11 @@ describe('usePopupScrollRestoration', () => {
       container.dispatchEvent(new Event('scroll'));
     });
     await renderState({ ...MAIN_VIEW, hasSettingsSearch: true });
+    expect(container.scrollTop).toBe(0);
     storageSet.mockClear();
 
     act(() => {
-      container.scrollTop = 0;
+      container.scrollTop = 100;
       container.dispatchEvent(new Event('scroll'));
       vi.advanceTimersByTime(150);
     });
@@ -372,6 +381,47 @@ describe('usePopupScrollRestoration', () => {
 
     await renderState(MAIN_VIEW);
     expect(container.scrollTop).toBe(620);
+  });
+
+  it('waits for active tab context and opens plugin views at the top', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 420 });
+    container.scrollTop = 300;
+
+    await renderState({ ...MAIN_VIEW, activeTabContextLoaded: false });
+    expect(container.scrollTop).toBe(0);
+
+    container.scrollTop = 300;
+    await renderState({ ...MAIN_VIEW, isPluginSite: true });
+    expect(container.scrollTop).toBe(0);
+
+    await renderState(MAIN_VIEW);
+    expect(container.scrollTop).toBe(420);
+  });
+
+  it('does not overwrite scrolling that happens before local storage finishes loading', async () => {
+    let resolveStorageGet: ((value: Record<string, number>) => void) | undefined;
+    storageGet.mockReturnValue(
+      new Promise<Record<string, number>>((resolve) => {
+        resolveStorageGet = resolve;
+      }),
+    );
+
+    await renderState(MAIN_VIEW);
+    act(() => {
+      container.scrollTop = 300;
+      container.dispatchEvent(new Event('scroll'));
+    });
+
+    await act(async () => {
+      resolveStorageGet?.({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 900 });
+      await Promise.resolve();
+    });
+    flushAnimationFrame();
+
+    expect(container.scrollTop).toBe(300);
+    storageSet.mockClear();
+    act(() => window.dispatchEvent(new Event('pagehide')));
+    expect(storageSet).toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 300 });
   });
 
   it('ignores a layout clamp while a temporary view commits', async () => {

--- a/src/pages/popup/hooks/__tests__/usePopupScrollRestoration.test.tsx
+++ b/src/pages/popup/hooks/__tests__/usePopupScrollRestoration.test.tsx
@@ -1,0 +1,430 @@
+import React, { act, useLayoutEffect } from 'react';
+import { type Root, createRoot } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { StorageKeys } from '@/core/types/common';
+
+import {
+  type PopupScrollViewState,
+  clampPopupScrollTop,
+  shouldTrackPopupSettingsScroll,
+  usePopupScrollRestoration,
+} from '../usePopupScrollRestoration';
+
+const { storageGet, storageSet } = vi.hoisted(() => ({
+  storageGet: vi.fn(),
+  storageSet: vi.fn(),
+}));
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    storage: {
+      local: { get: storageGet, set: storageSet },
+    },
+  },
+}));
+
+const MAIN_VIEW: PopupScrollViewState = {
+  hasSettingsSearch: false,
+  isPluginSite: false,
+  showStarredHistory: false,
+  showStorageManager: false,
+};
+
+function Harness({
+  state,
+  onLayoutCommit,
+}: {
+  state: PopupScrollViewState;
+  onLayoutCommit?: () => void;
+}) {
+  usePopupScrollRestoration(state);
+  useLayoutEffect(() => onLayoutCommit?.(), [onLayoutCommit]);
+  return <div data-popup-content />;
+}
+
+describe('usePopupScrollRestoration', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let resizeObserverCallback: ResizeObserverCallback | null;
+  let resizeObserverTarget: Element | null;
+  let pendingAnimationFrame: { id: number; callback: FrameRequestCallback } | null;
+  let nextAnimationFrameId: number;
+
+  const flushAnimationFrame = (): void => {
+    const pending = pendingAnimationFrame;
+    pendingAnimationFrame = null;
+    if (pending) act(() => pending.callback(0));
+  };
+
+  const renderState = async (
+    state: PopupScrollViewState,
+    flushRestoreFrame = true,
+  ): Promise<void> => {
+    await act(async () => {
+      root.render(<Harness state={state} />);
+      await Promise.resolve();
+    });
+    if (flushRestoreFrame) flushAnimationFrame();
+  };
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    storageGet.mockReset().mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 0 });
+    storageSet.mockReset().mockResolvedValue(undefined);
+    resizeObserverCallback = null;
+    resizeObserverTarget = null;
+    pendingAnimationFrame = null;
+    nextAnimationFrameId = 0;
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      const id = ++nextAnimationFrameId;
+      pendingAnimationFrame = { id, callback };
+      return id;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      if (pendingAnimationFrame?.id === id) pendingAnimationFrame = null;
+    });
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeObserverCallback = callback;
+        }
+
+        observe(target: Element): void {
+          resizeObserverTarget = target;
+        }
+        unobserve(): void {}
+        disconnect(): void {}
+      },
+    );
+
+    container = document.createElement('div');
+    container.id = '__root';
+    Object.defineProperties(container, {
+      clientHeight: { configurable: true, value: 600 },
+      scrollHeight: { configurable: true, value: 2000 },
+    });
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    container.remove();
+  });
+
+  it.each([undefined, null, '420', -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    'falls back to the top for invalid value %s',
+    (value) => {
+      expect(clampPopupScrollTop(value, 1400)).toBe(0);
+    },
+  );
+
+  it('clamps a stored position to the current scroll range', () => {
+    expect(clampPopupScrollTop(5000, 1400)).toBe(1400);
+    expect(clampPopupScrollTop(419.6, 1400)).toBe(420);
+  });
+
+  it('tracks only the full main settings view', () => {
+    expect(shouldTrackPopupSettingsScroll(MAIN_VIEW)).toBe(true);
+    expect(shouldTrackPopupSettingsScroll({ ...MAIN_VIEW, hasSettingsSearch: true })).toBe(false);
+    expect(shouldTrackPopupSettingsScroll({ ...MAIN_VIEW, showStorageManager: true })).toBe(false);
+    expect(shouldTrackPopupSettingsScroll({ ...MAIN_VIEW, showStarredHistory: true })).toBe(false);
+    expect(shouldTrackPopupSettingsScroll({ ...MAIN_VIEW, isPluginSite: true })).toBe(false);
+  });
+
+  it('restores a valid local position', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 420 });
+
+    await renderState(MAIN_VIEW);
+
+    expect(container.scrollTop).toBe(420);
+  });
+
+  it('retries the stored target when asynchronous layout growth increases the scroll range', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 1800 });
+
+    await renderState(MAIN_VIEW);
+    expect(container.scrollTop).toBe(1400);
+
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 2400 });
+    act(() => resizeObserverCallback?.([], {} as ResizeObserver));
+
+    expect(container.scrollTop).toBe(1800);
+  });
+
+  it('retries after Firefox applies a delayed layout clamp', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 1800 });
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 2400 });
+
+    await renderState(MAIN_VIEW, false);
+    expect(container.scrollTop).toBe(1800);
+    storageSet.mockClear();
+
+    act(() => {
+      container.scrollTop = 121;
+      container.dispatchEvent(new Event('scroll'));
+      resizeObserverCallback?.([], {} as ResizeObserver);
+    });
+    flushAnimationFrame();
+    act(() => vi.advanceTimersByTime(150));
+
+    expect(container.scrollTop).toBe(1800);
+    expect(storageSet).not.toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 121 });
+  });
+
+  it('retries a layout clamp that arrives after the first animation frame', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 1800 });
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 2400 });
+
+    await renderState(MAIN_VIEW);
+    expect(container.scrollTop).toBe(1800);
+    storageSet.mockClear();
+
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 721 });
+    act(() => {
+      container.scrollTop = 121;
+      container.dispatchEvent(new Event('scroll'));
+    });
+
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 2400 });
+    act(() => resizeObserverCallback?.([], {} as ResizeObserver));
+    act(() => vi.advanceTimersByTime(150));
+
+    expect(container.scrollTop).toBe(1800);
+    expect(storageSet).not.toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 121 });
+  });
+
+  it('observes rendered content while waiting for the scroll range to grow', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 1800 });
+
+    await renderState(MAIN_VIEW);
+
+    expect(resizeObserverTarget).toBe(container.firstElementChild);
+    expect(resizeObserverTarget).not.toBe(container);
+  });
+
+  it('does not reapply the stored target after the user scrolls during layout restoration', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 1800 });
+
+    await renderState(MAIN_VIEW);
+    const pendingResizeCallback = resizeObserverCallback;
+    act(() => {
+      container.scrollTop = 600;
+      container.dispatchEvent(new Event('scroll'));
+    });
+
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 2400 });
+    act(() => pendingResizeCallback?.([], {} as ResizeObserver));
+
+    expect(container.scrollTop).toBe(600);
+  });
+
+  it('disables scroll anchoring while tracking to keep restored positions stable', async () => {
+    container.style.setProperty('overflow-anchor', 'auto');
+
+    await renderState(MAIN_VIEW);
+
+    expect(container.style.getPropertyValue('overflow-anchor')).toBe('none');
+
+    await renderState({ ...MAIN_VIEW, hasSettingsSearch: true });
+
+    expect(container.style.getPropertyValue('overflow-anchor')).toBe('auto');
+  });
+
+  it('clamps an oversized local position during restore', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 5000 });
+
+    await renderState(MAIN_VIEW);
+
+    expect(container.scrollTop).toBe(1400);
+  });
+
+  it('persists the final clamp when the stored target stays outside the settled layout', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 5000 });
+
+    await renderState(MAIN_VIEW);
+    storageSet.mockClear();
+    act(() => vi.advanceTimersByTime(2000));
+
+    expect(storageSet).toHaveBeenCalledOnce();
+    expect(storageSet).toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 1400 });
+  });
+
+  it('falls back to the top when local storage cannot be read', async () => {
+    storageGet.mockRejectedValue(new Error('storage unavailable'));
+    container.scrollTop = 300;
+
+    await renderState(MAIN_VIEW);
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it('does not overwrite local position after a read failure without user scrolling', async () => {
+    storageGet.mockRejectedValue(new Error('storage unavailable'));
+
+    await renderState(MAIN_VIEW);
+    storageSet.mockClear();
+    await renderState({ ...MAIN_VIEW, showStorageManager: true });
+
+    expect(storageSet).not.toHaveBeenCalled();
+  });
+
+  it('persists user scrolling after a local read failure', async () => {
+    storageGet.mockRejectedValue(new Error('storage unavailable'));
+
+    await renderState(MAIN_VIEW);
+    storageSet.mockClear();
+    act(() => {
+      container.scrollTop = 300;
+      container.dispatchEvent(new Event('scroll'));
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(storageSet).toHaveBeenCalledOnce();
+    expect(storageSet).toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 300 });
+  });
+
+  it('debounces repeated scroll events into one local write', async () => {
+    await renderState(MAIN_VIEW);
+    storageSet.mockClear();
+
+    act(() => {
+      container.scrollTop = 300;
+      container.dispatchEvent(new Event('scroll'));
+      container.scrollTop = 420;
+      container.dispatchEvent(new Event('scroll'));
+      vi.advanceTimersByTime(149);
+    });
+    expect(storageSet).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(storageSet).toHaveBeenCalledOnce();
+    expect(storageSet).toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 420 });
+  });
+
+  it('flushes the latest main position on pagehide', async () => {
+    await renderState(MAIN_VIEW);
+    storageSet.mockClear();
+
+    act(() => {
+      container.scrollTop = 515;
+      container.dispatchEvent(new Event('scroll'));
+      window.dispatchEvent(new Event('pagehide'));
+    });
+
+    expect(storageSet).toHaveBeenCalledOnce();
+    expect(storageSet).toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 515 });
+  });
+
+  it('flushes the latest main position when tracking stops', async () => {
+    await renderState(MAIN_VIEW);
+    storageSet.mockClear();
+
+    act(() => {
+      container.scrollTop = 515;
+      container.dispatchEvent(new Event('scroll'));
+    });
+    await renderState({ ...MAIN_VIEW, showStorageManager: true });
+
+    expect(storageSet).toHaveBeenCalledOnce();
+    expect(storageSet).toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 515 });
+  });
+
+  it('does not break scrolling when a local write throws synchronously', async () => {
+    await renderState(MAIN_VIEW);
+    storageSet.mockImplementationOnce(() => {
+      throw new Error('extension context invalidated');
+    });
+
+    expect(() => {
+      act(() => {
+        container.scrollTop = 515;
+        container.dispatchEvent(new Event('scroll'));
+        vi.advanceTimersByTime(150);
+      });
+    }).not.toThrow();
+  });
+
+  it('ignores temporary-view scrolling and restores the main position on return', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 420 });
+    await renderState(MAIN_VIEW);
+
+    act(() => {
+      container.scrollTop = 620;
+      container.dispatchEvent(new Event('scroll'));
+    });
+    await renderState({ ...MAIN_VIEW, hasSettingsSearch: true });
+    storageSet.mockClear();
+
+    act(() => {
+      container.scrollTop = 0;
+      container.dispatchEvent(new Event('scroll'));
+      vi.advanceTimersByTime(150);
+    });
+    expect(storageSet).not.toHaveBeenCalled();
+
+    await renderState(MAIN_VIEW);
+    expect(container.scrollTop).toBe(620);
+  });
+
+  it('ignores a layout clamp while a temporary view commits', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 420 });
+    await renderState(MAIN_VIEW);
+
+    act(() => {
+      container.scrollTop = 620;
+      container.dispatchEvent(new Event('scroll'));
+    });
+    storageSet.mockClear();
+
+    let dispatchedClamp = false;
+    await act(async () => {
+      root.render(
+        <Harness
+          state={{ ...MAIN_VIEW, hasSettingsSearch: true }}
+          onLayoutCommit={() => {
+            if (dispatchedClamp) return;
+            dispatchedClamp = true;
+            container.scrollTop = 0;
+            container.dispatchEvent(new Event('scroll'));
+          }}
+        />,
+      );
+      await Promise.resolve();
+    });
+    act(() => vi.advanceTimersByTime(150));
+
+    expect(storageSet).not.toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 0 });
+
+    await renderState(MAIN_VIEW);
+    expect(container.scrollTop).toBe(620);
+  });
+
+  it('keeps the main target while filtered content grows back after search clears', async () => {
+    storageGet.mockResolvedValue({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 1800 });
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 2400 });
+    await renderState(MAIN_VIEW);
+    expect(container.scrollTop).toBe(1800);
+
+    await renderState({ ...MAIN_VIEW, hasSettingsSearch: true });
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 721 });
+    container.scrollTop = 0;
+    storageSet.mockClear();
+
+    await renderState(MAIN_VIEW);
+    expect(container.scrollTop).toBe(121);
+
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 2400 });
+    act(() => resizeObserverCallback?.([], {} as ResizeObserver));
+
+    expect(container.scrollTop).toBe(1800);
+    expect(storageSet).not.toHaveBeenCalledWith({ [StorageKeys.GV_POPUP_SCROLL_TOP]: 121 });
+  });
+});

--- a/src/pages/popup/hooks/usePopupScrollRestoration.ts
+++ b/src/pages/popup/hooks/usePopupScrollRestoration.ts
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import browser from 'webextension-polyfill';
+
+import { StorageKeys } from '@/core/types/common';
+
+const POPUP_ROOT_ID = '__root';
+const SCROLL_WRITE_DEBOUNCE_MS = 150;
+const RESTORE_LAYOUT_WINDOW_MS = 2000;
+
+export interface PopupScrollViewState {
+  hasSettingsSearch: boolean;
+  isPluginSite: boolean;
+  showStarredHistory: boolean;
+  showStorageManager: boolean;
+}
+
+function normalizePopupScrollTop(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return 0;
+  return Math.round(value);
+}
+
+export function clampPopupScrollTop(value: unknown, maxScrollTop: number): number {
+  return Math.min(normalizePopupScrollTop(value), normalizePopupScrollTop(maxScrollTop));
+}
+
+export function shouldTrackPopupSettingsScroll(state: PopupScrollViewState): boolean {
+  return (
+    !state.hasSettingsSearch &&
+    !state.isPluginSite &&
+    !state.showStarredHistory &&
+    !state.showStorageManager
+  );
+}
+
+export function usePopupScrollRestoration(state: PopupScrollViewState): void {
+  const active = shouldTrackPopupSettingsScroll(state);
+  const positionRef = useRef(0);
+  const restorationTargetRef = useRef<number | null>(null);
+  const persistedPositionRef = useRef<number | null>(null);
+  const writeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  const persistPosition = useCallback((): void => {
+    if (writeTimerRef.current) {
+      clearTimeout(writeTimerRef.current);
+      writeTimerRef.current = null;
+    }
+
+    const position = normalizePopupScrollTop(positionRef.current);
+    if (position === persistedPositionRef.current) return;
+    persistedPositionRef.current = position;
+
+    try {
+      void browser.storage.local.set({ [StorageKeys.GV_POPUP_SCROLL_TOP]: position }).catch(() => {
+        if (persistedPositionRef.current === position) persistedPositionRef.current = null;
+      });
+    } catch {
+      if (persistedPositionRef.current === position) {
+        persistedPositionRef.current = null;
+      }
+    }
+  }, []);
+
+  const schedulePersist = useCallback((): void => {
+    if (writeTimerRef.current) clearTimeout(writeTimerRef.current);
+    writeTimerRef.current = setTimeout(persistPosition, SCROLL_WRITE_DEBOUNCE_MS);
+  }, [persistPosition]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const finishAtTop = (): void => {
+      if (cancelled) return;
+      positionRef.current = 0;
+      restorationTargetRef.current = 0;
+      persistedPositionRef.current = 0;
+      setLoaded(true);
+    };
+
+    try {
+      void browser.storage.local
+        .get(StorageKeys.GV_POPUP_SCROLL_TOP)
+        .then((result) => {
+          if (cancelled) return;
+          const position = normalizePopupScrollTop(result[StorageKeys.GV_POPUP_SCROLL_TOP]);
+          positionRef.current = position;
+          restorationTargetRef.current = position;
+          persistedPositionRef.current = position;
+          setLoaded(true);
+        })
+        .catch(finishAtTop);
+    } catch {
+      finishAtTop();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!loaded || !active) return;
+    const container = document.getElementById(POPUP_ROOT_ID);
+    if (!container) return;
+
+    const previousOverflowAnchor = container.style.getPropertyValue('overflow-anchor');
+    // Firefox scroll anchoring can turn async layout shifts into persisted offset drift.
+    container.style.setProperty('overflow-anchor', 'none');
+
+    let resizeObserver: ResizeObserver | null = null;
+    let restoreTimer: ReturnType<typeof setTimeout> | null = null;
+    let restoreFrame: number | null = null;
+    let awaitingInitialLayout = true;
+    let lastAppliedScrollTop: number | null = null;
+
+    const stopLayoutObservation = (): void => {
+      resizeObserver?.disconnect();
+      resizeObserver = null;
+      if (restoreTimer) {
+        clearTimeout(restoreTimer);
+        restoreTimer = null;
+      }
+      if (restoreFrame !== null) {
+        cancelAnimationFrame(restoreFrame);
+        restoreFrame = null;
+      }
+    };
+    const finishRestoring = (finalPosition?: number): void => {
+      stopLayoutObservation();
+      restorationTargetRef.current = null;
+      if (finalPosition !== undefined) positionRef.current = finalPosition;
+    };
+    const applyRestorationTarget = (target: number): number => {
+      const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+      const restoredPosition = clampPopupScrollTop(target, maxScrollTop);
+      lastAppliedScrollTop = restoredPosition;
+      container.scrollTop = restoredPosition;
+      return restoredPosition;
+    };
+
+    const restorationTarget = restorationTargetRef.current ?? positionRef.current;
+    restorationTargetRef.current = restorationTarget;
+    applyRestorationTarget(restorationTarget);
+    if (typeof ResizeObserver === 'function') {
+      resizeObserver = new ResizeObserver(() => {
+        if (restorationTargetRef.current !== restorationTarget) return;
+        applyRestorationTarget(restorationTarget);
+      });
+      resizeObserver.observe(container.firstElementChild ?? container);
+      restoreTimer = setTimeout(() => {
+        if (restorationTargetRef.current !== restorationTarget) return;
+        const finalPosition = applyRestorationTarget(restorationTarget);
+        finishRestoring(finalPosition);
+        persistPosition();
+      }, RESTORE_LAYOUT_WINDOW_MS);
+    }
+
+    // Firefox can apply a queued layout clamp after scrollTop appears restored.
+    restoreFrame = requestAnimationFrame(() => {
+      restoreFrame = null;
+      if (restorationTargetRef.current !== restorationTarget) return;
+      awaitingInitialLayout = false;
+      const confirmedPosition = applyRestorationTarget(restorationTarget);
+      if (!resizeObserver) {
+        finishRestoring(confirmedPosition);
+      }
+    });
+
+    const onScroll = (): void => {
+      const position = normalizePopupScrollTop(container.scrollTop);
+      if (awaitingInitialLayout) return;
+      const activeRestorationTarget = restorationTargetRef.current;
+      if (activeRestorationTarget !== null) {
+        if (position === lastAppliedScrollTop) return;
+        const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+        if (position === clampPopupScrollTop(activeRestorationTarget, maxScrollTop)) return;
+        finishRestoring();
+      }
+      positionRef.current = position;
+      schedulePersist();
+    };
+    const onPageHide = (): void => persistPosition();
+
+    container.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('pagehide', onPageHide);
+
+    return () => {
+      container.removeEventListener('scroll', onScroll);
+      window.removeEventListener('pagehide', onPageHide);
+      stopLayoutObservation();
+      if (previousOverflowAnchor) {
+        container.style.setProperty('overflow-anchor', previousOverflowAnchor);
+      } else {
+        container.style.removeProperty('overflow-anchor');
+      }
+      persistPosition();
+    };
+  }, [active, loaded, persistPosition, schedulePersist]);
+
+  useEffect(
+    () => () => {
+      if (writeTimerRef.current) clearTimeout(writeTimerRef.current);
+    },
+    [],
+  );
+}

--- a/src/pages/popup/hooks/usePopupScrollRestoration.ts
+++ b/src/pages/popup/hooks/usePopupScrollRestoration.ts
@@ -6,9 +6,9 @@ import { StorageKeys } from '@/core/types/common';
 
 const POPUP_ROOT_ID = '__root';
 const SCROLL_WRITE_DEBOUNCE_MS = 150;
-const RESTORE_LAYOUT_WINDOW_MS = 2000;
 
 export interface PopupScrollViewState {
+  activeTabContextLoaded: boolean;
   hasSettingsSearch: boolean;
   isPluginSite: boolean;
   showStarredHistory: boolean;
@@ -26,6 +26,7 @@ export function clampPopupScrollTop(value: unknown, maxScrollTop: number): numbe
 
 export function shouldTrackPopupSettingsScroll(state: PopupScrollViewState): boolean {
   return (
+    state.activeTabContextLoaded &&
     !state.hasSettingsSearch &&
     !state.isPluginSite &&
     !state.showStarredHistory &&
@@ -38,6 +39,7 @@ export function usePopupScrollRestoration(state: PopupScrollViewState): void {
   const positionRef = useRef(0);
   const restorationTargetRef = useRef<number | null>(null);
   const persistedPositionRef = useRef<number | null>(null);
+  const userScrolledBeforeLoadRef = useRef(false);
   const writeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [loaded, setLoaded] = useState(false);
 
@@ -71,8 +73,10 @@ export function usePopupScrollRestoration(state: PopupScrollViewState): void {
     let cancelled = false;
     const finishAtTop = (): void => {
       if (cancelled) return;
-      positionRef.current = 0;
-      restorationTargetRef.current = 0;
+      if (!userScrolledBeforeLoadRef.current) {
+        positionRef.current = 0;
+        restorationTargetRef.current = 0;
+      }
       persistedPositionRef.current = 0;
       setLoaded(true);
     };
@@ -83,8 +87,10 @@ export function usePopupScrollRestoration(state: PopupScrollViewState): void {
         .then((result) => {
           if (cancelled) return;
           const position = normalizePopupScrollTop(result[StorageKeys.GV_POPUP_SCROLL_TOP]);
-          positionRef.current = position;
-          restorationTargetRef.current = position;
+          if (!userScrolledBeforeLoadRef.current) {
+            positionRef.current = position;
+            restorationTargetRef.current = position;
+          }
           persistedPositionRef.current = position;
           setLoaded(true);
         })
@@ -99,6 +105,33 @@ export function usePopupScrollRestoration(state: PopupScrollViewState): void {
   }, []);
 
   useLayoutEffect(() => {
+    const container = document.getElementById(POPUP_ROOT_ID);
+    if (!container) return;
+
+    if (!active) {
+      container.scrollTop = 0;
+      return;
+    }
+    if (loaded) return;
+
+    const onScrollBeforeLoad = (): void => {
+      userScrolledBeforeLoadRef.current = true;
+      restorationTargetRef.current = null;
+      positionRef.current = normalizePopupScrollTop(container.scrollTop);
+    };
+    container.addEventListener('scroll', onScrollBeforeLoad, { passive: true });
+    return () => container.removeEventListener('scroll', onScrollBeforeLoad);
+  }, [
+    active,
+    loaded,
+    state.activeTabContextLoaded,
+    state.hasSettingsSearch,
+    state.isPluginSite,
+    state.showStarredHistory,
+    state.showStorageManager,
+  ]);
+
+  useLayoutEffect(() => {
     if (!loaded || !active) return;
     const container = document.getElementById(POPUP_ROOT_ID);
     if (!container) return;
@@ -108,7 +141,6 @@ export function usePopupScrollRestoration(state: PopupScrollViewState): void {
     container.style.setProperty('overflow-anchor', 'none');
 
     let resizeObserver: ResizeObserver | null = null;
-    let restoreTimer: ReturnType<typeof setTimeout> | null = null;
     let restoreFrame: number | null = null;
     let awaitingInitialLayout = true;
     let lastAppliedScrollTop: number | null = null;
@@ -116,26 +148,20 @@ export function usePopupScrollRestoration(state: PopupScrollViewState): void {
     const stopLayoutObservation = (): void => {
       resizeObserver?.disconnect();
       resizeObserver = null;
-      if (restoreTimer) {
-        clearTimeout(restoreTimer);
-        restoreTimer = null;
-      }
       if (restoreFrame !== null) {
         cancelAnimationFrame(restoreFrame);
         restoreFrame = null;
       }
     };
-    const finishRestoring = (finalPosition?: number): void => {
+    const finishRestoring = (): void => {
       stopLayoutObservation();
       restorationTargetRef.current = null;
-      if (finalPosition !== undefined) positionRef.current = finalPosition;
     };
-    const applyRestorationTarget = (target: number): number => {
+    const applyRestorationTarget = (target: number): void => {
       const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
       const restoredPosition = clampPopupScrollTop(target, maxScrollTop);
       lastAppliedScrollTop = restoredPosition;
       container.scrollTop = restoredPosition;
-      return restoredPosition;
     };
 
     const restorationTarget = restorationTargetRef.current ?? positionRef.current;
@@ -147,12 +173,6 @@ export function usePopupScrollRestoration(state: PopupScrollViewState): void {
         applyRestorationTarget(restorationTarget);
       });
       resizeObserver.observe(container.firstElementChild ?? container);
-      restoreTimer = setTimeout(() => {
-        if (restorationTargetRef.current !== restorationTarget) return;
-        const finalPosition = applyRestorationTarget(restorationTarget);
-        finishRestoring(finalPosition);
-        persistPosition();
-      }, RESTORE_LAYOUT_WINDOW_MS);
     }
 
     // Firefox can apply a queued layout clamp after scrollTop appears restored.
@@ -160,10 +180,7 @@ export function usePopupScrollRestoration(state: PopupScrollViewState): void {
       restoreFrame = null;
       if (restorationTargetRef.current !== restorationTarget) return;
       awaitingInitialLayout = false;
-      const confirmedPosition = applyRestorationTarget(restorationTarget);
-      if (!resizeObserver) {
-        finishRestoring(confirmedPosition);
-      }
+      applyRestorationTarget(restorationTarget);
     });
 
     const onScroll = (): void => {


### PR DESCRIPTION
### Description / 描述

Remember and restore the vertical scroll position of Voyager's full popup settings view.

- Persist `gvPopupScrollTop` in device-local extension storage.
- Keep the value out of settings backup and cloud sync.
- Prevent search, Storage Manager, Saved Library, and plugin-only views from overwriting the main settings position.
- Safely handle invalid or oversized values, async layout growth, Firefox layout clamps, storage failures, and debounced/cleanup writes.
- Add focused regression coverage for restoration, temporary views, delayed layout, and backup exclusion.

### Related Issue / 相关 Issue

Closes #883

- [x] Not applicable: #883 is not labeled `community-only`; the maintainer-approved scope is recorded in the Issue.

### Visual Proof / 可视化证据

Firefox redacted screenshot sequence and the structured black-box result were captured locally for the tested commit. Chrome, Edge, and Firefox manual Live verification is complete, but no public redacted recording has been attached yet. This PR remains Draft until visual proof is attached or a maintainer confirms the structured evidence is sufficient.

### Browser Testing / 浏览器测试

Tested commit / 测试提交: `02bef757833c9f73046c923807b96862c6d42824`

| Browser / version | Scenario and result / 场景与结果 | Evidence / 证据 |
| ----------------- | -------------------------------- | --------------- |
| Chrome 150.0.7871.130, Windows | Loaded `dist_chrome`; main scroll position restored across repeated popup reopen and extension reload; search, Storage Manager, and Saved Library did not overwrite it; no new popup console errors | Manual contributor verification; public redacted recording pending |
| Edge 150.0.4078.105, Windows | Loaded `dist_edge`; main scroll position restored across repeated popup reopen and extension reload; search, Storage Manager, and Saved Library did not overwrite it; no new popup console errors | Manual contributor verification; public redacted recording pending |
| Firefox 152.0.6, Windows | Loaded temporary Voyager 1.6.0; manual five-scenario smoke passed. Earlier black-box run stored position 2800, restored it in 5/5 reopen cycles, and preserved it through search, Storage Manager, and Saved Library | Manual contributor verification plus local automated transcript and redacted screenshots; public recording pending |

Missing checks and owner, or N/A reason / 缺失检查与负责人，或不适用理由:

- Needs a public redacted short recording of the approved scroll-restoration workflow, or maintainer confirmation that the structured evidence is sufficient; owner: `@shallowaria`.
- Edge package build is covered by green CI because the Windows local packaging step requires an external `zip` executable; the generated unpacked `dist_edge` artifact was used for Live verification.

Commands run / 已运行命令:

- `bash .githooks/pre-commit`
- changed-file Prettier and ESLint checks
- `bun run lint` (0 errors; 209 existing warnings)
- `bun run typecheck`
- `bun run i18n:check`
- `bun run test src/pages/popup` (114/114)
- `bun run test src/pages/content/folder/__tests__/observerBatching.test.ts` (19/19, twice)
- `bunx vitest run --exclude scripts/__tests__/verify-release-privacy.test.ts`
- `bun run build:all`
- `bun run docs:build`
- Firefox Loaded/Live black-box workflow on the tested commit
- Chrome, Edge, and Firefox manual Loaded/Live five-scenario smoke on the tested commit

Commands not run successfully and reason / 未成功运行的命令及原因:

- `bun run format:check` and `bun run verify:pr` stop on `AGENTS.md`: Git records it as a symlink, while this Windows checkout uses `core.symlinks=false`; all six changed files pass Prettier.
- `bun run test` has one stable Windows-only baseline failure in `verify-release-privacy.test.ts`, whose `/` path matcher rejects legal `embedded.provisionprofile` paths containing `\`. One full parallel run also saw an unrelated `observerBatching.test.ts` timing failure; that file passed twice in isolation, and the full suite excluding the stable Windows baseline then passed.

### Video / 视频
https://github.com/user-attachments/assets/dd952435-8204-4610-8a78-76b77be20249

### Checklist / 检查清单

- [x] If I used an agent, I discussed the requirement, affected scope, and verification plan clearly. / 如果使用了 Agent，我已讨论清楚需求、影响范围和验证方式。
- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] For UI/behavior changes, I have tried the real workflow for about 15 minutes when possible. / 对于 UI/行为改动，条件允许时我已用真实流程体验约 15 分钟。
- [x] For UI/behavior changes, I have included visual proof after verification. / 对于 UI/行为改动，我已在验证后提供可视化证据。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] This PR focuses on one issue or one coherent change. / 此 PR 只聚焦一个问题或一个清晰完整的改动。
- [x] I ran `bun run format`, `bun run lint`, then the standard local `bun run verify:pr`, or listed every omitted command and reason above. / 我已依次运行格式化、自动修复及标准本地 `bun run verify:pr` 验证，或在上方逐项说明未运行命令及原因。
- [x] I added/updated regression tests for behavior changes, or explained why no test is useful. / 行为改动已添加或更新回归测试；若无需测试，我已说明理由。
- [x] I listed the affected browsers actually tested and identified any required follow-up owner. / 我已列出实际测试的受影响浏览器，并标明所有必需补测的负责人。