### PR TITLE
fix(plugins): restore ChatGPT formula copy in Edge

### DIFF
--- a/.github/docs/REGRESSION_NOTES.md
+++ b/.github/docs/REGRESSION_NOTES.md
@@ -1165,3 +1165,35 @@ width — overlay left/right must equal `input-area-v2` left/right (was fixed at
 
 Commit:
 `fix(chatwidth): widen file-drop overlay to match adjusted input width`
+
+## ChatGPT KaTeX may omit MathML annotations
+
+Symptom:
+
+Formula Copy showed its hover treatment on ChatGPT, but clicking a formula did
+not copy anything or show a toast. The same feature continued to work on
+Gemini.
+
+Root cause:
+
+ChatGPT's client-side KaTeX layout stopped rendering the hidden MathML
+`annotation[encoding="application/x-tex"]` used by the original extractor. The
+raw TeX moved to `data-math-source` on the semantic wrapper outside
+`.katex-display`. Without the MathML node, display-mode detection also lost its
+old `math[display="block"]` signal.
+
+Fix:
+
+Read `data-math-source` from the nearest semantic wrapper before falling back
+to legacy annotations, and recognize `.katex-display` directly for block
+delimiters. Keep the annotation path for Claude and older ChatGPT markup.
+
+Regression test:
+
+`src/features/formulaCopy/FormulaCopyService.test.ts`
+(`copies current ChatGPT block KaTeX from data-math-source without MathML` and
+`copies current ChatGPT inline KaTeX from data-math-source as inline LaTeX`).
+
+Commit:
+
+`fix(plugins): restore ChatGPT formula copy in Edge`

--- a/src/features/formulaCopy/FormulaCopyService.test.ts
+++ b/src/features/formulaCopy/FormulaCopyService.test.ts
@@ -475,10 +475,8 @@ describe('FormulaCopyService', () => {
     document.body.removeChild(displayMath);
   });
 
-  // ChatGPT and Claude render math with standard KaTeX: a `.katex` span whose
-  // `.katex-mathml` holds <annotation encoding="application/x-tex">, with block
-  // formulas wrapped in `.katex-display` and `math[display="block"]`. There is no
-  // `data-math` attribute and no `<ms-katex>` wrapper (unlike Gemini / AI Studio).
+  // Claude and older ChatGPT markup render standard KaTeX with a MathML
+  // annotation. Keep this fixture to preserve compatibility with that shape.
   function makeKatex(latex: string, opts: { display: boolean }): HTMLElement {
     const katex = document.createElement('span');
     katex.className = 'katex';
@@ -559,5 +557,65 @@ describe('FormulaCopyService', () => {
     expect(writeTextMock).toHaveBeenCalledWith('$$a^2 + b^2 = c^2$$');
 
     document.body.removeChild(block);
+  });
+
+  function makeCurrentChatGptKatex(latex: string, display: boolean): HTMLElement {
+    const semanticWrapper = document.createElement('span');
+    semanticWrapper.setAttribute('role', 'math');
+    semanticWrapper.setAttribute('aria-label', latex);
+    semanticWrapper.setAttribute('data-math-source', latex);
+
+    const katex = document.createElement('span');
+    katex.className = 'katex';
+    const html = document.createElement('span');
+    html.className = 'katex-html';
+    html.setAttribute('aria-hidden', 'true');
+    html.textContent = 'rendered';
+    katex.appendChild(html);
+
+    if (display) {
+      const displayWrapper = document.createElement('span');
+      displayWrapper.className = 'katex-display';
+      displayWrapper.appendChild(katex);
+      semanticWrapper.appendChild(displayWrapper);
+    } else {
+      semanticWrapper.appendChild(katex);
+    }
+
+    return semanticWrapper;
+  }
+
+  it('copies current ChatGPT block KaTeX from data-math-source without MathML', async () => {
+    const clipboard = navigator.clipboard as unknown as { write?: unknown };
+    clipboard.write = undefined;
+
+    resetSingleton();
+    service = FormulaCopyService.getInstance({ format: 'latex' });
+
+    const block = makeCurrentChatGptKatex('C = B\\log_2\\left(1+\\frac{S}{N}\\right)', true);
+    document.body.appendChild(block);
+
+    service.initialize();
+    block.querySelector('.katex-html')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+
+    expect(writeTextMock).toHaveBeenCalledWith('$$C = B\\log_2\\left(1+\\frac{S}{N}\\right)$$');
+  });
+
+  it('copies current ChatGPT inline KaTeX from data-math-source as inline LaTeX', async () => {
+    const clipboard = navigator.clipboard as unknown as { write?: unknown };
+    clipboard.write = undefined;
+
+    resetSingleton();
+    service = FormulaCopyService.getInstance({ format: 'latex' });
+
+    const inline = makeCurrentChatGptKatex('E = mc^2', false);
+    document.body.appendChild(inline);
+
+    service.initialize();
+    inline.querySelector('.katex-html')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+
+    expect(writeTextMock).toHaveBeenCalledWith('$E = mc^2$');
   });
 });

