### PR TITLE
fix(chatwidth): prevent Gemini logo hitbox from blocking header buttons

### DIFF
--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -1091,3 +1091,40 @@ Regression test:
 
 Commit:
 `fix(timeline): use stable Gemini turn identities`
+
+## The chat width sparkle rule also matches the Gemini logo pill
+
+Symptom:
+With Voyager loaded and the sidebar open at >=1024px, Gemini's own header
+buttons (close sidebar, Upgrade, temporary chat, more) became hard or impossible
+to click. Narrowing the conversation-width slider changed how many buttons were
+affected, which made the bug look like a sidebar-width problem.
+
+Root cause:
+`chatWidth` clamps loading indicators with `main > div:has(img[src*="sparkle"])`
+(added for #110). Gemini's header logo wrapper `main > div.side-nav-menu-button`
+also contains a sparkle SVG, so it matched too and was stretched to
+`round(percent% x screen.availWidth)`. The wrapper itself is
+`pointer-events: none`, but its child `chat-app-side-nav-menu-button` is
+`pointer-events: auto` and inherits the stretched box, turning a 101px pill into
+a transparent hit box across the header. That is why the blast radius tracked
+the slider: the phantom width equals the computed pixel value, so low
+percentages only covered the close-sidebar button while 100% swallowed the whole
+header. Measuring the phantom box while only `sidebarWidth` is suspected is a
+dead end — the box is real but `pointer-events: none`, so it looks harmless.
+
+Fix:
+Exclude the logo wrapper from that one rule with
+`:not(:has(chat-app-side-nav-menu-button))`. Genuine sparkle content wrappers
+still get clamped, so #110 does not regress. Do not clamp the host's width or
+geometry instead: the host is `static` and in-flow, so touching its box
+perturbs header layout.
+
+Regression test:
+`src/pages/content/chatWidth/__tests__/chatWidth.test.ts`
+Live-page verification: toggling only that selector moves the host between 101px
+(hit-stack top `mat-icon` / `span.dynamic-upsell-label`) and the slider's pixel
+value (hit-stack top `chat-app-side-nav-menu-button`) at 30/50/70/100%.
+
+Commit:
+`fix(chatwidth): stop the sparkle rule from stretching the Gemini logo pill`

--- a/src/pages/content/chatWidth/__tests__/chatWidth.test.ts
+++ b/src/pages/content/chatWidth/__tests__/chatWidth.test.ts
@@ -119,4 +119,36 @@ describe('chatWidth', () => {
     expect(styleText).toContain(`max-width: ${expectedPx}px !important`);
     expect(styleText).toContain(`width: min(100%, ${expectedPx}px) !important`);
   });
+
+  it('excludes the header logo pill wrapper from the sparkle width rule (#875)', async () => {
+    const { startChatWidthAdjuster } = await import('../index');
+    startChatWidthAdjuster();
+
+    const styleText = getInjectedStyle().textContent ?? '';
+    // Read the selector back out of the injected CSS so this test fails if the
+    // shipped rule changes, instead of only checking a hardcoded copy of it
+    const sparkleSelector = styleText.match(/main > div:has\(img\[src\*="sparkle"\]\)[^{]*/)?.[0];
+    expect(sparkleSelector).toBeDefined();
+    expect(sparkleSelector?.trim()).toBe(
+      'main > div:has(img[src*="sparkle"]):not(:has(chat-app-side-nav-menu-button))',
+    );
+
+    // Behavioral check on the shipped selector: it must match sparkle content
+    // wrappers but never the Gemini logo pill wrapper, whose stretched
+    // transparent hit box blocked the header buttons (#875)
+    document.body.innerHTML = `
+      <main>
+        <div class="side-nav-menu-button">
+          <chat-app-side-nav-menu-button>
+            <img src="https://www.gstatic.com/lamda/images/gemini_sparkle_aurora.svg" />
+          </chat-app-side-nav-menu-button>
+        </div>
+        <div class="loading-wrapper">
+          <img src="https://www.gstatic.com/lamda/images/gemini_sparkle_loading.svg" />
+        </div>
+      </main>
+    `;
+    const matches = [...document.querySelectorAll(sparkleSelector as string)];
+    expect(matches.map((el) => el.className)).toEqual(['loading-wrapper']);
+  });
 });

--- a/src/pages/content/chatWidth/index.ts
+++ b/src/pages/content/chatWidth/index.ts
@@ -174,9 +174,12 @@ function applyWidth(widthPercent: number) {
       overflow-x: auto !important;
     }
 
+    /* Exclude the header logo pill wrapper: it also contains a sparkle img, and
+       widening it stretches chat-app-side-nav-menu-button into a transparent
+       hit box that blocks the header buttons (#875) */
     model-response:has(> .deferred-response-indicator),
