### PR TITLE
fix(popup): hide duplicate native search clear control

### DIFF
--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -2685,7 +2685,7 @@ export default function Popup({ sourceTabId }: PopupProps = {}) {
               onChange={(event) => updateSettingsSearchQuery(event.target.value)}
               placeholder={t('popupSettingsSearchPlaceholder')}
               aria-label={t('popupSettingsSearchPlaceholder')}
-              className="bg-card border-border focus:ring-primary/40 w-full rounded-lg border py-2 pr-9 pl-9 text-sm shadow-sm transition-all outline-none focus:ring-2"
+              className="bg-card border-border focus:ring-primary/40 w-full rounded-lg border py-2 pr-9 pl-9 text-sm shadow-sm transition-all outline-none focus:ring-2 [&::-webkit-search-cancel-button]:hidden"
             />
             {settingsSearchQuery && (
               <button

--- a/src/pages/popup/__tests__/settingsSearchClearControl.test.ts
+++ b/src/pages/popup/__tests__/settingsSearchClearControl.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('settings search clear control', () => {
+  it('hides the native Chromium cancel button while keeping the accessible custom control', () => {
+    const popupSource = readFileSync(resolve(process.cwd(), 'src/pages/popup/Popup.tsx'), 'utf8');
+    const searchStart = popupSource.indexOf('<input\n              type="search"');
+    const searchEnd = popupSource.indexOf('</button>', searchStart);
+    const searchControls = popupSource.slice(searchStart, searchEnd);
+
+    expect(searchStart).toBeGreaterThan(-1);
+    expect(searchEnd).toBeGreaterThan(searchStart);
+    expect(searchControls).toContain('value={settingsSearchQuery}');
+    expect(searchControls).toContain('[&::-webkit-search-cancel-button]:hidden');
+    expect(searchControls).toContain("onClick={() => updateSettingsSearchQuery('')}");
+    expect(searchControls).toContain("aria-label={t('popupSettingsSearchClear')}");
+    expect(searchControls).toContain("title={t('popupSettingsSearchClear')}");
+  });
+});


### PR DESCRIPTION
### AI-Assisted PR Policy / AI 辅助 PR 政策

- AI-assisted PRs are welcome, but they must be manually reviewed and verified by the contributor. / 欢迎使用 AI 辅助提交 PR，但贡献者必须亲自复核和验证。
- You are responsible for the PR's goal, scope, behavior, and verification results. You do not need to fully understand every line generated by an agent, but you should be able to explain what the PR is trying to solve and why the approach is reasonable. / 你需要为 PR 的目标、范围、行为变化和验证结果负责。你不必完全读懂 Agent 生成的每一行代码，但应该能说明这个 PR 要解决什么，以及为什么这个方案是合理的。
- Before coding, discuss the requirement with your agent clearly: expected behavior, affected pages/features, and how to verify it. / 开始改代码前，请先和 Agent 讨论清楚需求：预期行为、影响范围，以及如何验证。
- This contribution used the repository-bundled `voyager-contribute` skill. / 本次贡献使用了仓库自带的 `voyager-contribute` skill。
- Keep the PR focused: one PR should fix one issue or make one coherent change. / 保持 PR 聚焦：一个 PR 只修一个问题，或只做一个清晰完整的改动。
- After changing code, manually use the feature yourself. For UI/behavior changes, please spend about 15 minutes trying the real workflow when possible. / 改完后请亲自手动体验。涉及 UI 或行为变化时，条件允许的话请用真实流程体验约 15 分钟。
- Provide visual proof after verification: screenshots, screen recordings, or before/after clips. / 验证后请提供可视化证据：截图、录屏或前后对比。

---

### Description / 描述

Chromium renders its native cancel control for `type="search"`, while Voyager already provides an accessible Lucide clear button. This caused two clickable clear controls to appear in the popup settings search field.

This PR:

- keeps the semantic `type="search"` input;
- hides only the native `::-webkit-search-cancel-button`;
- preserves the existing custom clear handler, accessible name, and tooltip;
- adds a focused regression test protecting the input semantics and custom control.

User impact: the popup now shows one clear button instead of two when the settings search contains text.

Non-goals: no search filtering, storage, layout, or localization behavior changes.

### Related Issue / 相关 Issue

Fixes #892

- [x] Not applicable: #892 is not labeled `community-only`. / 不适用：#892 未标记 `community-only`。

### Visual Proof / 可视化证据

The reporter manually captured the following after-fix screenshots. Each shows one clear control and the expected empty-results layout.

**Chrome 150.0.7871.184**

<img width="360" height="212" alt="Chrome popup settings search showing one clear button" src="https://github.com/user-attachments/assets/b12cf507-d0dd-4a2e-af1a-c2a598246f4f" />

**Edge 151.0.4129.59**

<img width="347" height="211" alt="Edge popup settings search showing one clear button" src="https://github.com/user-attachments/assets/ba888984-1926-4f06-914f-54cf34e52c78" />

**Firefox 151.0.1**

<img width="357" height="221" alt="Firefox popup settings search showing one clear button" src="https://github.com/user-attachments/assets/4ad51210-a49c-4c07-9ec9-e42446ab7825" />

The original before-fix screenshot remains available in #892.

### Browser Testing / 浏览器测试

Tested commit / 测试提交: `0d82fec0a8a99e3b771f75699d0c50807bd4d508` (live browser evidence)

Current PR head / 当前 PR 提交: `01df53cf07c0af10a7a4244dd00eb8568ec49c0f`

The live browser screenshots were captured before the rebase. The rebased commit has the same stable patch ID, and the current head was reverified with the local automated checks listed below before push.

| Browser / version | Scenario and result / 场景与结果 | Evidence / 证据 |
| ----------------- | -------------------------------- | --------------- |
| Chrome 150.0.7871.184 | Loaded the local extension, entered `Chrome Test` in popup settings search, and confirmed exactly one working clear control with normal layout. | Screenshot above |
| Edge 151.0.4129.59 | Loaded the local extension, entered `Edge Test`, and confirmed exactly one working clear control with normal layout. | Screenshot above |
| Firefox 151.0.1 | Loaded the local extension, entered `Firefox Test`, and confirmed exactly one working clear control with normal layout. | Screenshot above |

Missing checks and owner, or N/A reason / 缺失检查与负责人，或不适用理由:

- Needs Safari live verification because the WebKit pseudo-element is affected; owner: maintainer or contributor with macOS and Safari access (pending assignment).
- Needs a dark-theme visual smoke check and popup/background console check; owner: @shallowaria.

Commands run and results / 已运行命令及结果:

- `bun run format` — passed.
- `bun run lint` — passed with 0 errors and 209 pre-existing warnings.
- Focused clear-control regression test — passed (1/1).
- Rebased `0d82fec0` onto `origin/main` at `b88409ee`; new head: `01df53cf`.
- Rebase before/after `git patch-id --stable` values match.
- Watermark `fetchInterceptor.test.ts` — passed (12/12) after inheriting main's `d1394738` fix.
- Changed-file Prettier and ESLint checks — passed (0 errors).
- `bun run lint:check` — passed with 0 errors and 209 pre-existing warnings.
- `bun run typecheck` — passed.
- `bun run i18n:check` — passed for all 10 locales (693 keys).
- `bun run test` — all tests passed except the existing Windows path-separator failure in `verify-release-privacy.test.ts`.
- `bunx vitest run --exclude scripts/__tests__/verify-release-privacy.test.ts` — passed.
- `bun run build:all` — passed.
- `bun run docs:build` — passed.
- `git diff --check` — passed.

Commands not run or not completed and reason / 未运行或未完成命令及原因:

- `bun run verify:pr` — attempted, but stopped at the known Windows symlink checkout of `AGENTS.md` during `format:check`; both changed files pass Prettier.
- `bun run build:edge` — not run because the repository documents that the Windows environment lacks the external `zip` executable required by the Edge packaging step.

### Checklist / 检查清单

- [x] If I used an agent, I discussed the requirement, affected scope, and verification plan clearly. / 如果使用了 Agent，我已讨论清楚需求、影响范围和验证方式。
- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] For UI/behavior changes, I have tried the real workflow for about 15 minutes when possible. / 对于 UI/行为改动，条件允许时我已用真实流程体验约 15 分钟。
- [x] For UI/behavior changes, I have included visual proof after verification. / 对于 UI/行为改动，我已在验证后提供可视化证据。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] This PR focuses on one issue or one coherent change. / 此 PR 只聚焦一个问题或一个清晰完整的改动。
- [x] I ran `bun run format`, `bun run lint`, then the standard local `bun run verify:pr`, or listed every omitted command and reason above. / 我已依次运行格式化、自动修复及标准本地 `bun run verify:pr` 验证，或在上方逐项说明未运行命令及原因。
- [x] I added/updated regression tests for behavior changes, or explained why no test is useful. / 行为改动已添加或更新回归测试；若无需测试，我已说明理由。
- [x] I listed the affected browsers actually tested and identified any required follow-up owner. / 我已列出实际测试的受影响浏览器，并标明所有必需补测的负责人。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the settings search experience by preventing the browser’s native cancel button from appearing.
  - Preserved the custom clear control for reliably clearing search text.

- **Tests**
  - Added coverage to verify search input behavior and accessibility of the custom clear control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->