### PR TITLE
docs(contributing): link gh install and align the documented auth check

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -353,7 +353,7 @@ AI tools can be helpful, but copy-paste PRs without clear intent, focused scope,
 ### Prerequisites
 
 - **Bun 1.3.12** (matching `packageManager` and CI)
-- **GitHub CLI (`gh`)**: install it and authenticate with `gh auth login`; the `voyager-contribute` skill relies on it for Issue/PR state and publishing. Without `gh`, use the GitHub web UI instead and note that in the PR.
+- **GitHub CLI (`gh`)** ([installation](https://cli.github.com/)): install it and authenticate with `gh auth login`, then run `gh auth status` to confirm the active account is the one you intend to contribute as; the `voyager-contribute` skill relies on it for Issue/PR state and publishing. Without `gh`, use the GitHub web UI instead and note that in the PR.
 - The affected browsers for loading the extension and exercising the real workflow
 
 ### Quick Start

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,7 +60,7 @@ AI 是很好的辅助工具，但缺少明确目标、聚焦范围和真实验�
 ### 前置要求
 
 - **Bun 1.3.12**（与 `packageManager` 和 CI 一致）
-- **GitHub CLI（`gh`）**：安装后运行 `gh auth login` 完成认证；`voyager-contribute` skill 依赖它查询和发布 Issue/PR。没有 `gh` 时可改用 GitHub 网页操作，并在 PR 中注明。
+- **GitHub CLI（`gh`）**（[安装](https://cli.github.com/)）：安装后运行 `gh auth login` 完成认证，再运行 `gh auth status` 确认当前账号就是你准备用来贡献的账号；`voyager-contribute` skill 依赖它查询和发布 Issue/PR。没有 `gh` 时可改用 GitHub 网页操作，并在 PR 中注明。
 - 用于加载扩展并验证真实流程的受影响浏览器
 
 ### 快速启动

--- a/.github/CONTRIBUTING_ES.md
+++ b/.github/CONTRIBUTING_ES.md
@@ -53,7 +53,7 @@ Aunque las herramientas de IA son grandes asistentes, las contribuciones de "cop
 ### Requisitos Previos
 
 - **Bun 1.3.12** (coincide con `packageManager` y CI)
-- **GitHub CLI (`gh`)**: instálalo y autentícate con `gh auth login`; la skill `voyager-contribute` lo usa para consultar y publicar Issues/PRs. Sin `gh`, usa la interfaz web de GitHub e indícalo en la PR.
+- **GitHub CLI (`gh`)** ([instalación](https://cli.github.com/)): instálalo y autentícate con `gh auth login`, luego ejecuta `gh auth status` para confirmar que la cuenta activa es la que quieres usar para contribuir; la skill `voyager-contribute` lo usa para consultar y publicar Issues/PRs. Sin `gh`, usa la interfaz web de GitHub e indícalo en la PR.
 - Los navegadores afectados para cargar la extensión y probar el flujo real
 
 ### Inicio Rápido

--- a/.github/CONTRIBUTING_FR.md
+++ b/.github/CONTRIBUTING_FR.md
@@ -53,7 +53,7 @@ Bien que les outils d'IA soient d'excellents assistants, les contributions "pare
 ### Prérequis
 
 - **Bun 1.3.12** (aligné sur `packageManager` et la CI)
-- **GitHub CLI (`gh`)** : installez-le et authentifiez-vous avec `gh auth login` ; la skill `voyager-contribute` s'en sert pour consulter et publier les Issues/PRs. Sans `gh`, utilisez l'interface web GitHub et signalez-le dans la PR.
+- **GitHub CLI (`gh`)** ([installation](https://cli.github.com/)) : installez-le et authentifiez-vous avec `gh auth login`, puis exécutez `gh auth status` pour vérifier que le compte actif est bien celui avec lequel vous souhaitez contribuer; la skill `voyager-contribute` s'en sert pour consulter et publier les Issues/PRs. Sans `gh`, utilisez l'interface web GitHub et signalez-le dans la PR.
 - Les navigateurs concernés pour charger l'extension et tester le parcours réel
 
 ### Démarrage Rapide

--- a/.github/CONTRIBUTING_JA.md
+++ b/.github/CONTRIBUTING_JA.md
@@ -53,7 +53,7 @@ AI ツールは優れたアシスタントですが、「怠惰な」コピー�
 ### 前提条件
 
 - **Bun 1.3.12**（`packageManager` および CI と統一）
-- **GitHub CLI（`gh`）**：インストール後 `gh auth login` で認証してください。`voyager-contribute` skill は Issue/PR の照会・公開に `gh` を利用します。`gh` がない場合は GitHub の Web UI を使い、その旨を PR に記載してください。
+- **GitHub CLI（`gh`）**（[インストール](https://cli.github.com/)）：インストール後 `gh auth login` で認証してください。その後、`gh auth status` で有効なアカウントが貢献に使うアカウントであることを確認してください。`voyager-contribute` skill は Issue/PR の照会・公開に `gh` を利用します。`gh` がない場合は GitHub の Web UI を使い、その旨を PR に記載してください。
 - 拡張機能を読み込み、実際のフローを確認する対象ブラウザ
 
 ### クイックスタート


### PR DESCRIPTION
`9ecdaa87` already supplied the skill-side web UI fallback; this PR completes the remaining documentation gaps.

Docs-only change; no rendered UI change.

Closes #878