### PR TITLE
fix(chatwidth): align file-drop overlay with adjusted input width

### DIFF
--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -1091,3 +1091,40 @@ Regression test:
 
 Commit:
 `fix(timeline): use stable Gemini turn identities`
+
+## The file-drop overlay is pinned to Gemini's native input width
+
+Symptom (#887):
+With chat width widened, the blue "Drop files here" overlay shown while
+dragging a file over the page is visibly narrower than the input box. Dropping
+outside the overlay still uploads, because the real drop target is the
+`xap-uploader-dropzone` directive on the whole `.chat-container` — the overlay
+is only a visual hint, so only the hint is wrong.
+
+Root cause:
+Gemini pins the overlay card with
+`.overlay-container[data-filedrop-id="chat-window-input-container"]
+{ max-width: var(--bard-chat-window-max-width-default, 760px) }`. The variable
+is unset, so the overlay is always 760px — which coincides with Gemini's
+native input width, so nothing looks wrong until `chatWidth` or
+`editInputWidth` widens `input-area-v2` past 760px without widening the
+overlay.
+
+Fix:
+Both width adjusters inject a matching overlay rule with their own width
+value. The selectors are deliberately asymmetric: `chatWidth` prefixes
+`input-container` (higher specificity), `editInputWidth` does not, mirroring
+how the two modules' `input-area-v2` rules already resolve — so when both
+features are enabled the overlay follows the same winner as the visible input
+box in either injection order. Keep that relationship if either selector
+changes.
+
+Regression tests:
+`src/pages/content/chatWidth/__tests__/chatWidth.test.ts`
+`src/pages/content/editInputWidth/__tests__/editInputWidth.test.ts`
+Live verification: synthetic dragenter/dragover over `.chat-container` at 70%
+width — overlay left/right must equal `input-area-v2` left/right (was fixed at
+760px centered).
+
+Commit:
+`fix(chatwidth): widen file-drop overlay to match adjusted input width`

--- a/src/pages/content/chatWidth/__tests__/chatWidth.test.ts
+++ b/src/pages/content/chatWidth/__tests__/chatWidth.test.ts
@@ -119,4 +119,45 @@ describe('chatWidth', () => {
     expect(styleText).toContain(`max-width: ${expectedPx}px !important`);
     expect(styleText).toContain(`width: min(100%, ${expectedPx}px) !important`);
   });
+
+  it('widens the file-drop overlay to match the input area (#887)', async () => {
+    const { startChatWidthAdjuster } = await import('../index');
+    startChatWidthAdjuster();
+
+    const styleText = getInjectedStyle().textContent ?? '';
+    // Read the selector back out of the injected CSS so this test fails if the
+    // shipped rule changes, instead of only checking a hardcoded copy of it
+    const overlayRule = styleText.match(/(input-container file-drop-indicator[^{]+)\{([^}]+)\}/);
+    expect(overlayRule).not.toBeNull();
+    const [, selector, body] = overlayRule as RegExpMatchArray;
+
+    const expectedPx = percentToPixels(85);
+    expect(body).toContain(`max-width: ${expectedPx}px !important`);
+    expect(body).toContain(`width: min(100%, ${expectedPx}px) !important`);
+    expect(body).toContain('margin-left: auto !important');
+    expect(body).toContain('margin-right: auto !important');
+
+    // Behavioral check against the real DOM shape: the overlay Gemini renders
+    // while dragging must match; an overlay with a different filedrop id
+    // (a non-chat drop target) must not
+    document.body.innerHTML = `
+      <main>
+        <input-container>
+          <fieldset class="input-area-container">
+            <input-area-v2></input-area-v2>
+            <file-drop-indicator>
+              <div class="overlay-container" data-filedrop-id="chat-window-input-container"></div>
+            </file-drop-indicator>
+          </fieldset>
+        </input-container>
+        <file-drop-indicator>
+          <div class="overlay-container" data-filedrop-id="some-other-target"></div>
+        </file-drop-indicator>
+      </main>
+    `;
+    const matches = [...document.querySelectorAll(selector.trim())];
+    expect(matches.map((el) => el.getAttribute('data-filedrop-id'))).toEqual([
+      'chat-window-input-container',
+    ]);
+  });
 });

--- a/src/pages/content/chatWidth/index.ts
+++ b/src/pages/content/chatWidth/index.ts
@@ -216,6 +216,18 @@ function applyWidth(widthPercent: number) {
       margin-right: auto !important;
     }
 