-    .response-container:has(img[src*="sparkle"]), 
-    main > div:has(img[src*="sparkle"]) {
+    .response-container:has(img[src*="sparkle"]),
+    main > div:has(img[src*="sparkle"]):not(:has(chat-app-side-nav-menu-button)) {
       max-width: ${widthValue} !important;
       width: min(100%, ${widthValue}) !important;
       margin-left: auto !important;


### PR DESCRIPTION
### 说明

这个 PR 只修复 #875：`chatWidth` 的 sparkle 选择器会误中 Gemini 左上角 Logo 容器，把其中可点击的 `chat-app-side-nav-menu-button` 拉伸成覆盖顶部按钮的透明命中区域。

- 从 sparkle 宽度规则中排除包含 `chat-app-side-nav-menu-button` 的 Logo 包装器。
- 保留真正的 sparkle 加载容器宽度约束，避免原有加载布局行为回归。
- 添加聚焦 DOM 回归测试，并记录根因与保护测试。

不在本 PR 范围内：其他宽度问题、文件拖拽提示层、`editInputWidth`、滑块语义、存储、权限、manifest，以及其他 Gemini 布局行为。

本 PR 替代已关闭的 #903。#903 关闭后分支被 rebase，GitHub 不允许直接 reopen，因此从相同修复的新 head 重新提交。

### 关联 Issue

Fixes #875

### 变更范围

基线：`upstream/main` `b88409ee51bea8a14c18ad9a6dce011a6480f5a8`

测试提交：`17505fc29d5ad4d0ca347e3d05fce6da1ab2b6f5`

rebase 后仅包含 1 个修复提交和以下 3 个文件：

- `.github/docs/REGRESSION_NOTES.md`
- `src/pages/content/chatWidth/index.ts`
- `src/pages/content/chatWidth/__tests__/chatWidth.test.ts`

### 可视化证据

以下 Live GIF 来自拆分前提交 `b22c10d236a7f508ec22c3a46af756a2b63cdbd0`。该提交包含与本 PR 相同的 #875 补丁，但来自拆分前的组合分支；因此这些 GIF 只作为历史行为证据保留，不冒充当前 head 的重新录制结果。

#### macOS · Chrome 150.0.7871.187

结果：调整对话区域宽度后，Gemini 顶部原生按钮保持可点击，不再被异常拉伸的 Logo 命中区域遮挡。

![macOS Chrome：对话区域宽度及顶部按钮回归验证](https://github.com/user-attachments/assets/525bf962-1dc0-4b8a-96c6-e21cba623816)

#### Windows · Chrome 150.0.7871.187

结果：调整对话区域宽度后，Gemini 顶部原生按钮保持可点击，不再被异常拉伸的 Logo 命中区域遮挡。

![Windows Chrome：对话区域宽度及顶部按钮回归验证](https://github.com/user-attachments/assets/0ec0800e-107a-4a58-af03-dc8ff38c8c62)

### 当前 head 自动化验证

- 3 个改动文件的 Prettier 检查：通过。
- `bun run lint:check`：通过，0 errors；209 个仓库既有 warnings。
- `bun run typecheck`：通过。
- `bun run i18n:check`：通过，10 个 locale、693 个 key 一致。
- `bun run test src/pages/content/chatWidth/__tests__/chatWidth.test.ts`：1 个文件、4 项测试通过。
- `bun run test`：此前 CI 失败的 watermark bridge 测试已随最新 main 修复并通过；仅剩 1 项与本 PR 无关的 Windows 基线失败，见下方说明。
- `bun run build:browsers`：Chrome、Edge、Firefox、Safari 生产构建通过；Safari 资源接线校验通过。
- `bun run docs:build`：通过。
- `git diff --check upstream/main...HEAD`：通过。

完整 `verify:pr` 子项已分拆执行，避免已知的 Windows `AGENTS.md` symlink 占位文件在全仓库 `format:check` 阶段产生无关失败。

全量测试的唯一 Windows 基线失败：`scripts/__tests__/verify-release-privacy.test.ts` 将临时目录中的两个合法 `embedded.provisionprofile` 误判为 forbidden release filename；本 PR 不修改该脚本或发布隐私逻辑。

### 浏览器状态

| 浏览器 | 当前 head 证据 | 状态 |
| --- | --- | --- |
| Chrome | 生产构建；拆分前相同 #875 补丁有上述 macOS/Windows Live GIF | 当前 head 尚待重新 Loaded / Live |
| Firefox | 生产构建 | 当前 head 尚待 Loaded / Live |
| Safari | 生产构建与资源接线校验 | 本修复不包含 Safari 专属代码 |
| Edge | 生产构建与 zip 打包 | 本修复不包含 Chromium 专属、manifest 或权限改动 |

待补检查：

- Chrome 当前 head Loaded / Live：宽度关闭、默认值、50%、100%，检查顶部原生按钮和控制台；负责人：@Daisy-1515。
- Firefox 当前 head Loaded / Live：执行同一回归矩阵并检查控制台；负责人：@Daisy-1515。

<!-- This PR intentionally contains one issue only: #875. -->
### 当前 CI 状态

GitHub Actions：[run 31066370318](https://github.com/Nagi-ovo/voyager/actions/runs/31066370318)

- Test：通过；此前 watermark bridge 超时已由最新 `main` 修复。
- Format、Lint、Typecheck、i18n：通过。
- Chrome、Edge、Firefox、Safari 构建：通过。
- Native Swift Test & Xcode Build：通过。
- CI Summary：通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Gemini’s header logo wrapper could be incorrectly expanded, stretching its clickable area across nearby header controls.
  * Preserved the intended width adjustment for genuine sparkle content in chat responses.

* **Tests**
  * Added regression coverage to verify correct behavior for both header controls and chat content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->