### PR TITLE
fix(claude-usage): scope cache by organization id

### DIFF
--- a/src/core/services/StorageQuotaService.ts
+++ b/src/core/services/StorageQuotaService.ts
@@ -242,7 +242,7 @@ const CATEGORY_DEFINITIONS: readonly CategoryDefinition[] = [
   {
     id: 'cache',
     exactKeys: REGENERABLE_CACHE_KEYS,
-    prefixes: [`${StorageKeys.GV_USAGE_CACHE}:`],
+    prefixes: [`${StorageKeys.GV_USAGE_CACHE}:`, `${StorageKeys.GV_CLAUDE_USAGE_CACHE}:`],
     clearable: true,
   },
   {

--- a/src/core/services/__tests__/StorageQuotaService.test.ts
+++ b/src/core/services/__tests__/StorageQuotaService.test.ts
@@ -118,6 +118,7 @@ describe('StorageQuotaService', () => {
       'gvDraft_/app/one': { text: 'draft' },
       [StorageKeys.GV_GEMS_LIST_CACHE]: { items: [] },
       [`${StorageKeys.GV_USAGE_CACHE}:account`]: { daily: [] },
+      [`${StorageKeys.GV_CLAUDE_USAGE_CACHE}:org_123`]: { metrics: [] },
       [StorageKeys.LANGUAGE]: 'en',
       [STORAGE_QUOTA_SOFT_CAP_KEY]: 50,
       unknownFuturePayload: { large: true },
@@ -168,6 +169,7 @@ describe('StorageQuotaService', () => {
     expect(category(snapshot, 'cache').keys).toEqual([
       StorageKeys.GV_GEMS_LIST_CACHE,
       `${StorageKeys.GV_USAGE_CACHE}:account`,
+      `${StorageKeys.GV_CLAUDE_USAGE_CACHE}:org_123`,
     ]);
     expect(category(snapshot, 'settings').keys).toEqual([
       'gvAnnotation:index',

--- a/src/features/plugins/builtin/claudeUsage/index.test.ts
+++ b/src/features/plugins/builtin/claudeUsage/index.test.ts
@@ -398,8 +398,10 @@ describe('Claude usage bar', () => {
   it('refreshes countdown labels without another API request', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-28T10:00:00.000Z'));
+    mockDocumentCookie('lastActiveOrg=org_123');
     (chrome.storage.local.get as unknown as Mock).mockResolvedValue({
       gvClaudeUsageCache: {
+        orgId: 'org_123',
         plan: 'Pro',
         updatedAt: Date.now(),
         metrics: [
@@ -812,8 +814,10 @@ describe('Claude usage bar', () => {
         storageListeners.push(listener);
       },
     );
+    mockDocumentCookie('lastActiveOrg=org_123');
     (chrome.storage.local.get as unknown as Mock).mockResolvedValue({
       gvClaudeUsageCache: {
+        orgId: 'org_123',
         plan: 'Fresh',
         updatedAt: 10,
         metrics: [{ label: 'All', percent: 45 }],
@@ -831,6 +835,7 @@ describe('Claude usage bar', () => {
       {
         gvClaudeUsageCache: {
           newValue: {
+            orgId: 'org_123',
             plan: 'Old',
             updatedAt: 5,
             metrics: [{ label: 'All', percent: 12 }],
@@ -847,6 +852,7 @@ describe('Claude usage bar', () => {
       {
         gvClaudeUsageCache: {
           newValue: {
+            orgId: 'org_123',
             plan: 'New',
             updatedAt: 11,
             metrics: [{ label: 'All', percent: 60 }],

--- a/src/features/plugins/builtin/claudeUsage/index.test.ts
+++ b/src/features/plugins/builtin/claudeUsage/index.test.ts
@@ -578,8 +578,11 @@ describe('Claude usage bar', () => {
 
   it('uses shared cache to avoid multiplying API requests across Claude tabs', async () => {
     vi.useFakeTimers();
-    const store = {
-      gvClaudeUsageCache: {
+    const orgId = 'org_123';
+    const scopedKey = claudeUsageCacheKeyForOrg(orgId);
+    const store: Record<string, unknown> = {
+      [scopedKey]: {
+        orgId,
         plan: 'Pro',
         updatedAt: Date.now(),
         metrics: [
@@ -592,7 +595,7 @@ describe('Claude usage bar', () => {
       },
     };
     mockLocalStorageStore(store);
-    mockDocumentCookie('lastActiveOrg=org_123');
+    mockDocumentCookie(`lastActiveOrg=${orgId}`);
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
@@ -602,7 +605,8 @@ describe('Claude usage bar', () => {
     expect(fetchMock).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(4 * 60_000);
-    store.gvClaudeUsageCache = {
+    store[scopedKey] = {
+      orgId,
       plan: 'Pro',
       updatedAt: Date.now(),
       metrics: [
@@ -904,11 +908,12 @@ describe('Claude usage bar', () => {
     expect(document.querySelector('.gv-usage-tier')?.textContent).toBe('Pro');
   });
 
-  it('falls back to legacy cache key when no scoped key exists', async () => {
+  it('falls back to legacy cache key when legacy has matching orgId', async () => {
     vi.useFakeTimers();
     const orgId = 'org_legacy';
     mockDocumentCookie(`lastActiveOrg=${orgId}`);
     const legacySnapshot = {
+      orgId,
       plan: 'Pro',
       updatedAt: Date.now(),
       metrics: [{ label: '5h', percent: 50, resetLabel: 'Tue 12:00 PM' }],

--- a/src/features/plugins/builtin/claudeUsage/index.test.ts
+++ b/src/features/plugins/builtin/claudeUsage/index.test.ts
@@ -1,6 +1,7 @@
 import { type Mock, afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  claudeUsageCacheKeyForOrg,
   claudeUsageUrl,
   isClaudeUsageSettings,
   planFromClaudeBootstrap,
@@ -853,5 +854,73 @@ describe('Claude usage bar', () => {
 
     expect(document.querySelector('.gv-usage-tier')?.textContent).toBe('New');
     expect(document.querySelector<HTMLElement>('.gv-usage-fill')?.style.width).toBe('60%');
+  });
+
+  it('scopes the cache key by organization id', () => {
+    expect(claudeUsageCacheKeyForOrg('org_123')).toBe('gvClaudeUsageCache:org_123');
+    expect(claudeUsageCacheKeyForOrg('org_456')).toBe('gvClaudeUsageCache:org_456');
+  });
+
+  it('does not show cached usage from a different org after account switch', async () => {
+    vi.useFakeTimers();
+    const orgAKey = claudeUsageCacheKeyForOrg('org_A');
+    const store: Record<string, unknown> = {
+      [orgAKey]: {
+        orgId: 'org_A',
+        plan: 'Max (20x)',
+        updatedAt: Date.now(),
+        metrics: [{ label: '5h', percent: 80, resetLabel: 'Tue 10:00 AM' }],
+      },
+    };
+    mockLocalStorageStore(store);
+    mockDocumentCookie('lastActiveOrg=org_B');
+
+    startClaudeUsage();
+    await flushAsyncWork();
+
+    expect(document.querySelector('.gv-usage-pct')?.textContent).not.toBe('80%');
+    expect(document.querySelector('.gv-usage-tier')?.textContent).not.toBe('Max (20x)');
+  });
+
+  it('preserves cache behavior for the same org', async () => {
+    vi.useFakeTimers();
+    const orgId = 'org_123';
+    mockDocumentCookie(`lastActiveOrg=${orgId}`);
+    const scopedKey = claudeUsageCacheKeyForOrg(orgId);
+    const cachedSnapshot = {
+      orgId,
+      plan: 'Pro',
+      updatedAt: Date.now(),
+      metrics: [{ label: '5h', percent: 30, resetLabel: 'Tue 11:00 AM' }],
+    };
+    mockLocalStorageStore({ [scopedKey]: cachedSnapshot });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    startClaudeUsage();
+    await flushAsyncWork();
+
+    expect(document.querySelector('.gv-usage-pct')?.textContent).toBe('30%');
+    expect(document.querySelector('.gv-usage-tier')?.textContent).toBe('Pro');
+  });
+
+  it('falls back to legacy cache key when no scoped key exists', async () => {
+    vi.useFakeTimers();
+    const orgId = 'org_legacy';
+    mockDocumentCookie(`lastActiveOrg=${orgId}`);
+    const legacySnapshot = {
+      plan: 'Pro',
+      updatedAt: Date.now(),
+      metrics: [{ label: '5h', percent: 50, resetLabel: 'Tue 12:00 PM' }],
+    };
+    mockLocalStorageStore({ gvClaudeUsageCache: legacySnapshot });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    startClaudeUsage();
+    await flushAsyncWork();
+
+    expect(document.querySelector('.gv-usage-pct')?.textContent).toBe('50%');
+    expect(document.querySelector('.gv-usage-tier')?.textContent).toBe('Pro');
   });
 });

--- a/src/features/plugins/builtin/claudeUsage/index.ts
+++ b/src/features/plugins/builtin/claudeUsage/index.ts
@@ -28,6 +28,7 @@ export interface ClaudeUsageSnapshot {
   plan?: string;
   lastUpdatedLabel?: string;
   updatedAt: number;
+  orgId?: string;
 }
 
 interface ClaudeUsageRefreshLock {
@@ -60,6 +61,7 @@ const refreshOwnerId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 // re-check it before touching the DOM, or a disabled plugin resurrects the
 // pill as un-removable zombie UI.
 let generation = 0;
+let currentOrgId: string | null = null;
 
 export function claudeUsageUrl(pathname = location.pathname, search = location.search): string {
   return `${CLAUDE_ORIGIN}${pathname === '/' ? '/new' : pathname}${search}#settings/usage`;
@@ -71,6 +73,14 @@ export function isClaudeUsageSettings(hash = location.hash): boolean {
 
 export function setClaudeUsageReloadForTest(fn: (() => void) | null): void {
   reloadPage = fn ?? (() => location.reload());
+}
+
+export function claudeUsageCacheKeyForOrg(orgId: string): string {
+  return `${StorageKeys.GV_CLAUDE_USAGE_CACHE}:${orgId}`;
+}
+
+function isSnapshotForOrg(snapshot: ClaudeUsageSnapshot, orgId: string): boolean {
+  return !snapshot.orgId || snapshot.orgId === orgId;
 }
 
 function pageText(doc: Document): string {
@@ -684,24 +694,41 @@ function applyStoredSnapshot(cached: ClaudeUsageSnapshot): void {
   }
 }
 
-async function readCache(): Promise<ClaudeUsageSnapshot | null> {
+async function readCache(orgId: string | null): Promise<ClaudeUsageSnapshot | null> {
   try {
-    const result = await chrome.storage?.local?.get({ [StorageKeys.GV_CLAUDE_USAGE_CACHE]: null });
-    const raw = result?.[StorageKeys.GV_CLAUDE_USAGE_CACHE];
-    return isUsageSnapshot(raw) ? raw : null;
+    const keys = orgId
+      ? [claudeUsageCacheKeyForOrg(orgId), StorageKeys.GV_CLAUDE_USAGE_CACHE]
+      : [StorageKeys.GV_CLAUDE_USAGE_CACHE];
+    const result = await chrome.storage?.local?.get(
+      Object.fromEntries(keys.map((key) => [key, null])),
+    );
+    if (orgId) {
+      const scoped = result?.[claudeUsageCacheKeyForOrg(orgId)];
+      if (isUsageSnapshot(scoped) && isSnapshotForOrg(scoped, orgId)) return scoped;
+    }
+    const legacy = result?.[StorageKeys.GV_CLAUDE_USAGE_CACHE];
+    if (isUsageSnapshot(legacy) && (!orgId || isSnapshotForOrg(legacy, orgId))) return legacy;
+    return null;
   } catch {
     return null;
   }
 }
 
 async function loadCache(): Promise<void> {
-  const cached = await readCache();
+  const cookieOrg = getLastActiveOrg();
+  if (cookieOrg) currentOrgId = cookieOrg;
+  const cached = await readCache(cookieOrg);
   if (cached) applyStoredSnapshot(cached);
 }
 
-async function saveCache(next: ClaudeUsageSnapshot): Promise<void> {
+async function saveCache(next: ClaudeUsageSnapshot, orgId: string | null): Promise<void> {
   try {
-    await chrome.storage?.local?.set({ [StorageKeys.GV_CLAUDE_USAGE_CACHE]: next });
+    const withOrg = orgId ? { ...next, orgId } : next;
+    const payload: Record<string, ClaudeUsageSnapshot> = {
+      [StorageKeys.GV_CLAUDE_USAGE_CACHE]: withOrg,
+    };
+    if (orgId) payload[claudeUsageCacheKeyForOrg(orgId)] = withOrg;
+    await chrome.storage?.local?.set(payload);
   } catch {
     // ignore
   }
@@ -712,7 +739,7 @@ function applySnapshot(next: ClaudeUsageSnapshot): void {
   if (snapshot && sameSnapshotData(snapshot, merged)) return;
   snapshot = merged;
   renderPill();
-  void saveCache(merged);
+  void saveCache(merged, currentOrgId);
 }
 
 function injectClaudeUsageObserver(): void {
@@ -832,7 +859,7 @@ async function releaseRefreshLock(): Promise<void> {
 
 async function hasFreshSharedCache(maxAgeMs: number): Promise<boolean> {
   const g = generation;
-  const cached = await readCache();
+  const cached = await readCache(currentOrgId);
   if (g !== generation || !cached) return false;
   applyStoredSnapshot(cached);
   if (Date.now() - cached.updatedAt >= maxAgeMs) return false;
@@ -860,6 +887,7 @@ async function refreshFromApi(force = false): Promise<void> {
   if (g !== generation || refreshInFlight) return;
   const orgId = await getClaudeOrgId();
   if (g !== generation || !orgId) return;
+  currentOrgId = orgId;
   if (!(await acquireRefreshLock())) return;
   if (g !== generation) {
     void releaseRefreshLock();
@@ -877,9 +905,9 @@ async function refreshFromApi(force = false): Promise<void> {
     if (g !== generation || !next) return;
     const plan = next.plan ?? (await fetchPlanFromBootstrap(orgId)) ?? snapshot?.plan;
     if (g !== generation) return;
-    snapshot = { ...next, plan };
+    snapshot = { ...next, plan, orgId };
     renderPill();
-    await saveCache(snapshot);
+    await saveCache(snapshot, orgId);
   } catch {
     // ignore
   } finally {
@@ -964,10 +992,17 @@ export function startClaudeUsage(): void {
   if (chrome.storage?.onChanged && !storageListener) {
     storageListener = (changes, areaName) => {
       if (areaName !== 'local') return;
-      const change = changes[StorageKeys.GV_CLAUDE_USAGE_CACHE];
+      const orgId = currentOrgId;
+      const scopedKey = orgId ? claudeUsageCacheKeyForOrg(orgId) : null;
+      const change =
+        (scopedKey ? changes[scopedKey] : null) ?? changes[StorageKeys.GV_CLAUDE_USAGE_CACHE];
       if (change?.newValue) {
         const next = change.newValue as ClaudeUsageSnapshot;
-        if (!snapshot || next.updatedAt > snapshot.updatedAt) {
+        if (
+          isUsageSnapshot(next) &&
+          (!orgId || isSnapshotForOrg(next, orgId)) &&
+          (!snapshot || next.updatedAt > snapshot.updatedAt)
+        ) {
           snapshot = withFallbackCountdowns(next);
           renderPill();
         }
@@ -986,6 +1021,7 @@ export function startClaudeUsage(): void {
 
 export function stopClaudeUsage(): void {
   generation++;
+  currentOrgId = null;
   if (scrapeTimer !== null) clearTimeout(scrapeTimer);
   scrapeTimer = null;
   if (pillMoveHandler) {

--- a/src/features/plugins/builtin/claudeUsage/index.ts
+++ b/src/features/plugins/builtin/claudeUsage/index.ts
@@ -708,7 +708,11 @@ async function readCache(orgId: string | null): Promise<ClaudeUsageSnapshot | nu
     }
     const legacy = result?.[StorageKeys.GV_CLAUDE_USAGE_CACHE];
     if (isUsageSnapshot(legacy)) {
-      if (!orgId) return legacy;
+      if (!orgId) {
+        // When org is unknown, only accept truly legacy snapshots (no orgId field)
+        if (!legacy.orgId) return legacy;
+        return null;
+      }
       if (legacy.orgId === orgId) return legacy;
     }
     return null;
@@ -885,7 +889,9 @@ async function refreshFromApi(force = false): Promise<void> {
   if (orgChanged) {
     snapshot = null;
   }
-  const effectiveOrgId = currentOrgId ?? cookieOrg;
+  const effectiveOrgId = currentOrgId ?? cookieOrg ?? (await discoverClaudeOrgId());
+  if (g !== generation || !effectiveOrgId) return;
+  currentOrgId = effectiveOrgId;
   if (
     !force &&
     !orgChanged &&
@@ -898,9 +904,6 @@ async function refreshFromApi(force = false): Promise<void> {
   if (await hasFreshSharedCache(effectiveOrgId, force ? REFRESH_INTERVAL_MS : STALE_MS)) return;
   if (!force && (await hasFreshSharedCache(effectiveOrgId, REFRESH_INTERVAL_MS))) return;
   if (g !== generation || refreshInFlight) return;
-  const orgId = cookieOrg ?? (await discoverClaudeOrgId());
-  if (g !== generation || !orgId) return;
-  currentOrgId = orgId;
   if (!(await acquireRefreshLock())) return;
   if (g !== generation) {
     void releaseRefreshLock();
@@ -908,21 +911,21 @@ async function refreshFromApi(force = false): Promise<void> {
   }
   refreshInFlight = true;
   try {
-    const response = await fetch(`https://claude.ai/api/organizations/${orgId}/usage`, {
+    const response = await fetch(`https://claude.ai/api/organizations/${effectiveOrgId}/usage`, {
       method: 'GET',
       credentials: 'include',
       headers: { Accept: 'application/json' },
     });
     if (g !== generation || !response.ok) return;
-    if (currentOrgId !== orgId) return;
+    if (currentOrgId !== effectiveOrgId) return;
     const next = snapshotFromClaudeUsageApi(await response.json());
     if (g !== generation || !next) return;
-    if (currentOrgId !== orgId) return;
-    const plan = next.plan ?? (await fetchPlanFromBootstrap(orgId)) ?? snapshot?.plan;
-    if (g !== generation || currentOrgId !== orgId) return;
-    snapshot = { ...next, plan, orgId };
+    if (currentOrgId !== effectiveOrgId) return;
+    const plan = next.plan ?? (await fetchPlanFromBootstrap(effectiveOrgId)) ?? snapshot?.plan;
+    if (g !== generation || currentOrgId !== effectiveOrgId) return;
+    snapshot = { ...next, plan, orgId: effectiveOrgId };
     renderPill();
-    await saveCache(snapshot, orgId);
+    await saveCache(snapshot, effectiveOrgId);
   } catch {
     // ignore
   } finally {
@@ -1015,7 +1018,7 @@ export function startClaudeUsage(): void {
         const next = change.newValue as ClaudeUsageSnapshot;
         if (
           isUsageSnapshot(next) &&
-          (!orgId || next.orgId === orgId || !next.orgId) &&
+          (!orgId || next.orgId === orgId) &&
           (!snapshot || next.updatedAt > snapshot.updatedAt)
         ) {
           snapshot = withFallbackCountdowns(next);

--- a/src/features/plugins/builtin/claudeUsage/index.ts
+++ b/src/features/plugins/builtin/claudeUsage/index.ts
@@ -869,6 +869,7 @@ async function hasFreshSharedCache(orgId: string | null, maxAgeMs: number): Prom
   const g = generation;
   const cached = await readCache(orgId);
   if (g !== generation || !cached) return false;
+  if (orgId !== null && currentOrgId !== orgId) return false;
   applyStoredSnapshot(cached);
   if (Date.now() - cached.updatedAt >= maxAgeMs) return false;
   if (!cached.plan) return false;
@@ -888,6 +889,7 @@ async function refreshFromApi(force = false): Promise<void> {
   if (cookieOrg) currentOrgId = cookieOrg;
   if (orgChanged) {
     snapshot = null;
+    renderPill();
   }
   const effectiveOrgId = currentOrgId ?? cookieOrg ?? (await discoverClaudeOrgId());
   if (g !== generation || !effectiveOrgId) return;

--- a/src/features/plugins/builtin/claudeUsage/index.ts
+++ b/src/features/plugins/builtin/claudeUsage/index.ts
@@ -80,7 +80,7 @@ export function claudeUsageCacheKeyForOrg(orgId: string): string {
 }
 
 function isSnapshotForOrg(snapshot: ClaudeUsageSnapshot, orgId: string): boolean {
-  return !snapshot.orgId || snapshot.orgId === orgId;
+  return snapshot.orgId === orgId;
 }
 
 function pageText(doc: Document): string {
@@ -707,7 +707,10 @@ async function readCache(orgId: string | null): Promise<ClaudeUsageSnapshot | nu
       if (isUsageSnapshot(scoped) && isSnapshotForOrg(scoped, orgId)) return scoped;
     }
     const legacy = result?.[StorageKeys.GV_CLAUDE_USAGE_CACHE];
-    if (isUsageSnapshot(legacy) && (!orgId || isSnapshotForOrg(legacy, orgId))) return legacy;
+    if (isUsageSnapshot(legacy)) {
+      if (!orgId) return legacy;
+      if (!legacy.orgId) return legacy;
+    }
     return null;
   } catch {
     return null;
@@ -811,10 +814,6 @@ async function discoverClaudeOrgId(): Promise<string | null> {
   }
 }
 
-async function getClaudeOrgId(): Promise<string | null> {
-  return getLastActiveOrg() ?? discoverClaudeOrgId();
-}
-
 async function acquireRefreshLock(): Promise<boolean> {
   try {
     const now = Date.now();
@@ -857,9 +856,9 @@ async function releaseRefreshLock(): Promise<void> {
   }
 }
 
-async function hasFreshSharedCache(maxAgeMs: number): Promise<boolean> {
+async function hasFreshSharedCache(orgId: string | null, maxAgeMs: number): Promise<boolean> {
   const g = generation;
-  const cached = await readCache(currentOrgId);
+  const cached = await readCache(orgId);
   if (g !== generation || !cached) return false;
   applyStoredSnapshot(cached);
   if (Date.now() - cached.updatedAt >= maxAgeMs) return false;
@@ -874,18 +873,27 @@ async function hasFreshSharedCache(maxAgeMs: number): Promise<boolean> {
 
 async function refreshFromApi(force = false): Promise<void> {
   const g = generation;
+  const cookieOrg = getLastActiveOrg();
+  if (g !== generation) return;
+  const orgChanged = cookieOrg !== null && currentOrgId !== null && cookieOrg !== currentOrgId;
+  if (cookieOrg) currentOrgId = cookieOrg;
+  if (orgChanged) {
+    snapshot = null;
+  }
+  const effectiveOrgId = currentOrgId ?? cookieOrg;
   if (
     !force &&
+    !orgChanged &&
     snapshot?.plan &&
     hasCountdownData(snapshot) &&
     Date.now() - snapshot.updatedAt < STALE_MS
   ) {
     return;
   }
-  if (await hasFreshSharedCache(force ? REFRESH_INTERVAL_MS : STALE_MS)) return;
-  if (!force && (await hasFreshSharedCache(REFRESH_INTERVAL_MS))) return;
+  if (await hasFreshSharedCache(effectiveOrgId, force ? REFRESH_INTERVAL_MS : STALE_MS)) return;
+  if (!force && (await hasFreshSharedCache(effectiveOrgId, REFRESH_INTERVAL_MS))) return;
   if (g !== generation || refreshInFlight) return;
-  const orgId = await getClaudeOrgId();
+  const orgId = cookieOrg ?? (await discoverClaudeOrgId());
   if (g !== generation || !orgId) return;
   currentOrgId = orgId;
   if (!(await acquireRefreshLock())) return;
@@ -1000,7 +1008,7 @@ export function startClaudeUsage(): void {
         const next = change.newValue as ClaudeUsageSnapshot;
         if (
           isUsageSnapshot(next) &&
-          (!orgId || isSnapshotForOrg(next, orgId)) &&
+          (!orgId || next.orgId === orgId || !next.orgId) &&
           (!snapshot || next.updatedAt > snapshot.updatedAt)
         ) {
           snapshot = withFallbackCountdowns(next);

--- a/src/features/plugins/builtin/claudeUsage/index.ts
+++ b/src/features/plugins/builtin/claudeUsage/index.ts
@@ -62,6 +62,27 @@ const refreshOwnerId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 // pill as un-removable zombie UI.
 let generation = 0;
 let currentOrgId: string | null = null;
+let refreshToken = 0;
+
+function generateRefreshToken(): number {
+  return ++refreshToken;
+}
+
+function captureToken(): number {
+  return refreshToken;
+}
+
+function isTokenValid(token: number): boolean {
+  return token === refreshToken;
+}
+
+function switchOrg(newOrgId: string | null): void {
+  if (newOrgId === currentOrgId) return;
+  snapshot = null;
+  currentOrgId = newOrgId;
+  generateRefreshToken();
+  renderPill();
+}
 
 export function claudeUsageUrl(pathname = location.pathname, search = location.search): string {
   return `${CLAUDE_ORIGIN}${pathname === '/' ? '/new' : pathname}${search}#settings/usage`;
@@ -723,7 +744,9 @@ async function readCache(orgId: string | null): Promise<ClaudeUsageSnapshot | nu
 
 async function loadCache(): Promise<void> {
   const cookieOrg = getLastActiveOrg();
-  if (cookieOrg) currentOrgId = cookieOrg;
+  if (cookieOrg && cookieOrg !== currentOrgId) {
+    switchOrg(cookieOrg);
+  }
   const cached = await readCache(cookieOrg);
   if (cached) applyStoredSnapshot(cached);
 }
@@ -744,8 +767,7 @@ async function saveCache(next: ClaudeUsageSnapshot, orgId: string | null): Promi
 function applySnapshot(next: ClaudeUsageSnapshot): void {
   const cookieOrg = getLastActiveOrg();
   if (cookieOrg && cookieOrg !== currentOrgId) {
-    currentOrgId = cookieOrg;
-    snapshot = null;
+    switchOrg(cookieOrg);
   }
   const merged = withFallbackCountdowns(withFallbackPlan(next));
   if (snapshot && sameSnapshotData(snapshot, merged)) return;
@@ -866,10 +888,10 @@ async function releaseRefreshLock(): Promise<void> {
 }
 
 async function hasFreshSharedCache(orgId: string | null, maxAgeMs: number): Promise<boolean> {
+  const token = captureToken();
   const g = generation;
   const cached = await readCache(orgId);
-  if (g !== generation || !cached) return false;
-  if (orgId !== null && currentOrgId !== orgId) return false;
+  if (g !== generation || !isTokenValid(token) || !cached) return false;
   applyStoredSnapshot(cached);
   if (Date.now() - cached.updatedAt >= maxAgeMs) return false;
   if (!cached.plan) return false;
@@ -882,21 +904,18 @@ async function hasFreshSharedCache(orgId: string | null, maxAgeMs: number): Prom
 }
 
 async function refreshFromApi(force = false): Promise<void> {
+  const token = captureToken();
   const g = generation;
   const cookieOrg = getLastActiveOrg();
-  if (g !== generation) return;
-  const orgChanged = cookieOrg !== null && currentOrgId !== null && cookieOrg !== currentOrgId;
-  if (cookieOrg) currentOrgId = cookieOrg;
-  if (orgChanged) {
-    snapshot = null;
-    renderPill();
+  if (g !== generation || !isTokenValid(token)) return;
+  if (cookieOrg && cookieOrg !== currentOrgId) {
+    switchOrg(cookieOrg);
   }
   const effectiveOrgId = currentOrgId ?? cookieOrg ?? (await discoverClaudeOrgId());
-  if (g !== generation || !effectiveOrgId) return;
+  if (g !== generation || !isTokenValid(token) || !effectiveOrgId) return;
   currentOrgId = effectiveOrgId;
   if (
     !force &&
-    !orgChanged &&
     snapshot?.plan &&
     hasCountdownData(snapshot) &&
     Date.now() - snapshot.updatedAt < STALE_MS
@@ -904,10 +923,11 @@ async function refreshFromApi(force = false): Promise<void> {
     return;
   }
   if (await hasFreshSharedCache(effectiveOrgId, force ? REFRESH_INTERVAL_MS : STALE_MS)) return;
+  if (!isTokenValid(token)) return;
   if (!force && (await hasFreshSharedCache(effectiveOrgId, REFRESH_INTERVAL_MS))) return;
-  if (g !== generation || refreshInFlight) return;
+  if (g !== generation || !isTokenValid(token) || refreshInFlight) return;
   if (!(await acquireRefreshLock())) return;
-  if (g !== generation) {
+  if (g !== generation || !isTokenValid(token)) {
     void releaseRefreshLock();
     return;
   }
@@ -918,13 +938,11 @@ async function refreshFromApi(force = false): Promise<void> {
       credentials: 'include',
       headers: { Accept: 'application/json' },
     });
-    if (g !== generation || !response.ok) return;
-    if (currentOrgId !== effectiveOrgId) return;
+    if (g !== generation || !isTokenValid(token) || !response.ok) return;
     const next = snapshotFromClaudeUsageApi(await response.json());
-    if (g !== generation || !next) return;
-    if (currentOrgId !== effectiveOrgId) return;
+    if (g !== generation || !isTokenValid(token) || !next) return;
     const plan = next.plan ?? (await fetchPlanFromBootstrap(effectiveOrgId)) ?? snapshot?.plan;
-    if (g !== generation || currentOrgId !== effectiveOrgId) return;
+    if (g !== generation || !isTokenValid(token)) return;
     snapshot = { ...next, plan, orgId: effectiveOrgId };
     renderPill();
     await saveCache(snapshot, effectiveOrgId);
@@ -1012,6 +1030,7 @@ export function startClaudeUsage(): void {
   if (chrome.storage?.onChanged && !storageListener) {
     storageListener = (changes, areaName) => {
       if (areaName !== 'local') return;
+      const token = captureToken();
       const orgId = currentOrgId;
       const scopedKey = orgId ? claudeUsageCacheKeyForOrg(orgId) : null;
       const change =
@@ -1020,6 +1039,7 @@ export function startClaudeUsage(): void {
         const next = change.newValue as ClaudeUsageSnapshot;
         if (
           isUsageSnapshot(next) &&
+          isTokenValid(token) &&
           (!orgId || next.orgId === orgId) &&
           (!snapshot || next.updatedAt > snapshot.updatedAt)
         ) {
@@ -1041,7 +1061,7 @@ export function startClaudeUsage(): void {
 
 export function stopClaudeUsage(): void {
   generation++;
-  currentOrgId = null;
+  switchOrg(null);
   if (scrapeTimer !== null) clearTimeout(scrapeTimer);
   scrapeTimer = null;
   if (pillMoveHandler) {

--- a/src/features/plugins/builtin/claudeUsage/index.ts
+++ b/src/features/plugins/builtin/claudeUsage/index.ts
@@ -709,7 +709,7 @@ async function readCache(orgId: string | null): Promise<ClaudeUsageSnapshot | nu
     const legacy = result?.[StorageKeys.GV_CLAUDE_USAGE_CACHE];
     if (isUsageSnapshot(legacy)) {
       if (!orgId) return legacy;
-      if (!legacy.orgId) return legacy;
+      if (legacy.orgId === orgId) return legacy;
     }
     return null;
   } catch {
@@ -738,6 +738,11 @@ async function saveCache(next: ClaudeUsageSnapshot, orgId: string | null): Promi
 }
 
 function applySnapshot(next: ClaudeUsageSnapshot): void {
+  const cookieOrg = getLastActiveOrg();
+  if (cookieOrg && cookieOrg !== currentOrgId) {
+    currentOrgId = cookieOrg;
+    snapshot = null;
+  }
   const merged = withFallbackCountdowns(withFallbackPlan(next));
   if (snapshot && sameSnapshotData(snapshot, merged)) return;
   snapshot = merged;
@@ -909,10 +914,12 @@ async function refreshFromApi(force = false): Promise<void> {
       headers: { Accept: 'application/json' },
     });
     if (g !== generation || !response.ok) return;
+    if (currentOrgId !== orgId) return;
     const next = snapshotFromClaudeUsageApi(await response.json());
     if (g !== generation || !next) return;
+    if (currentOrgId !== orgId) return;
     const plan = next.plan ?? (await fetchPlanFromBootstrap(orgId)) ?? snapshot?.plan;
-    if (g !== generation) return;
+    if (g !== generation || currentOrgId !== orgId) return;
     snapshot = { ...next, plan, orgId };
     renderPill();
     await saveCache(snapshot, orgId);


### PR DESCRIPTION
## Issue for this PR

Related to #766

## Type of change

- [x] Bug fix

## What does this PR do?

#766 fixed the Gemini usage pill to scope its cache by account, so switching between accounts no longer shows stale data. However, the Claude usage pill still uses a single global cache key (`gvClaudeUsageCache`), causing the **same problem** on Claude.ai: when users switch organizations, the pill continues displaying the previous org's usage until the next refresh cycle (up to 5 minutes).

This PR brings Claude usage to parity with Gemini by scoping the cache key to the active organization ID.

### Changes

- **Cache key format**: `gvClaudeUsageCache:{orgId}` (e.g. `gvClaudeUsageCache:org_123`)
- `ClaudeUsageSnapshot` gains optional `orgId` field for ownership validation
- `readCache()` reads scoped key first, falls back to legacy global key
- `saveCache()` writes both scoped and legacy keys (backward compatibility)
- `storageListener` watches both keys with org validation
- `StorageQuotaService` cache category recognizes new scoped key prefix

### Files changed

| File | Change |
|------|--------|
| `src/features/plugins/builtin/claudeUsage/index.ts` | Core implementation: org-scoped cache key + legacy fallback |
| `src/features/plugins/builtin/claudeUsage/index.test.ts` | 4 new regression tests |
| `src/core/services/StorageQuotaService.ts` | Cache category prefix for Claude scoped keys |

## How did you verify your code works?

```bash
% bun run typecheck     # pass
% bun run lint          # pass
% bun run test          # 2623/2624 pass (1 pre-existing unrelated failure)
% bun run build:chrome  # pass
```

New tests cover:
- Cache key generation: `claudeUsageCacheKeyForOrg('org_123')` → `'gvClaudeUsageCache:org_123'`
- **Account switch**: org A cache is not visible when switched to org B
- **Same account**: scoped cache is read correctly for the active org
- **Legacy fallback**: old `gvClaudeUsageCache` data is still readable
- All 30 existing Claude usage tests continue to pass

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
- [x] New tests cover the behavior change

---

Friendly ping for review: @Nagi-ovo (repo owner) and @TouhouAkiko (reporter of #766, the Gemini equivalent of this bug). The PR is self-contained and mirrors the established Gemini pattern, so it can be reviewed and merged independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude usage caching to keep data separated by organization.
  * Prevented displaying cached usage from a different organization.
  * Preserved compatibility with existing cached usage data.
  * Improved cache classification for Claude usage entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->