+    /* Widen the file-drop overlay with the input area (#887). Gemini pins it to
+       var(--bard-chat-window-max-width-default, 760px), which only matches the
+       native input width. The input-container prefix keeps this rule more
+       specific than editInputWidth's overlay rule, mirroring how the two
+       modules' input-area-v2 rules already resolve when both are enabled. */
+    input-container file-drop-indicator .overlay-container[data-filedrop-id="chat-window-input-container"] {
+      max-width: ${widthValue} !important;
+      width: min(100%, ${widthValue}) !important;
+      margin-left: auto !important;
+      margin-right: auto !important;
+    }
+
     /* Specific fix for user bubble background to fit content but respect max-width */
     .user-query-bubble-with-background {
       max-width: ${widthValue} !important;

--- a/src/pages/content/editInputWidth/__tests__/editInputWidth.test.ts
+++ b/src/pages/content/editInputWidth/__tests__/editInputWidth.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const STYLE_ID = 'gemini-voyager-edit-input-width';
+const STORAGE_KEY = 'geminiEditInputWidth';
+const ENABLED_KEY = 'gvEditInputWidthEnabled';
+
+function getInjectedStyle(): HTMLStyleElement {
+  const style = document.getElementById(STYLE_ID);
+  expect(style).not.toBeNull();
+  return style as HTMLStyleElement;
+}
+
+describe('editInputWidth', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    document.head.innerHTML = '';
+    document.body.innerHTML = '<main></main>';
+
+    (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (_keys: string[], callback: (value: Record<string, unknown>) => void) => {
+        callback({ [STORAGE_KEY]: 80, [ENABLED_KEY]: true });
+      },
+    );
+  });
+
+  afterEach(() => {
+    window.dispatchEvent(new Event('beforeunload'));
+  });
+
+  it('applies the configured width to the main input area', async () => {
+    const { startEditInputWidthAdjuster } = await import('../index');
+    startEditInputWidthAdjuster();
+
+    const styleText = getInjectedStyle().textContent ?? '';
+    expect(styleText).toContain('max-width: 80vw !important');
+    expect(styleText).toContain('width: min(100%, 80vw) !important');
+  });
+
+  it('widens the file-drop overlay to match the input area (#887)', async () => {
+    const { startEditInputWidthAdjuster } = await import('../index');
+    startEditInputWidthAdjuster();
+
+    const styleText = getInjectedStyle().textContent ?? '';
+    // Read the selector back out of the injected CSS so this test fails if the
+    // shipped rule changes, instead of only checking a hardcoded copy of it
+    const overlayRule = styleText.match(/(^|\n)\s*(file-drop-indicator[^{]+)\{([^}]+)\}/);
+    expect(overlayRule).not.toBeNull();
+    const selector = (overlayRule as RegExpMatchArray)[2].trim();
+    const body = (overlayRule as RegExpMatchArray)[3];
+
+    // Must stay less specific than chatWidth's input-container-prefixed overlay
+    // rule so both-enabled sessions resolve the same way as the input-area rules
+    expect(selector).toBe(
+      'file-drop-indicator .overlay-container[data-filedrop-id="chat-window-input-container"]',
+    );
+    expect(body).toContain('max-width: 80vw !important');
+    expect(body).toContain('width: min(100%, 80vw) !important');
+    expect(body).toContain('margin-left: auto !important');
+    expect(body).toContain('margin-right: auto !important');
+
+    // Behavioral check against the real DOM shape: the chat overlay matches,
+    // an overlay for a different drop target does not
+    document.body.innerHTML = `
+      <main>
+        <input-container>
+          <fieldset class="input-area-container">
+            <file-drop-indicator>
+              <div class="overlay-container" data-filedrop-id="chat-window-input-container"></div>
+            </file-drop-indicator>
+          </fieldset>
+        </input-container>
+        <file-drop-indicator>
+          <div class="overlay-container" data-filedrop-id="some-other-target"></div>
+        </file-drop-indicator>
+      </main>
+    `;
+    const matches = [...document.querySelectorAll(selector)];
+    expect(matches.map((el) => el.getAttribute('data-filedrop-id'))).toEqual([
+      'chat-window-input-container',
+    ]);
+  });
+});

--- a/src/pages/content/editInputWidth/index.ts
+++ b/src/pages/content/editInputWidth/index.ts
@@ -135,6 +135,17 @@ function applyWidth(widthPercent: number): void {
       width: 100% !important;
     }
 
