### PR TITLE
fix(content): register beforeunload cleanup unconditionally

### DIFF
--- a/src/pages/content/__tests__/index.test.tsx
+++ b/src/pages/content/__tests__/index.test.tsx
@@ -1,0 +1,111 @@
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The entrypoint IIFE calls these modules before its early returns. Mock them
+// all to no-ops so the plugin-platform / custom-website entry paths can be
+// exercised without mounting real features.
+vi.mock('@/features/plugins', () => ({
+  startPluginHost: () => () => {},
+}));
+vi.mock('@/features/formulaCopy', () => ({
+  startFormulaCopy: () => {},
+}));
+vi.mock('@/utils/i18n', () => ({
+  initI18n: async () => undefined,
+}));
+vi.mock('../visualEffects', () => ({
+  startVisualEffects: () => {},
+}));
+vi.mock('../accountContext', () => ({
+  startAccountContextBridge: () => () => {},
+}));
+vi.mock('../pluginNativeRegistration', () => ({
+  registerBuiltinNativeHandlers: () => {},
+}));
+vi.mock('../platformTheme', () => ({
+  startBrandTheme: () => () => {},
+}));
+vi.mock('../remoteAnnouncements/index', () => ({
+  startRemoteAnnouncements: () => () => {},
+}));
+vi.mock('../storageQuotaWarning', () => ({
+  startStorageQuotaWarningToast: () => () => {},
+}));
+vi.mock('../katexConfig', () => ({
+  initKaTeXConfig: () => {},
+}));
+vi.mock('../prompt/index', () => ({
+  startPromptManager: async () => ({ destroy: () => {} }),
+}));
+vi.mock('../prompt/slashPromptFeature', () => ({
+  startSlashPromptFeature: async () => ({ destroy: () => {} }),
+}));
+vi.mock('../prompt/customSiteCoverage', () => ({
+  createCustomSiteCoverageReconciler: () => ({
+    handleChange: () => {},
+    destroy: () => {},
+  }),
+}));
+
+function mockUrl(url: string): void {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: new URL(url),
+  });
+}
+
+function mockCustomWebsites(hosts: string[]): void {
+  (chrome.storage.sync.get as unknown as Mock).mockImplementation(
+    (
+      _keys: unknown,
+      callback?: (result: Record<string, unknown>) => void,
+    ): Promise<Record<string, unknown>> => {
+      const result = { gvPromptCustomWebsites: hosts };
+      if (typeof callback === 'function') callback(result);
+      return Promise.resolve(result);
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('content entrypoint beforeunload cleanup registration', () => {
+  it('registers beforeunload cleanup on the plugin-platform early return', async () => {
+    mockUrl('https://claude.ai/');
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+    await import('../index');
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  }, 15_000);
+
+  it('registers beforeunload cleanup on the custom-website entry', async () => {
+    mockUrl('https://example.com/');
+    mockCustomWebsites(['example.com']);
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+    await import('../index');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('executes registered cleanups when beforeunload fires', async () => {
+    mockUrl('https://claude.ai/');
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+    await import('../index');
+
+    const beforeunloadHandler = addEventListenerSpy.mock.calls.find(
+      (call) => (call[0] as string) === 'beforeunload',
+    )?.[1] as (() => void) | undefined;
+    expect(beforeunloadHandler).toBeDefined();
+
+    expect(() => beforeunloadHandler?.()).not.toThrow();
+  });
+});

--- a/src/pages/content/__tests__/index.test.tsx
+++ b/src/pages/content/__tests__/index.test.tsx
@@ -1,10 +1,14 @@
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const mocks = vi.hoisted(() => ({
+  pluginCleanup: vi.fn(),
+}));
+
 // The entrypoint IIFE calls these modules before its early returns. Mock them
 // all to no-ops so the plugin-platform / custom-website entry paths can be
 // exercised without mounting real features.
 vi.mock('@/features/plugins', () => ({
-  startPluginHost: () => () => {},
+  startPluginHost: () => mocks.pluginCleanup,
 }));
 vi.mock('@/features/formulaCopy', () => ({
   startFormulaCopy: () => {},
@@ -68,6 +72,7 @@ function mockCustomWebsites(hosts: string[]): void {
 
 beforeEach(() => {
   vi.resetModules();
+  mocks.pluginCleanup.mockClear();
 });
 
 afterEach(() => {
@@ -107,5 +112,6 @@ describe('content entrypoint beforeunload cleanup registration', () => {
     expect(beforeunloadHandler).toBeDefined();
 
     expect(() => beforeunloadHandler?.()).not.toThrow();
+    expect(mocks.pluginCleanup).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -531,6 +531,20 @@ function handleVisibilityChange(): void {
   try {
     if (!hasValidExtensionContext()) return;
 
+    // Setup cleanup on page unload to prevent memory leaks. Registered before
+    // any early return so cleanup functions queued on every entry path (plugin
+    // host, brand theme, error listeners, …) always run on unload.
+    window.addEventListener('beforeunload', () => {
+      try {
+        cleanupManager.executeCleanups();
+      } catch (e) {
+        if (isExtensionContextInvalidatedError(e)) {
+          return;
+        }
+        console.error('[Gemini Voyager] Cleanup error:', e);
+      }
+    });
+
     const pluginPlatformId = resolvePluginPlatformId(location.href);
     const isPluginSubframe = window.top !== window && pluginPlatformId !== null;
 
@@ -725,18 +739,6 @@ function handleVisibilityChange(): void {
 
     // Listen for visibility changes to handle tab switching
     document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    // Setup cleanup on page unload to prevent memory leaks
-    window.addEventListener('beforeunload', () => {
-      try {
-        cleanupManager.executeCleanups();
-      } catch (e) {
-        if (isExtensionContextInvalidatedError(e)) {
-          return;
-        }
-        console.error('[Gemini Voyager] Cleanup error:', e);
-      }
-    });
   } catch (e) {
     if (isExtensionContextInvalidatedError(e)) {
       return;


### PR DESCRIPTION
## Issue for this PR

Closes #912

## Type of change

- [x] Bug fix

## What does this PR do?

The entrypoint IIFE (`src/pages/content/index.tsx`) registers the `beforeunload` cleanup handler only on the supported-site path. The plugin-platform (Claude/ChatGPT/Grok), plugin-subframe, and unknown-site (custom website) paths hit early returns **before** the handler is registered, so cleanup functions queued earlier on those paths (plugin host, brand theme, error listeners, remote announcements, prompt manager destroy) never run on page unload — leaking listeners and DOM.

This PR moves the `beforeunload` registration to the top of the IIFE, right after the extension-context validity check and before any early return, so it is registered unconditionally on every entry path.

## How did you verify your code works?

**Automated tests** (new file `src/pages/content/__tests__/index.test.tsx`, 3 tests):
- plugin-platform early return (claude.ai URL) → `beforeunload` is registered
- custom-website entry (example.com) → `beforeunload` is registered
- registered cleanups execute without throwing when `beforeunload` fires

```bash
% bun run typecheck    # pass
% bun run lint         # pass (0 errors)
% bun run test         # 2628/2629 pass (1 pre-existing unrelated failure in releaseArtifacts.test.ts)
% bun run build:chrome # pass
```

**Live verification** (loaded `dist_chrome_dev` in Chrome):
- gemini.google.com: dispatch `beforeunload` → `[BackupService] BeforeUnload backup created` and the Prompt Manager trigger is removed from the DOM
- example.com (custom website): dispatch `beforeunload` → Prompt Manager trigger removed from the DOM (screenshot below)

<img width="1509" height="860" alt="Screenshot 2026-08-08 at 10 10 54 PM" src="https://github.com/user-attachments/assets/e8b2958c-9b1c-49f7-b90b-88dc37921513" />

<img width="1512" height="982" alt="testexample com" src="https://github.com/user-attachments/assets/a25b76e0-70c6-408a-a92b-5670a44433ed" />

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
- [x] New tests cover the behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup handling when leaving the content page.
  * Ensured cleanup actions are registered before page initialization, preventing missed cleanup tasks.
  * Applied consistent cleanup behavior across supported platform and custom website experiences.

* **Tests**
  * Added coverage for cleanup registration and execution during page unload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->