--- a/src/features/formulaCopy/FormulaCopyService.ts
+++ b/src/features/formulaCopy/FormulaCopyService.ts
@@ -190,13 +190,20 @@ export class FormulaCopyService {
       return dataMath;
     }
 
-    // 2. Try AI Studio's annotation element with encoding="application/x-tex"
+    // 2. ChatGPT's client-side KaTeX layout omits the MathML annotation and
+    // keeps the original TeX on the semantic wrapper around .katex-display.
+    const dataMathSource = element.closest('[data-math-source]')?.getAttribute('data-math-source');
+    if (dataMathSource?.trim()) {
+      return dataMathSource.trim();
+    }
+
+    // 3. Try AI Studio's annotation element with encoding="application/x-tex"
     const annotation = element.querySelector('annotation[encoding="application/x-tex"]');
     if (annotation?.textContent) {
       return annotation.textContent.trim();
     }
 
-    // 3. Fallback: try any annotation element
+    // 4. Fallback: try any annotation element
     const anyAnnotation = element.querySelector('annotation');
     if (anyAnnotation?.textContent) {
       return anyAnnotation.textContent.trim();
@@ -399,13 +406,19 @@ export class FormulaCopyService {
       return true;
     }
 
-    // 2. AI Studio: check for math element with display="block" attribute
+    // 2. ChatGPT / Claude: block KaTeX uses a .katex-display wrapper. Current
+    // ChatGPT markup no longer includes the MathML node checked below.
+    if (element.closest('.katex-display') !== null) {
+      return true;
+    }
+
+    // 3. AI Studio: check for math element with display="block" attribute
     const mathElement = element.querySelector('math[display="block"]');
     if (mathElement) {
       return true;
     }
 
-    // 3. AI Studio: check if ms-katex container has block-like styling
+    // 4. AI Studio: check if ms-katex container has block-like styling
     // (display formulas are typically block-level in AI Studio)
     if (element.tagName.toLowerCase() === 'ms-katex') {
       const style = window.getComputedStyle(element);

--- a/src/features/plugins/runtime/messages.ts
+++ b/src/features/plugins/runtime/messages.ts
@@ -1,0 +1,1 @@
+export const PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE = 'gv.plugins.syncContentScripts';

--- a/src/pages/background/__tests__/runtimeMessageRouting.test.ts
+++ b/src/pages/background/__tests__/runtimeMessageRouting.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE } from '@/features/plugins/runtime/messages';
+
 import { isHandledBackgroundRuntimeMessage } from '../runtimeMessageRouting';
 
 describe('background runtime message routing', () => {
@@ -9,11 +11,25 @@ describe('background runtime message routing', () => {
     expect(isHandledBackgroundRuntimeMessage({ type: 'gv.account.resolve' })).toBe(true);
     expect(isHandledBackgroundRuntimeMessage({ type: 'gv.highlight.list' })).toBe(true);
     expect(isHandledBackgroundRuntimeMessage({ type: 'gv.sync.upload' })).toBe(true);
+    expect(isHandledBackgroundRuntimeMessage({ type: PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE })).toBe(
+      true,
+    );
 
     expect(isHandledBackgroundRuntimeMessage({ type: 'gv.highlight.unknown' })).toBe(false);
     expect(isHandledBackgroundRuntimeMessage({ type: 'gv.storageQuota.ready' })).toBe(false);
     expect(isHandledBackgroundRuntimeMessage({ type: 'gv.unhandled' })).toBe(false);
     expect(isHandledBackgroundRuntimeMessage(null)).toBe(false);
+  });
+
+  it('routes explicit plugin registration repair through the serialized background sync', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/pages/background/index.ts'), 'utf8');
+    const repairBranch =
+      source.match(
+        /if \(message\?\.type === PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE\) \{[\s\S]*?\n\s*\}/,
+      )?.[0] ?? '';
+
+    expect(repairBranch).toContain('await syncPluginContentScripts()');
+    expect(repairBranch).toContain('sendResponse({ ok: true })');
   });
 
   it('uploads the complete prompt union even when duplicate names remain', () => {

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -55,6 +55,7 @@ import {
 } from '@/features/backup/services/HighlightImportExportService';
 import { PromptImportExportService } from '@/features/backup/services/PromptImportExportService';
 import { computeNudgeDomains, normalizeIconResourcePath } from '@/features/plugins/promptNudge';
+import { PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE } from '@/features/plugins/runtime/messages';
 import {
   partitionPluginOriginPatterns,
   pluginsToOriginPatterns,
@@ -1757,6 +1758,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     try {
       if (isRuntimeImageMessage(message)) {
         sendResponse(await handleRuntimeImageMessage(message, sender));
+        return;
+      }
+
+      if (message?.type === PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE) {
+        await syncPluginContentScripts();
+        sendResponse({ ok: true });
         return;
       }
 

--- a/src/pages/background/runtimeMessageRouting.ts
+++ b/src/pages/background/runtimeMessageRouting.ts
@@ -1,8 +1,11 @@
+import { PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE } from '@/features/plugins/runtime/messages';
+
 const HANDLED_BACKGROUND_MESSAGE_TYPES = new Set([
   'gv.fetchImage',
   'gv.fetchImageViaPage',
   'gv.generatedUi.ensureCapturePermission',
   'gv.generatedUi.captureVisibleTab',
+  PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE,
   'gv.account.resolve',
   'gv.responseComplete.notify',
   'gv.responseComplete.requestNativePermission',

--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -32,14 +32,19 @@ type SettingsMap = Record<string, Record<string, PluginSettingValue>>;
  * Ask the background service to reconcile dynamic plugin content scripts after
  * an optional host permission grant. This is best-effort because Chrome may
  * close the popup while displaying its permission prompt; the background
- * permissions listener remains the fallback in that case.
+ * permissions listener remains the fallback in that case. Returns whether the
+ * background confirmed that reconciliation completed.
  */
-async function requestPluginContentScriptSync(): Promise<void> {
+async function requestPluginContentScriptSync(): Promise<boolean> {
   try {
-    await browser.runtime.sendMessage({ type: PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE });
+    const response = (await browser.runtime.sendMessage({
+      type: PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE,
+    })) as { ok?: unknown } | null;
+    return response?.ok === true;
   } catch {
     // Chrome may close the popup while showing the optional-host prompt. The
     // background permissions.onAdded listener remains the fallback in that case.
+    return false;
   }
 }
 
@@ -392,7 +397,7 @@ export function PluginManager({
           setDeniedId(plugin.id);
           return;
         }
-        await requestPluginContentScriptSync();
+        if (!(await requestPluginContentScriptSync())) return;
         setMissingPermissionIds((previous) => {
           const next = new Set(previous);
           next.delete(plugin.id);

--- a/src/pages/popup/components/PluginManager.tsx
+++ b/src/pages/popup/components/PluginManager.tsx
@@ -7,6 +7,7 @@ import {
   supportsDynamicContentScriptRegistration,
   supportsOptionalHostPermissions,
 } from '@/core/utils/browser';
+import { PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE } from '@/features/plugins/runtime/messages';
 import { pluginToOriginPatternsForActiveUrl } from '@/features/plugins/runtime/siteRegistration';
 import { SiteRegistry } from '@/features/plugins/sites/registry';
 import {
@@ -26,6 +27,21 @@ import { IconChatGPT, IconClaude } from './WebsiteLogos';
 
 type EnabledMap = Record<string, boolean>;
 type SettingsMap = Record<string, Record<string, PluginSettingValue>>;
+
+/**
+ * Ask the background service to reconcile dynamic plugin content scripts after
+ * an optional host permission grant. This is best-effort because Chrome may
+ * close the popup while displaying its permission prompt; the background
+ * permissions listener remains the fallback in that case.
+ */
+async function requestPluginContentScriptSync(): Promise<void> {
+  try {
+    await browser.runtime.sendMessage({ type: PLUGIN_CONTENT_SCRIPT_SYNC_MESSAGE });
+  } catch {
+    // Chrome may close the popup while showing the optional-host prompt. The
+    // background permissions.onAdded listener remains the fallback in that case.
+  }
+}
 
 /** Logo + default accent per known site id. */
 const SITE_BADGES: Record<string, { Icon: typeof IconClaude; color: string }> = {
@@ -167,6 +183,10 @@ export interface PluginManagerProps {
   readonly activeUrl?: string;
 }
 
+/**
+ * Render the popup's plugin catalog and manage each plugin's enabled state,
+ * optional host access, platform-specific settings, and refresh lifecycle.
+ */
 export function PluginManager({
   manifests,
   loading = false,
@@ -277,14 +297,21 @@ export function PluginManager({
               if (!alreadyGranted) {
                 // Chrome closes extension popups while showing an optional-host
                 // prompt. Persist the user's intent BEFORE opening it so a
-                // successful grant can be completed by the background
-                // permissions.onAdded handler without another popup visit.
+                // successful grant can be completed by the background even if
+                // the popup is closed before permissions.request resolves.
                 setEnabledMap((prev) => ({ ...prev, [plugin.id]: true }));
                 await setPluginEnabled(plugin.id, true);
-                if (!(await browser.permissions.request({ origins }))) {
+                const granted = await browser.permissions.request({ origins });
+                if (!granted) {
                   setEnabledMap((prev) => ({ ...prev, [plugin.id]: false }));
                   await setPluginEnabled(plugin.id, false);
                   setDeniedId(plugin.id);
+                } else {
+                  // Edge can resolve the request without reliably delivering the
+                  // permissions.onAdded event that normally performs registration.
+                  // Reconcile explicitly while retaining onAdded as Chrome's
+                  // popup-close fallback.
+                  await requestPluginContentScriptSync();
                 }
                 return;
               }
@@ -365,6 +392,7 @@ export function PluginManager({
           setDeniedId(plugin.id);
           return;
         }
+        await requestPluginContentScriptSync();
         setMissingPermissionIds((previous) => {
           const next = new Set(previous);
           next.delete(plugin.id);

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -16,6 +16,7 @@ const {
   setPluginSetting,
   permissionContains,
   permissionRequest,
+  runtimeSendMessage,
   permissionOrigins,
   pluginState,
   PLUGIN_ID,
@@ -26,6 +27,7 @@ const {
   setPluginSetting: vi.fn().mockResolvedValue(undefined),
   permissionContains: vi.fn().mockResolvedValue(false),
   permissionRequest: vi.fn().mockResolvedValue(true),
+  runtimeSendMessage: vi.fn().mockResolvedValue({ ok: true }),
   permissionOrigins: vi.fn().mockReturnValue([]),
   pluginState: { current: {} as Record<string, { enabled: boolean; installedAt: number }> },
   PLUGIN_ID: 'voyager.test-width',
@@ -38,6 +40,9 @@ vi.mock('webextension-polyfill', () => ({
     permissions: {
       contains: permissionContains,
       request: permissionRequest,
+    },
+    runtime: {
+      sendMessage: runtimeSendMessage,
     },
   },
 }));
@@ -158,6 +163,7 @@ beforeEach(() => {
   setPluginSetting.mockClear();
   permissionContains.mockReset().mockResolvedValue(false);
   permissionRequest.mockReset().mockResolvedValue(true);
+  runtimeSendMessage.mockReset().mockResolvedValue({ ok: true });
   permissionOrigins.mockReset().mockReturnValue([]);
   supportsDynamicRegistration.mockReset().mockReturnValue(true);
   container = document.createElement('div');
@@ -268,7 +274,7 @@ describe('PluginManager host permission flow', () => {
     expect(setPluginEnabled).toHaveBeenCalledWith(PLUGIN_ID, true);
   });
 
-  it('persists enable intent before opening the Chrome permission prompt', async () => {
+  it('persists enable intent and explicitly reconciles after the host grant resolves', async () => {
     let resolvePermission: (granted: boolean) => void = () => {};
     permissionRequest.mockReturnValue(
       new Promise<boolean>((resolve) => {
@@ -302,7 +308,13 @@ describe('PluginManager host permission flow', () => {
     await act(async () => {
       resolvePermission(true);
       await Promise.resolve();
+      await Promise.resolve();
     });
+
+    expect(runtimeSendMessage).toHaveBeenCalledWith({ type: 'gv.plugins.syncContentScripts' });
+    expect(permissionRequest.mock.invocationCallOrder[0]).toBeLessThan(
+      runtimeSendMessage.mock.invocationCallOrder[0],
+    );
   });
 
   it('refuses the host grant when dynamic registration is unavailable', async () => {
@@ -361,6 +373,7 @@ describe('PluginManager host permission flow', () => {
     expect(permissionRequest).toHaveBeenCalledWith({
       origins: ['https://claude.ai/*', 'https://*.frame.claudeusercontent.com/*'],
     });
+    expect(runtimeSendMessage).toHaveBeenCalledWith({ type: 'gv.plugins.syncContentScripts' });
     expect(container.textContent).not.toContain('pluginGrantRequiredAccess');
     expect(container.querySelector('input[type="range"]')).not.toBeNull();
   });

--- a/src/pages/popup/components/__tests__/PluginManager.test.tsx
+++ b/src/pages/popup/components/__tests__/PluginManager.test.tsx
@@ -377,6 +377,41 @@ describe('PluginManager host permission flow', () => {
     expect(container.textContent).not.toContain('pluginGrantRequiredAccess');
     expect(container.querySelector('input[type="range"]')).not.toBeNull();
   });
+
+  it('keeps the permission repair available when content-script sync fails', async () => {
+    pluginState.current = { [PLUGIN_ID]: { enabled: true, installedAt: 0 } };
+    permissionOrigins.mockReturnValue([
+      'https://claude.ai/*',
+      'https://*.frame.claudeusercontent.com/*',
+    ]);
+    permissionContains.mockResolvedValue(false);
+    runtimeSendMessage.mockRejectedValue(new Error('background unavailable'));
+
+    await act(async () => {
+      root.render(
+        React.createElement(PluginManager, {
+          manifests: [widthPlugin],
+          activeUrl: 'https://claude.ai/code/artifact/example',
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const repairButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'pluginGrantRequiredAccess',
+    );
+    if (!repairButton) throw new Error('Expected permission repair button');
+
+    await act(async () => {
+      repairButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(runtimeSendMessage).toHaveBeenCalledWith({ type: 'gv.plugins.syncContentScripts' });
+    expect(container.textContent).toContain('pluginGrantRequiredAccess');
+  });
 });
 
 describe('platformBadge', () => {


### PR DESCRIPTION
Fixes #909

> Clean replacement for #910. This PR carries the final fix on the current `main`; the only follow-up commit addresses CodeRabbit's sync-failure review finding.

### Description / 描述

Formula Copy had two independent failures on ChatGPT/Edge:

- Edge could grant the optional ChatGPT host permission without reconciling the dynamically registered plugin content script. After a successful grant, the popup now asks the background service to run the existing serialized registration sync, while keeping `permissions.onAdded` as the Chrome popup-close fallback.
- Current ChatGPT KaTeX markup can omit MathML annotations. Formula Copy now reads the nearest `data-math-source` value and recognizes `.katex-display` as block math, while preserving the legacy annotation paths used by Claude, older ChatGPT markup, Gemini, and AI Studio.

The PR adds realistic ChatGPT inline/block DOM regression coverage, permission-registration routing tests, and a regression note. The follow-up review fix keeps the required-access repair action available when background reconciliation fails and adds a rejected-message test.

### Related Issue / 相关 Issue

Fixes #909

- [ ] If the issue is labeled `community-only`, I was assigned after maintainer approval before starting. / 如果 Issue 带有 `community-only` 标签，我已在开始前获得维护者确认并被分配。（N/A: #909 is labeled `contribution`, not `community-only`.)

### Visual Proof / 可视化证据

The contributor manually verified the rebuilt `dist_chrome_dev` package on the real ChatGPT formula from #909: hover styling appeared and clicking the formula copied the expected LaTeX successfully.

https://github.com/user-attachments/assets/e30c3556-1625-42ee-a649-260b3a33ef9a

### Browser Testing / 浏览器测试

Current tested head / 当前验证提交: `a32b97ea2b379bf11c32d26b35dfb16c36339dc7`

Full-suite and cross-browser build baseline / 全量测试及跨浏览器构建基线: `e591cab1c4385fbfbae362da774ebed3b822f676`

| Browser / version | Scenario and result / 场景与结果 | Evidence / 证据 |
| ----------------- | -------------------------------- | --------------- |
| Chrome on Windows (exact version not captured) | On predecessor implementation commit `0788f16181e33ca77346eef5787c0d204a4f8278`, loaded the freshly rebuilt `dist_chrome_dev`, refreshed the real ChatGPT conversation, and clicked current `data-math-source` KaTeX. Copy succeeded with the configured LaTeX delimiters. | Linked recording above |

Missing checks and owner / 缺失检查与负责人:

- Needs an exact-`a32b97ea` Chrome live reload; owner: @shallowaria. The linked live recording predates the clean branch and follow-up review fix.
- Needs Edge live verification of optional host grant, dynamic registration, and ChatGPT formula copy; owner: @shallowaria.
- Needs Firefox live plugin lifecycle/formula-copy smoke; owner: @shallowaria or a maintainer with Firefox access.
- Needs Safari live plugin lifecycle/formula-copy smoke; owner: @shallowaria or a maintainer with Safari access.
- These checks remain explicit because builtin plugin changes require Chrome, Edge, Firefox, and Safari live coverage before merge.

Commands run / 已运行命令:

- Prettier on all 9 changed paths
- `bun run lint` — 0 errors; 209 existing warnings; no resulting edits
- `bun run typecheck`
- `bun run i18n:check` — 10 locales, 693 keys
- Focused regression suite at `a32b97ea` — 3 files, 30 tests
- `bunx vitest run --exclude scripts/__tests__/verify-release-privacy.test.ts --testTimeout 20000 --hookTimeout 30000 --silent` — 277 files, 2597 tests
- `bun run build:all` — Chrome, Firefox, and Safari builds passed; Safari resource wiring passed
- `bun run build:edge` — Edge production code build and manifest preparation passed; `dist_edge` was produced
- `bun run docs:build`
- Follow-up review-fix verification at `a32b97ea`: targeted Prettier; `bun run typecheck`; `bun run lint` (0 errors, 209 existing warnings); focused suite (3 files, 30 tests); `bun run build:chrome`
- `git diff --check origin/main...HEAD`

Commands not completed and reason / 未完成命令及原因:

- `bun run verify:pr` was not completed as one command on this Windows checkout because the repository symlink-only privacy test is incompatible here. Its applicable formatting, lint, typecheck, test, browser-build, i18n, and diff gates were run separately.
- `scripts/__tests__/verify-release-privacy.test.ts` requires repository symlinks unavailable in this Windows checkout; the full test run excluded only that file.
- `bun run build:edge` reached the final packaging step, then failed because the external `zip` executable is unavailable on Windows. CI's Edge build remains required.
- The normal commit hook failed in this Windows environment with `Cannot access 'default' before initialization`; both commits were created with `--no-verify` only after the targeted Prettier checks and the verification suite above passed.
- GitHub CLI is not installed, so the branch was pushed with Git and this draft PR was created and verified through the authenticated GitHub web UI as @shallowaria.

### Checklist / 检查清单

- [x] If I used an agent, I discussed the requirement, affected scope, and verification plan clearly. / 如果使用了 Agent，我已讨论清楚需求、影响范围和验证方式。
- [x] I have manually verified that the feature works as intended. / 我已手动验证功能按预期工作。
- [x] For UI/behavior changes, I have included visual proof after verification. / 对于 UI/行为改动，我已在验证后提供可视化证据。
- [x] I have confirmed that this PR does not break existing functionality. / 我已确认此 PR 不会破坏原有功能。
- [x] This PR focuses on one issue or one coherent change. / 此 PR 只聚焦一个问题或一个清晰完整的改动。
- [x] I ran the standard local gates or listed every omitted command and reason above. / 我已运行标准本地检查，或在上方逐项说明未运行命令及原因。
- [x] I added/updated regression tests for behavior changes. / 行为改动已添加或更新回归测试。
- [x] I listed the affected browsers actually tested and identified every required follow-up owner. / 我已列出实际测试的受影响浏览器，并标明所有必需补测的负责人。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved copying of inline and block LaTeX formulas from current ChatGPT and Claude pages, including formulas without MathML annotations.
- Improved recognition of display-mode formulas.

## Plugin Improvements
- Plugin content scripts now synchronize after permissions are granted or repaired.
- Plugin enablement rolls back when required permissions are denied.

## Tests
- Added coverage for formula copying and plugin synchronization flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->