+    /* Widen the file-drop overlay with the input area (#887). Gemini pins it to
+       var(--bard-chat-window-max-width-default, 760px), which only matches the
+       native input width. Kept less specific than chatWidth's overlay rule so
+       both-enabled sessions follow chatWidth, like the input-area-v2 rules do. */
+    file-drop-indicator .overlay-container[data-filedrop-id="chat-window-input-container"] {
+      max-width: ${widthValue} !important;
+      width: min(100%, ${widthValue}) !important;
+      margin-left: auto !important;
+      margin-right: auto !important;
+    }
+
     /* Fallback for browsers without :has() support */
     @supports not selector(:has(*)) {
       .content-wrapper,


### PR DESCRIPTION
## 说明

修复 #887：当 `chatWidth` 或 `editInputWidth` 把 Gemini 输入区域扩宽后，文件拖拽提示层仍被 Gemini 的原生 `760px` 最大宽度限制，导致蓝色提示层明显窄于实际可投放区域。

本 PR：

- 让 `chatWidth` 注入的文件拖拽提示层规则跟随对话区域宽度。
- 让 `editInputWidth` 注入的文件拖拽提示层规则跟随编辑输入框宽度。
- 保持两条规则的 CSS 优先级与现有 `input-area-v2` 规则一致，确保两个功能同时开启、以任意顺序注入时结果稳定。
- 为两条路径补充 DOM/CSS 回归测试和回归记录。

不在本 PR 范围内：不改变文件上传命中区域、宽度滑块语义、存储结构、权限、manifest 或其他 Gemini 布局行为。

Fixes #887

## 变更范围

基线：`upstream/main` `b88409ee51bea8a14c18ad9a6dce011a6480f5a8`

测试提交：`adafb044d350a7bdee427b2408080a75a147aad1`

rebase 后仅包含 1 个修复提交和 5 个预期文件。

## 当前 head 自动化验证

- 5 个改动文件的 Prettier 检查：通过。
- `bun run lint:check`：通过，0 errors；209 个仓库既有 warnings。
- `bun run typecheck`：通过。
- `bun run i18n:check`：通过，10 个 locale、693 个 key 一致。
- `bun run test src/pages/content/chatWidth/__tests__/chatWidth.test.ts src/pages/content/editInputWidth/__tests__/editInputWidth.test.ts`：2 个文件、6 项测试通过。
- `bun run test`：此前 CI 失败的 watermark bridge 测试已随最新 main 修复并通过；仅剩 1 项与本 PR 无关的 Windows 基线失败，见下方说明。
- `bun run build:browsers`：Chrome、Edge、Firefox、Safari 生产构建通过；Safari 资源接线校验通过。
- `bun run docs:build`：通过。
- `git diff --check upstream/main...HEAD`：通过。

完整 `verify:pr` 子项已分拆执行，避免已知的 Windows `AGENTS.md` symlink 占位文件在全仓库 `format:check` 阶段产生无关失败。

全量测试的唯一 Windows 基线失败：`scripts/__tests__/verify-release-privacy.test.ts` 将临时目录中的两个合法 `embedded.provisionprofile` 误判为 forbidden release filename；本 PR 不修改该脚本或发布隐私逻辑。

## 浏览器证据

旧组合提交 `b22c10d236a7f508ec22c3a46af756a2b63cdbd0` 曾包含相同的 #887 修复，并完成以下历史 Live 验证；这些证据用于说明复现与预期效果，不冒充当前 head 的验证：

- macOS / Chrome 150.0.7871.187：[文件拖拽提示层与输入区域等宽](https://github.com/user-attachments/assets/92588645-46cd-4a4b-93cc-07e0a1530db2)
- Windows / Chrome 150.0.7871.187：[文件拖拽提示层与输入区域等宽](https://github.com/user-attachments/assets/2719f502-4acb-4a36-907e-7af155f8b936)

当前 head 的生产构建已完成，但尚未形成 Loaded / Live 证据。此 PR 保持 draft，待补：

- Chrome Live：宽度关闭、默认值、50%、100%，明暗主题与宽/窄布局；负责人：@Daisy-1515。
- Firefox Live：同一矩阵并检查页面控制台；负责人：@Daisy-1515。
- Safari Live：同一场景；负责人：@Daisy-1515，若缺少环境则协调维护者执行。

## 检查清单

- [x] 独立分支、单 Issue、基于最新 `upstream/main`。
- [x] 只包含 #887 的 5 文件修复。
- [x] 聚焦回归测试和生产构建完成。
- [x] 自动化例外已如实记录。
- [ ] 当前 head 的 Chrome / Firefox / Safari Live 验证。
- [x] 当前 head 的 GitHub CI 完成。
## 当前 CI 状态

GitHub Actions：[run 31066047960](https://github.com/Nagi-ovo/voyager/actions/runs/31066047960)

- Test：通过；此前 watermark bridge 超时已由最新 `main` 修复。
- Format、Lint、Typecheck、i18n：通过。
- Chrome、Edge、Firefox、Safari 构建：通过。
- Native Swift Test & Xcode Build：通过。
- CI Summary：通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File-drop overlays now match the configured chat and edit-input widths.
  * Overlays remain centered and align correctly when input areas are widened.
  * Improved targeting ensures width adjustments apply only to the appropriate chat drop zone.

* **Tests**
  * Added coverage for overlay sizing, centering, CSS precedence, and DOM behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->